### PR TITLE
Fixed saving and creating users. disabled email edit for exisiting users

### DIFF
--- a/src/frontend/src/api/ApiClient.ts
+++ b/src/frontend/src/api/ApiClient.ts
@@ -68,7 +68,7 @@ export default class ApiClient {
     }
 
     async updatePersonnelAsync(projectId: string, contractId: string, personnel: Person) {
-        const url = this.resourceCollection.personnelUpdate(projectId, contractId, personnel.personnelId);
+        const url = this.resourceCollection.personnel(projectId, contractId, personnel.personnelId);
         const reponse = await this.httpClient.putAsync<Person, Person, FusionApiHttpErrorResponse>(url, personnel);
         return reponse.data
     }

--- a/src/frontend/src/api/ApiClient.ts
+++ b/src/frontend/src/api/ApiClient.ts
@@ -55,15 +55,21 @@ export default class ApiClient {
         return this.httpClient.getAsync<ApiCollection<Personnel>, FusionApiHttpErrorResponse>(url);
     }
 
-    async updatePersonnelAsync(projectId: string, contractId: string,personnel: Person) {
+    async createPersonnelAsync(projectId: string, contractId: string, personnel: Person) {
         const url = this.resourceCollection.personnel(projectId, contractId);
-        const reponse = await this.httpClient.postAsync<Person,Person, FusionApiHttpErrorResponse>(url,personnel);
+        const reponse = await this.httpClient.postAsync<Person, Person, FusionApiHttpErrorResponse>(url, personnel);
         return reponse.data
     }
 
-    async updatePersonnelCollectionAsync(projectId: string, contractId: string,personnel: Person[]) {
+    async createPersonnelCollectionAsync(projectId: string, contractId: string, personnel: Person[]) {
         const url = this.resourceCollection.personnelCollection(projectId, contractId);
-        const reponse = await this.httpClient.postAsync<Person[],Person[], FusionApiHttpErrorResponse>(url,personnel);
+        const reponse = await this.httpClient.postAsync<Person[], Person[], FusionApiHttpErrorResponse>(url, personnel);
+        return reponse.data
+    }
+
+    async updatePersonnelAsync(projectId: string, contractId: string, personnel: Person) {
+        const url = this.resourceCollection.personnelUpdate(projectId, contractId, personnel.personnelId);
+        const reponse = await this.httpClient.putAsync<Person, Person, FusionApiHttpErrorResponse>(url, personnel);
         return reponse.data
     }
 

--- a/src/frontend/src/api/ResourceCollection.ts
+++ b/src/frontend/src/api/ResourceCollection.ts
@@ -22,17 +22,14 @@ export default class ResourceCollection {
         return combineUrls(this.contracts(projectId), contractId);
     }
 
-    personnel(projectId: string, contractId: string): string {
-        return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel');
+    personnel(projectId: string, contractId: string, personnelId?: string): string {
+        return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel', personnelId || '');
     }
 
     personnelCollection(projectId: string, contractId: string): string {
         return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel-collection');
     }
 
-    personnelUpdate(projectId: string, contractId: string, personnelId: string): string {
-        return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel', personnelId);
-    }
 
     personnelRequests(projectId: string, contractId: string, filter?: string): string {
         const personnelRequestsFilter = filter ? `?$filter=${filter}` : '';

--- a/src/frontend/src/api/ResourceCollection.ts
+++ b/src/frontend/src/api/ResourceCollection.ts
@@ -30,6 +30,10 @@ export default class ResourceCollection {
         return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel-collection');
     }
 
+    personnelUpdate(projectId: string, contractId: string, personnelId: string): string {
+        return combineUrls(this.contract(projectId, contractId), 'resources', 'personnel', personnelId);
+    }
+
     personnelRequests(projectId: string, contractId: string, filter?: string): string {
         const personnelRequestsFilter = filter ? `?$filter=${filter}` : '';
         return combineUrls(

--- a/src/frontend/src/models/Person.ts
+++ b/src/frontend/src/models/Person.ts
@@ -7,6 +7,7 @@ type Person = {
     lastName: string | null;
     phoneNumber: string;
     jobTitle: string;
+    created?: Date | null;
 };
 
 export default Person;

--- a/src/frontend/src/models/Personnel.ts
+++ b/src/frontend/src/models/Personnel.ts
@@ -14,6 +14,8 @@ type Personnel = {
     azureAdStatus: 'Available' | 'InviteSent' | 'NoAccount';
     hasCV: boolean;
     disciplines: PersonnelDiscipline[];
+    created?: Date | null;
+    updated?: Date | null;
 };
 
 export default Personnel;

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/AddPersonnelSideSheet/AddPersonnelFormTextInput.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/AddPersonnelSideSheet/AddPersonnelFormTextInput.tsx
@@ -18,12 +18,13 @@ const AddPersonnelFormTextInput: React.FC<PersonnelFormTextInputProps> = ({
     return (
         <TextInput
             disabled={disabled}
+            placeholder={item[field]?.toString() || ""}
             key={field + item.personnelId}
             onChange={newValue => {
                 const changedPerson = { ...item, [field]: newValue };
                 onChange(changedPerson);
             }}
-            value={item[field] || ""}
+            value={item[field]?.toString() || ""}
         />
     );
 };

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/AddPersonnelSideSheet/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/AddPersonnelSideSheet/index.tsx
@@ -38,9 +38,10 @@ const AddPersonnelSideSheet: React.FC<AddPersonnelToSideSheetProps> = ({
 
         setSaveInProgress(true);
         await Promise.all(
-            formState.map(
-                async person =>
-                    await apiClient.updatePersonnelAsync(currentContext.id, contractId, person)
+            formState.map(async person =>
+                person.created
+                    ? await apiClient.updatePersonnelAsync(currentContext.id, contractId, person)
+                    : await apiClient.createPersonnelAsync(currentContext.id, contractId, person)
             )
         )
             .then(() => {
@@ -149,7 +150,7 @@ const AddPersonnelSideSheet: React.FC<AddPersonnelToSideSheetProps> = ({
                                     <td className={styles.tableRowCell}>
                                         <AddPersonnelFormTextInput
                                             key={`mail${person.personnelId}`}
-                                            disabled={saveInProgress}
+                                            disabled={Boolean(person.created || saveInProgress)}
                                             item={person}
                                             onChange={onChange}
                                             field={'mail'}


### PR DESCRIPTION
In Api client:
updatePersonnelAsync is now put and takes in person paramter.
New createPersonnelAsync created to handle post request.
resurceCollections updated to reflect this.

Models:
added created to Person model. Need this to differentiate between a locally created user and one from the api.
created and updated fields also added to Personnel.

PersonnelSide sheet and saving routine: 
When saving personnel it now checks if user is created to select correct endpoint.
When editing users email field is disabled for already created users.
Added placeholder to input fields, just so it still show data even if its disabled.