### PR TITLE
update filterSection to use original nonefiltered datasource

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
@@ -51,8 +51,8 @@ const ActiveRequestsPage: React.FC = () => {
     }, [contractContext, currentContext]);
 
     const filterSections = React.useMemo(() => {
-        return getFilterSections(filteredActiveRequests);
-    }, [filteredActiveRequests]);
+        return getFilterSections(activeRequests || []);
+    }, [activeRequests]);
 
     if (error) {
         return (
@@ -84,16 +84,16 @@ const ActiveRequestsPage: React.FC = () => {
                         message="No active requests found for selected contract"
                     />
                 ) : (
-                    <SortableTable
-                        data={filteredActiveRequests || []}
-                        columns={columns}
-                        rowIdentifier="id"
-                        isFetching={isFetching}
-                        isSelectable
-                        selectedItems={selectedRequests}
-                        onSelectionChange={setSelectedRequests}
-                    />
-                )}
+                        <SortableTable
+                            data={filteredActiveRequests || []}
+                            columns={columns}
+                            rowIdentifier="id"
+                            isFetching={isFetching}
+                            isSelectable
+                            selectedItems={selectedRequests}
+                            onSelectionChange={setSelectedRequests}
+                        />
+                    )}
             </div>
             <GenericFilter
                 data={activeRequests}

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActualMppPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActualMppPage/index.tsx
@@ -42,8 +42,8 @@ const ActualMppPage: React.FC = () => {
     }, [contractContext, currentContext]);
 
     const filterSections = React.useMemo(() => {
-        return getFilterSections(filteredContractPositions);
-    }, [filteredContractPositions]);
+        return getFilterSections(contractPositions || []);
+    }, [contractPositions]);
 
     if (error) {
         return (
@@ -75,16 +75,16 @@ const ActualMppPage: React.FC = () => {
                         message="No positions found on selected contract"
                     />
                 ) : (
-                    <SortableTable
-                        data={filteredContractPositions || []}
-                        columns={columns}
-                        rowIdentifier="id"
-                        isFetching={isFetching}
-                        isSelectable
-                        selectedItems={selectedRequests}
-                        onSelectionChange={setSelectedRequests}
-                    />
-                )}
+                        <SortableTable
+                            data={filteredContractPositions || []}
+                            columns={columns}
+                            rowIdentifier="id"
+                            isFetching={isFetching}
+                            isSelectable
+                            selectedItems={selectedRequests}
+                            onSelectionChange={setSelectedRequests}
+                        />
+                    )}
             </div>
             <GenericFilter
                 data={contractPositions}

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/getFilterSections.ts
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/getFilterSections.ts
@@ -15,7 +15,7 @@ const getFilterSections = (personnel: Personnel[]): FilterSection<Personnel>[] =
                 {
                     key: 'search-filter',
                     type: FilterTypes.Search,
-                    title: 'Search',
+                    title: '',
                     getValue: p =>
                         p.name + (p.firstName || '') + (p.lastName || '') + p.mail + p.phoneNumber,
                 },


### PR DESCRIPTION
Notice this when setting up filters for mange personnel. 
Think this is unintended behaviour for the filters. 

Using the filtereddata to create a filterSections gives you filter selection based on the filtered data. 
Meaning you will not be able to select multiple statuses at once, because the rest disappear as soon as you select one. 

This changes makes it possible to select multiple status filters at the same time. 
It should still "remove" other filters thats empty in other filters.

