### PR TITLE
Manage personnel Filter pane

### DIFF
--- a/src/frontend/src/models/Personnel.ts
+++ b/src/frontend/src/models/Personnel.ts
@@ -2,6 +2,8 @@ export type PersonnelDiscipline = {
     name: string;
 };
 
+export type azureAdStatus = 'Available' | 'InviteSent' | 'NoAccount';
+
 type Personnel = {
     personnelId: string;
     azureUniquePersonId?: string;
@@ -11,7 +13,7 @@ type Personnel = {
     jobTitle: string;
     phoneNumber: string;
     mail: string;
-    azureAdStatus: 'Available' | 'InviteSent' | 'NoAccount';
+    azureAdStatus: azureAdStatus
     hasCV: boolean;
     disciplines: PersonnelDiscipline[];
     created?: Date | null;

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/PersonnelColumns.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/PersonnelColumns.tsx
@@ -1,31 +1,13 @@
 import * as React from 'react';
 import {
     DataTableColumn,
-    useTooltipRef,
-    DoneIcon,
-    WarningIcon,
-    CloseIcon,
-    styling,
 } from '@equinor/fusion-components';
 import Personnel from '../../../../../../models/Personnel';
+import AzureAdStatusIcon from './components/AzureAdStatus';
+
 
 export type DataItemProps = {
     item: Personnel;
-};
-
-// TODO: Get proper icons
-const AdStatus = {
-    Available: { text: 'Azure AD Approved', icon: <DoneIcon color={styling.colors.green} /> },
-    InviteSent: {
-        text: 'Azure AD pending approval',
-        icon: <WarningIcon outline color={styling.colors.orange} />,
-    },
-    NoAccount: { text: 'No Azure Access', icon: <CloseIcon color={styling.colors.red} /> },
-};
-
-const AzureAdStatus: React.FC<DataItemProps> = ({ item }) => {
-    const { text, icon } = AdStatus[item.azureAdStatus];
-    return <div ref={useTooltipRef(text)}>{icon}</div>;
 };
 
 const PersonnelColumns = (): DataTableColumn<Personnel>[] => [
@@ -62,7 +44,7 @@ const PersonnelColumns = (): DataTableColumn<Personnel>[] => [
         accessor: 'azureAdStatus',
         label: 'AD',
         priority: 15,
-        component: AzureAdStatus,
+        component: (p) => AzureAdStatusIcon(p.item.azureAdStatus),
         sortable: true,
         width: '20px',
     },

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/components/AzureAdStatus.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/components/AzureAdStatus.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {
+    useTooltipRef,
+    DoneIcon,
+    WarningIcon,
+    CloseIcon,
+    styling,
+} from '@equinor/fusion-components';
+import { azureAdStatus } from '../../../../../../../models/Personnel';
+
+type AdStatus = {
+    [index: string]: {
+        text: string;
+        color: string;
+        icon: JSX.Element;
+    };
+};
+
+// TODO: Get proper icons
+const AdStatus: AdStatus = {
+    Available: {
+        text: 'Azure AD Approved',
+        color: styling.colors.green,
+        icon: <DoneIcon color={styling.colors.green} />,
+    },
+    InviteSent: {
+        text: 'Azure AD pending approval',
+        color: styling.colors.orange,
+        icon: <WarningIcon outline color={styling.colors.orange} />,
+    },
+    NoAccount: {
+        text: 'No Azure Access',
+        color: styling.colors.red,
+        icon: <CloseIcon color={styling.colors.red} />,
+    },
+};
+
+const AzureAdStatusIcon: React.FC<azureAdStatus> = (status: azureAdStatus) => {
+    const { text, icon } = AdStatus[status];
+    return <div ref={useTooltipRef(text)}>{icon}</div>;
+};
+
+export const AzureAdStatusTextFormat = (status: azureAdStatus) => {
+    return AdStatus[status].text;
+};
+
+export const AzureAdStatusColor = (status: azureAdStatus) => {
+    return AdStatus[status].color;
+};
+
+export default AzureAdStatusIcon;

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/getFilterSections.ts
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/getFilterSections.ts
@@ -1,0 +1,48 @@
+import { FilterSection, FilterTypes, WarningIcon } from '@equinor/fusion-components';
+import Personnel, { azureAdStatus } from '../../../../../../models/Personnel';
+import { AzureAdStatusTextFormat, AzureAdStatusColor } from './components/AzureAdStatus';
+
+const getFilterSections = (personnel: Personnel[]): FilterSection<Personnel>[] => {
+    const uniqueAdStatus = personnel
+        .map(p => p.azureAdStatus)
+        .filter((d, i, l) => l.indexOf(d) === i);
+
+    return [
+        {
+            key: 'search',
+            title: 'Search',
+            filters: [
+                {
+                    key: 'search-filter',
+                    type: FilterTypes.Search,
+                    title: 'Search',
+                    getValue: p =>
+                        p.name + (p.firstName || '') + (p.lastName || '') + p.mail + p.phoneNumber,
+                },
+            ],
+        },
+        {
+            key: 'filters',
+            title: 'Filters',
+            isCollapsible: true,
+            filters: [
+                {
+                    key: 'azureAdStatus',
+                    title: 'Ad status',
+                    type: FilterTypes.Checkbox,
+                    getValue: p => p.azureAdStatus,
+                    isVisibleWhenPaneIsCollapsed: true,
+                    isCollapsible: true,
+
+                    options: uniqueAdStatus.map((ads: azureAdStatus) => ({
+                        key: ads,
+                        label: AzureAdStatusTextFormat(ads),
+                        color: AzureAdStatusColor(ads),
+                    })),
+                },
+            ],
+        },
+    ];
+};
+
+export default getFilterSections;

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
@@ -17,9 +17,7 @@ const ManagePersonnelPage: React.FC = () => {
         currentContract?.contract?.id || undefined,
         currentContext?.id
     );
-    const [filteredPersonnel, setFilteredPersonnel] = React.useState<Personnel[]>(
-        []
-    );
+    const [filteredPersonnel, setFilteredPersonnel] = React.useState<Personnel[]>([]);
 
     const { sortedData, setSortBy, sortBy, direction } = useSorting<Personnel>(
         filteredPersonnel,
@@ -37,8 +35,8 @@ const ManagePersonnelPage: React.FC = () => {
     );
 
     const filterSections = React.useMemo(() => {
-        return getFilterSections(filteredPersonnel);
-    }, [filteredPersonnel]);
+        return getFilterSections(personnel);
+    }, [personnel]);
 
     const personnelColumns = React.useMemo(() => PersonnelColumns(), []);
     const sortedByColumn = React.useMemo(
@@ -47,13 +45,11 @@ const ManagePersonnelPage: React.FC = () => {
     );
 
     return (
-
         <div className={styles.container}>
             <div className={styles.managePersonnel}>
                 <div className={styles.toolbar}>
                     <Button outlined onClick={() => setIsAddPersonOpen(true)}>
-                        {' '}
-                        <AddIcon /> Add Person{' '}
+                        <AddIcon /> Add Person
                     </Button>
                 </div>
                 <DataTable

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
@@ -1,20 +1,31 @@
-import * as React from 'react'
+import * as React from 'react';
 import { DataTable, DataTableColumn, Button, AddIcon } from '@equinor/fusion-components';
 import { useSorting, useCurrentContext } from '@equinor/fusion';
 import PersonnelColumns from './PersonnelColumns';
 import usePersonnel from './hooks/usePersonnel';
 import Personnel from '../../../../../../models/Personnel';
-import * as styles from './styles.less'
+import * as styles from './styles.less';
 import { useContractContext } from '../../../../../../contractContex';
-import AddPersonnelSideSheet from './AddPersonnelSideSheet'
-
-
+import AddPersonnelSideSheet from './AddPersonnelSideSheet';
+import getFilterSections from './getFilterSections';
+import GenericFilter from '../../../../../../components/GenericFilter';
 
 const ManagePersonnelPage: React.FC = () => {
-    const currentContext = useCurrentContext()
-    const currentContract = useContractContext()
-    const { personnel, isFetchingPersonnel, personnelError } = usePersonnel(currentContract?.contract?.id || undefined, currentContext?.id);
-    const { sortedData, setSortBy, sortBy, direction } = useSorting<Personnel>(personnel, "name", "asc");
+    const currentContext = useCurrentContext();
+    const currentContract = useContractContext();
+    const { personnel, isFetchingPersonnel, personnelError } = usePersonnel(
+        currentContract?.contract?.id || undefined,
+        currentContext?.id
+    );
+    const [filteredPersonnel, setFilteredPersonnel] = React.useState<Personnel[]>(
+        []
+    );
+
+    const { sortedData, setSortBy, sortBy, direction } = useSorting<Personnel>(
+        filteredPersonnel,
+        'name',
+        'asc'
+    );
     const [isAddPersonOpen, setIsAddPersonOpen] = React.useState<boolean>(false);
     const [selectedItems, setSelectedItems] = React.useState<Personnel[]>([]);
 
@@ -25,13 +36,26 @@ const ManagePersonnelPage: React.FC = () => {
         [sortBy, direction]
     );
 
+    const filterSections = React.useMemo(() => {
+        return getFilterSections(filteredPersonnel);
+    }, [filteredPersonnel]);
+
     const personnelColumns = React.useMemo(() => PersonnelColumns(), []);
-    const sortedByColumn = React.useMemo(() => personnelColumns.find(c => c.accessor === sortBy) || null, [sortBy]);
+    const sortedByColumn = React.useMemo(
+        () => personnelColumns.find(c => c.accessor === sortBy) || null,
+        [sortBy]
+    );
 
     return (
+
         <div className={styles.container}>
             <div className={styles.managePersonnel}>
-                <div className={styles.toolbar}><Button outlined onClick={() => setIsAddPersonOpen(true)} >  <AddIcon />  Add Person </Button></div>
+                <div className={styles.toolbar}>
+                    <Button outlined onClick={() => setIsAddPersonOpen(true)}>
+                        {' '}
+                        <AddIcon /> Add Person{' '}
+                    </Button>
+                </div>
                 <DataTable
                     columns={personnelColumns}
                     data={sortedData}
@@ -46,10 +70,21 @@ const ManagePersonnelPage: React.FC = () => {
                     onSelectionChange={setSelectedItems}
                     selectedItems={selectedItems}
                 />
-                {isAddPersonOpen && <AddPersonnelSideSheet isOpen={isAddPersonOpen} setIsOpen={setIsAddPersonOpen} selectedPersonnel={selectedItems.length ? selectedItems : null} />}
+                {isAddPersonOpen && (
+                    <AddPersonnelSideSheet
+                        isOpen={isAddPersonOpen}
+                        setIsOpen={setIsAddPersonOpen}
+                        selectedPersonnel={selectedItems.length ? selectedItems : null}
+                    />
+                )}
             </div>
+            <GenericFilter
+                data={personnel}
+                filterSections={filterSections}
+                onFilter={setFilteredPersonnel}
+            />
         </div>
     );
-}
+};
 
-export default ManagePersonnelPage
+export default ManagePersonnelPage;


### PR DESCRIPTION
Added filter pane to manage personnel. 
Has search option and filter for Ad status. 

Pulled out AzureAdStatus into its own component. 
So that the icons could be used in other places if needed. 
Wanted to use this in the filter pane, but that didnt work. 
Did extendt it though with some other functions. 
So you can pull out a "formatted" name for each status. 
And also color assosited with their icon. 



