### PR TITLE
Api - Personnel details

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiBasePosition.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiBasePosition.cs
@@ -1,0 +1,24 @@
+﻿using Fusion.Resources.Domain;
+using System;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiBasePosition
+    {
+        public ApiBasePosition(QueryBasePosition basePosition)
+        {
+            Id = basePosition.Id;
+            Name = basePosition.Name;
+            Discipline = basePosition.Disicipline;
+            ProjectType = basePosition.ProjectType;
+        }
+
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Discipline { get; set; }
+        public string ProjectType { get; set; }
+    }
+
+
+
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiContractPersonnel.cs
@@ -8,11 +8,6 @@ namespace Fusion.Resources.Api.Controllers
 {
     public class ApiContractPersonnel
     {
-        [Obsolete("Bogus")]
-        public ApiContractPersonnel()
-        {
-
-        }
         public ApiContractPersonnel(QueryContractPersonnel personnel)
         {
             PersonnelId = personnel.PersonnelId;
@@ -27,6 +22,9 @@ namespace Fusion.Resources.Api.Controllers
             Disciplines = personnel.Disciplines.Select(d => new ApiPersonnelDiscipline(d)).ToList();
             Created = personnel.Created;
             Updated = personnel.Updated;
+
+            Positions = personnel.Positions?.Select(p => new ApiPositionInstanceReference(p)).ToList();
+            Requests = personnel.Requests?.Select(r => new ApiRequestReference(r)).ToList();
         }
 
         public Guid PersonnelId { get; set; }
@@ -51,49 +49,83 @@ namespace Fusion.Resources.Api.Controllers
         public DateTimeOffset Created { get; set; }
         public DateTimeOffset? Updated { get; set; }
 
-        public enum ApiAccountStatus { Available, InviteSent, NoAccount }
-    }
+    
 
-    public class ApiExternalPersonnelPerson
-    {
-        public ApiExternalPersonnelPerson(QueryExternalPersonnelPerson person)
+        public List<ApiPositionInstanceReference>? Positions { get; set; }
+        public List<ApiRequestReference>? Requests { get; set; }
+
+
+        public enum ApiAccountStatus { Available, InviteSent, NoAccount }
+
+        public class ApiRequestReference
         {
-            Id = person.PersonnelId;
-            AzureUniquePersonId = person.AzureUniqueId;
-            Name = person.Name;
-            FirstName = person.FirstName;
-            LastName = person.LastName;
-            JobTitle = person.JobTitle;
-            PhoneNumber = person.PhoneNumber;
-            Mail = person.Mail;
-            AzureAdStatus = Enum.Parse<ApiAccountStatus>($"{person.AzureAdStatus}", true);
-            Disciplines = person.Disciplines.Select(d => new ApiPersonnelDiscipline(d)).ToList();
+            public ApiRequestReference(QueryPersonnelRequestReference request)
+            {
+                Id = request.Id;
+                Created = request.Created;
+                Updated = request.Updated;
+
+                State = Enum.Parse<ApiContractPersonnelRequest.ApiRequestState>($"{request.State}", true);
+                
+
+                Position = new ApiRequestPosition(request.Position);
+                Project = new ApiProjectReference(request.Project);
+                Contract = new ApiContractReference(request.Contract);
+            }
+
+            public Guid Id { get; set; }
+
+            public DateTimeOffset Created { get; set; }
+            public DateTimeOffset? Updated { get; set; }
+
+            [JsonConverter(typeof(JsonStringEnumConverter))]
+            public ApiContractPersonnelRequest.ApiRequestState State { get; set; }
+
+            public ApiRequestPosition Position { get; set; }
+
+            public ApiContractReference Contract { get; set; }
+            public ApiProjectReference Project { get; set; }
         }
 
-        /// <summary>
-        /// The id for the personnel item. This item can be used across multiple contracts. 
-        /// </summary>
-        public Guid Id { get; set; }
+        public class ApiPositionInstanceReference
+        {
+            public ApiPositionInstanceReference(QueryOrgPositionInstance instance)
+            {
+                PositionId = instance.PositionId;
+                InstanceId = instance.Id;
+                Name = instance.Name;
+                Obs = instance.Obs;
+                ExternalPositionId = instance.ExternalPositionId;
+                AppliesFrom = instance.AppliesFrom;
+                AppliesTo = instance.AppliesTo;
+                Workload = instance.Workload.GetValueOrDefault(0);
+
+                Project = instance.Project;
+                Contract = instance.Contract;
+                BasePosition = new ApiBasePosition(instance.BasePosition);
+            }
 
 
-        public Guid? AzureUniquePersonId { get; set; }
-        public string Name { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+            public Guid PositionId { get; set; }
 
-        public string JobTitle { get; set; }
-        public string PhoneNumber { get; set; }
-        public string Mail { get; set; }
+            /// <summary>
+            /// Id of the instance the person is assigned to.
+            /// </summary>
+            public Guid InstanceId { get; set; }
+            public string Name { get; set; }
+            public string Obs { get; set; }
+            public string ExternalPositionId { get; set; }
+            public DateTime? AppliesFrom { get; set; }
+            public DateTime? AppliesTo { get; set; }
+            public double Workload { get; set; }
 
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public ApiAccountStatus AzureAdStatus { get; set; }
+            public ApiBasePosition BasePosition { get; set; }
 
-        public bool HasCV { get; set; }
-
-        public List<ApiPersonnelDiscipline> Disciplines { get; set; }
-
-        public enum ApiAccountStatus { Available, Invited, NoAccount }
+            public Fusion.ApiClients.Org.ApiProjectReferenceV2 Project { get; set; }
+            public Fusion.ApiClients.Org.ApiContractReferenceV2 Contract { get; set; }
+        }
     }
+
 
 
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
@@ -1,0 +1,51 @@
+﻿using Fusion.Resources.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiExternalPersonnelPerson
+    {
+        public ApiExternalPersonnelPerson(QueryExternalPersonnelPerson person)
+        {
+            Id = person.PersonnelId;
+            AzureUniquePersonId = person.AzureUniqueId;
+            Name = person.Name;
+            FirstName = person.FirstName;
+            LastName = person.LastName;
+            JobTitle = person.JobTitle;
+            PhoneNumber = person.PhoneNumber;
+            Mail = person.Mail;
+            AzureAdStatus = Enum.Parse<ApiAccountStatus>($"{person.AzureAdStatus}", true);
+            Disciplines = person.Disciplines.Select(d => new ApiPersonnelDiscipline(d)).ToList();
+        }
+
+        /// <summary>
+        /// The id for the personnel item. This item can be used across multiple contracts. 
+        /// </summary>
+        public Guid Id { get; set; }
+
+
+        public Guid? AzureUniquePersonId { get; set; }
+        public string Name { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+        public string JobTitle { get; set; }
+        public string PhoneNumber { get; set; }
+        public string Mail { get; set; }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ApiAccountStatus AzureAdStatus { get; set; }
+
+        public bool HasCV { get; set; }
+
+        public List<ApiPersonnelDiscipline> Disciplines { get; set; }
+
+        public enum ApiAccountStatus { Available, Invited, NoAccount }
+    }
+
+
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
@@ -38,6 +38,22 @@ namespace Fusion.Resources.Api.Controllers
             return collection;
         }
 
+        [HttpGet("/projects/{projectIdentifier}/contracts/{contractIdentifier}/resources/personnel/{personIdentifier}")]
+        public async Task<ActionResult<ApiContractPersonnel>> GetContractPersonnel([FromRoute]ProjectIdentifier projectIdentifier, Guid contractIdentifier, string personIdentifier)
+        {
+            var personnelId = new PersonnelId(personIdentifier);
+
+            var contractPersonnel = await DispatchAsync(new GetContractPersonnelItem(contractIdentifier, personnelId));
+
+            if (contractPersonnel == null)
+            {
+                return FusionApiError.NotFound(personIdentifier, "Could not locate personnel");
+            }
+
+            var returnItem = new ApiContractPersonnel(contractPersonnel);
+            return returnItem;
+        }
+
         [HttpPost("/projects/{projectIdentifier}/contracts/{contractIdentifier}/resources/personnel")]
         public async Task<ActionResult<ApiContractPersonnel>> CreateContractPersonnel([FromRoute]ProjectIdentifier projectIdentifier, Guid contractIdentifier, [FromBody] CreateContractPersonnelRequest request)
         {

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="29.0.1" />
-    <PackageReference Include="Fusion.Integration" Version="3.1.0-preview-5" />
-    <PackageReference Include="Fusion.Integration.Authorization" Version="3.1.0-preview-5" />
-    <PackageReference Include="Fusion.Integration.Org" Version="3.1.0-preview-5" />
+    <PackageReference Include="Fusion.Integration" Version="3.1.0-preview-6" />
+    <PackageReference Include="Fusion.Integration.Authorization" Version="3.1.0-preview-6" />
+    <PackageReference Include="Fusion.Integration.Org" Version="3.1.0-preview-6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="3.1.0-rc-1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
 

--- a/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
+++ b/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="DbQueries\" />
+  </ItemGroup>
+
 </Project>

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeleteContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeleteContractPersonnel.cs
@@ -41,7 +41,7 @@ namespace Fusion.Resources.Domain.Commands
             {
                 var dbEntity = request.PersonnelId.Type switch
                 {
-                    PersonnelId.IdentifierType.UniqueId => await resourcesDb.ContractPersonnel.FirstOrDefaultAsync(c => c.Id == request.PersonnelId.UniqueId || c.Person.AzureUniqueId == request.PersonnelId.UniqueId),
+                    PersonnelId.IdentifierType.UniqueId => await resourcesDb.ContractPersonnel.FirstOrDefaultAsync(c => c.PersonId == request.PersonnelId.UniqueId || c.Person.AzureUniqueId == request.PersonnelId.UniqueId),
                     _ => await resourcesDb.ContractPersonnel.FirstOrDefaultAsync(c => c.Person.Mail == request.PersonnelId.Mail)
                 };
 

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeleteContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeleteContractPersonnel.cs
@@ -39,11 +39,9 @@ namespace Fusion.Resources.Domain.Commands
 
             protected override async Task Handle(DeleteContractPersonnel request, CancellationToken cancellationToken)
             {
-                var dbEntity = request.PersonnelId.Type switch
-                {
-                    PersonnelId.IdentifierType.UniqueId => await resourcesDb.ContractPersonnel.FirstOrDefaultAsync(c => c.PersonId == request.PersonnelId.UniqueId || c.Person.AzureUniqueId == request.PersonnelId.UniqueId),
-                    _ => await resourcesDb.ContractPersonnel.FirstOrDefaultAsync(c => c.Person.Mail == request.PersonnelId.Mail)
-                };
+                var dbEntity = await resourcesDb.ContractPersonnel
+                    .GetById(request.OrgContractId, request.PersonnelId)
+                    .FirstOrDefaultAsync();
 
                 if (dbEntity != null)
                 {

--- a/src/backend/api/Fusion.Resources.Domain/DbQueries/ContractPersonnelQueries.cs
+++ b/src/backend/api/Fusion.Resources.Domain/DbQueries/ContractPersonnelQueries.cs
@@ -1,0 +1,32 @@
+﻿using Fusion.Resources.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Fusion.Resources.Domain
+{
+    public static class ContractPersonnelQueries
+    {
+        public static IQueryable<DbContractPersonnel> GetById(this DbSet<DbContractPersonnel> table, PersonnelId identifier) 
+        {
+            return identifier.Type switch
+            {
+                PersonnelId.IdentifierType.UniqueId => table.Where(c => c.PersonId == identifier.UniqueId || c.Person.AzureUniqueId == identifier.UniqueId),
+                _ => table.Where(c => c.Person.Mail == identifier.Mail)
+            };
+        }
+
+        public static IQueryable<DbContractPersonnel> GetById(this DbSet<DbContractPersonnel> table, Guid orgContractId, PersonnelId identifier)
+        {
+            var query = table.Where(p => p.Contract.OrgContractId == orgContractId);
+
+            return identifier.Type switch
+            {
+                PersonnelId.IdentifierType.UniqueId => query.Where(c => c.PersonId == identifier.UniqueId || c.Person.AzureUniqueId == identifier.UniqueId),
+                _ => query.Where(c => c.Person.Mail == identifier.Mail)
+            };
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Extensions/ODataParamsExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/ODataParamsExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Fusion.AspNetCore.OData;
+using System;
+using System.Linq;
+
+namespace Fusion.Resources.Domain
+{
+    public static class ODataParamsExtensions
+    {
+        public static bool ShoudExpand(this ODataQueryParams query, string property)
+        {
+            if (query.Expand != null && query.Expand.Contains(property, StringComparer.OrdinalIgnoreCase))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Fusion.AspNetCore" Version="3.1.0" />
     <PackageReference Include="Fusion.Threading" Version="3.1.1" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="3.1.0-rc-1" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.1.0-preview-5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.1.0-preview-6" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
 
   </ItemGroup>

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryBasePosition.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryBasePosition.cs
@@ -1,4 +1,5 @@
 ﻿using Fusion.ApiClients.Org;
+using Fusion.Integration.Profile;
 using System;
 
 namespace Fusion.Resources.Domain
@@ -16,6 +17,16 @@ namespace Fusion.Resources.Domain
             Name = basePosition.Name;
             Disicipline = basePosition.Discipline;
             ProjectType = basePosition.ProjectType;
+
+            Resolved = true;
+        }
+
+        public QueryBasePosition(FusionBasePosition basePosition)
+        {
+            Id = basePosition.Id;
+            Name = basePosition.Name;
+            Disicipline = basePosition.Discipline;
+            ProjectType = basePosition.Type;
 
             Resolved = true;
         }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryContractPersonnel.cs
@@ -3,51 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using Fusion.Resources.Database.Entities;
 
+#nullable enable
+
 namespace Fusion.Resources.Domain
 {
-    public class QueryExternalPersonnelPerson
-    {
-        public QueryExternalPersonnelPerson(DbExternalPersonnelPerson item)
-        {
-            PersonnelId = item.Id;
-
-            AzureUniqueId = item.AzureUniqueId;
-            Name = item.Name;
-            FirstName = item.FirstName;
-            LastName = item.LastName;
-            Mail = item.Mail;
-            PhoneNumber = item.Phone;
-            JobTitle = item.JobTitle;
-            AzureAdStatus = item.AccountStatus;
-
-            Disciplines = item.Disciplines.Select(d => new QueryPersonnelDiscipline(d)).ToList();
-        }
-        public Guid PersonnelId { get; set; }
-        public Guid? AzureUniqueId { get; set; }
-        public string Name { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string JobTitle { get; set; }
-        public string PhoneNumber { get; set; }
-        public string Mail { get; set; }
-
-        public DbAzureAccountStatus AzureAdStatus { get; set; }
-
-        public List<QueryPersonnelDiscipline> Disciplines { get; set; }
-    }
-
-
 
     public class QueryContractPersonnel
     {
-        [Obsolete("Mock only")]
-        public QueryContractPersonnel()
-        {
-        }
-
         public QueryContractPersonnel(DbContractPersonnel item)
         {
-            PersonnelId = item.Id;
+            Id = item.Id;
+
+            PersonnelId = item.PersonId;
 
             AzureUniqueId = item.Person.AzureUniqueId;
             Name = item.Person.Name;
@@ -65,6 +32,15 @@ namespace Fusion.Resources.Domain
 
             Disciplines = item.Person.Disciplines.Select(d => new QueryPersonnelDiscipline(d)).ToList();
         }
+
+        /// <summary>
+        /// The id for the personnel relation to this contract.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// The id of the personnel item. This item can be used across multiple contracts.
+        /// </summary>
         public Guid PersonnelId { get; set; }
         public Guid? AzureUniqueId { get; set; }
         public string Name { get; set; }
@@ -83,7 +59,11 @@ namespace Fusion.Resources.Domain
         public DateTimeOffset Created { get; set; }
         public DateTimeOffset? Updated { get; set; }
 
-        public QueryProject Project { get; set; }
-        public QueryContract Contract { get; set; }
+        //public QueryProject Project { get; set; }
+        //public QueryContract Contract { get; set; }
+
+
+        public List<QueryOrgPositionInstance>? Positions { get; set; }
+        public List<QueryPersonnelRequestReference>? Requests { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryExternalPersonnelPerson.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fusion.Resources.Database.Entities;
+
+namespace Fusion.Resources.Domain
+{
+    public class QueryExternalPersonnelPerson
+    {
+        public QueryExternalPersonnelPerson(DbExternalPersonnelPerson item)
+        {
+            PersonnelId = item.Id;
+
+            AzureUniqueId = item.AzureUniqueId;
+            Name = item.Name;
+            FirstName = item.FirstName;
+            LastName = item.LastName;
+            Mail = item.Mail;
+            PhoneNumber = item.Phone;
+            JobTitle = item.JobTitle;
+            AzureAdStatus = item.AccountStatus;
+
+            Disciplines = item.Disciplines.Select(d => new QueryPersonnelDiscipline(d)).ToList();
+        }
+        public Guid PersonnelId { get; set; }
+        public Guid? AzureUniqueId { get; set; }
+        public string Name { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string JobTitle { get; set; }
+        public string PhoneNumber { get; set; }
+        public string Mail { get; set; }
+
+        public DbAzureAccountStatus AzureAdStatus { get; set; }
+
+        public List<QueryPersonnelDiscipline> Disciplines { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryOrgPositionInstance.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryOrgPositionInstance.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Fusion.Integration.Profile;
+
+namespace Fusion.Resources.Domain
+{
+    public class QueryOrgPositionInstance
+    {
+        public QueryOrgPositionInstance(FusionContract contract, FusionContractPosition positionInstance)
+        {
+            Project = new ApiClients.Org.ApiProjectReferenceV2
+            {
+                DomainId = contract.Project.DomainId,
+                Name = contract.Project.Name,
+                ProjectType = contract.Project.Type,
+                ProjectId = contract.Project.Id
+            };
+            Contract = new ApiClients.Org.ApiContractReferenceV2
+            {
+                Name = contract.Name,
+                Id = contract.Id,
+                ContractNumber = contract.ContractNumber
+                // TODO, company
+            };
+
+            Id = positionInstance.Id;
+            PositionId = positionInstance.PositionId;
+            Name = positionInstance.Name;
+            Obs = positionInstance.Obs;
+            ExternalPositionId = positionInstance.ExternalPositionId;
+            AppliesFrom = positionInstance.AppliesFrom;
+            AppliesTo = positionInstance.AppliesTo;
+            Workload = positionInstance.Workload;
+            BasePosition = new QueryBasePosition(positionInstance.BasePosition);
+        }
+
+        public Guid PositionId { get; set; }
+
+        /// <summary>
+        /// Id of the instance the person is assigned to.
+        /// </summary>
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Obs { get; set; }
+        public string ExternalPositionId { get; set; }
+        public DateTime? AppliesFrom { get; set; }
+        public DateTime? AppliesTo { get; set; }
+        public double? Workload { get; set; }
+        public QueryBasePosition BasePosition { get; set; }
+
+        public Fusion.ApiClients.Org.ApiProjectReferenceV2 Project { get; set; }
+        public Fusion.ApiClients.Org.ApiContractReferenceV2 Contract { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelRequestReference.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelRequestReference.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Fusion.Resources.Database.Entities;
+
+#nullable enable
+
+namespace Fusion.Resources.Domain
+{
+    /// <summary>
+    /// Reference to a personnel request where the specific personnel id is used.
+    /// 
+    /// This entity only holds info related to the request position, not the person.
+    /// </summary>
+    public class QueryPersonnelRequestReference
+    {
+        public QueryPersonnelRequestReference(DbContractorRequest request, QueryPositionRequest position)
+        {
+            Id = request.Id;
+            PersonnelId = request.Person.PersonId;
+            Position = position;
+
+            State = request.State;
+
+            Project = new QueryProject(request.Project);
+            Contract = new QueryContract(request.Contract);
+
+            Created = request.Created;
+            Updated = request.Updated;
+        }
+
+        public Guid Id { get; set; }
+        public Guid PersonnelId { get; set; }
+
+        public DbRequestState State { get; set; }
+
+        public QueryPositionRequest Position { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+        public DateTimeOffset? Updated { get; set; }
+
+        public QueryProject Project { get; set; }
+        public QueryContract Contract { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Fusion.AspNetCore.OData;
+using Fusion.Integration;
+using Fusion.Integration.Profile;
 using Fusion.Resources.Database;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -12,23 +14,56 @@ namespace Fusion.Resources.Domain
 {
     public class GetContractPersonnel : IRequest<IEnumerable<QueryContractPersonnel>>
     {
+        private ODataQueryParams query = null;
+
         public GetContractPersonnel(Guid contractId, ODataQueryParams query = null)
         {
             ContractId = contractId;
             Query = query;
+
+            
         }
 
         public Guid ContractId { get; set; }
-        public ODataQueryParams Query { get; set; }
+        public ODataQueryParams Query { get => query; set
+            {
+                this.query = value;
+
+                if (value != null)
+                {
+                    if (query.ShoudExpand("requests"))
+                        Expands |= ExpandProperties.Requests;
+
+                    if (query.ShoudExpand("positions"))
+                        Expands |= ExpandProperties.Positions;
+                }
+            }
+        }
+
+
+        public ExpandProperties Expands { get; set; }
+
+        [Flags]
+        public enum ExpandProperties {
+            None        = 0,
+            Positions   = 1 << 0,
+            Requests    = 1 << 1,
+
+            All = Positions | Requests
+        }
 
 
         public class Handler : IRequestHandler<GetContractPersonnel, IEnumerable<QueryContractPersonnel>>
         {
             private readonly ResourcesDbContext db;
+            private readonly IFusionProfileResolver profileResolver;
+            private readonly IProjectOrgResolver orgResolver;
 
-            public Handler(ResourcesDbContext db)
+            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver, IProjectOrgResolver orgResolver)
             {
                 this.db = db;
+                this.profileResolver = profileResolver;
+                this.orgResolver = orgResolver;
             }
 
             public async Task<IEnumerable<QueryContractPersonnel>> Handle(GetContractPersonnel request, CancellationToken cancellationToken)
@@ -53,11 +88,91 @@ namespace Fusion.Resources.Domain
                     .Include(i => i.Person).ThenInclude(p => p.Disciplines)
                     .ToListAsync();
 
+
                 var returnItems = items.Select(i => new QueryContractPersonnel(i))
                     .ToList();
 
+
+                if (request.Expands.HasFlag(ExpandProperties.Requests))
+                {
+                    await ExpandRequestsAsync(returnItems);
+                }
+
+                if (request.Expands.HasFlag(ExpandProperties.Positions))
+                {
+                    await ExpandPositionsAsync(returnItems);
+                }
+
                 return returnItems;
+            }
+
+            private async Task ExpandPositionsAsync(IEnumerable<QueryContractPersonnel> personnelItems)
+            {
+                var azureIds = personnelItems.Where(i => i.AzureUniqueId.HasValue).Select(i => i.AzureUniqueId.Value);
+
+                var profiles = new List<FusionFullPersonProfile>();
+
+                int index = 0;
+                while (true)
+                {
+                    var page = azureIds.Skip(index).Take(10);
+                    index += 10;
+
+                    if (page.Count() == 0)
+                        break;
+
+                    var resolved = await Task.WhenAll(page.Select(i => profileResolver.ResolvePersonFullProfileAsync(i)));
+                    profiles.AddRange(resolved);
+                }
+
+                foreach (var item in personnelItems)
+                {
+                    if (item.AzureUniqueId.HasValue == false)
+                        continue;
+
+                    var profile = profiles.FirstOrDefault(p => p.AzureUniqueId == item.AzureUniqueId);
+                    if (profile is null)
+                        throw new InvalidOperationException($"Could locate profile for person with azure id {item.AzureUniqueId}. The profile should have been loaded...");
+
+
+                    item.Positions = profile.Contracts.SelectMany(c => c.Positions.Select(p => new QueryOrgPositionInstance(c, p))).ToList();
+                }
+
+            }
+        
+            private async Task ExpandRequestsAsync(IEnumerable<QueryContractPersonnel> personnelItems)
+            {
+                var ids = personnelItems.Select(i => i.PersonnelId);
+
+                var requests = await db.ContractorRequests
+                    .Include(r => r.Person)
+                    .Include(r => r.Contract)
+                    .Include(r => r.Project)
+                    .Where(r => ids.Contains(r.Person.Person.Id))
+                    .ToListAsync();
+
+                var basePositions = await Task.WhenAll(requests
+                    .Select(q => q.Position.BasePositionId)
+                    .Distinct()
+                    .Select(bp => orgResolver.ResolveBasePositionAsync(bp))
+                );
+
+                var positions = requests.Select(p =>
+                {
+                    var position = new QueryPositionRequest(p.Position)
+                        .WithResolvedBasePosition(basePositions.FirstOrDefault(bp => bp.Id == p.Position.BasePositionId));
+
+                    return new QueryPersonnelRequestReference(p, position);
+                }).ToList();
+
+
+                foreach (var item in personnelItems)
+                {
+                    item.Requests = positions.Where(p => p.PersonnelId == item.PersonnelId).ToList();
+                }
             }
         }
     }
+
+
 }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelItem.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Integration;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fusion.Resources.Domain
+{
+    public class GetContractPersonnelItem : IRequest<QueryContractPersonnel>
+    {
+
+        public GetContractPersonnelItem(Guid orgContractId, PersonnelId personnelId)
+        {
+            OrgContractId = orgContractId;
+            PersonnelId = personnelId;
+        }
+
+        public Guid OrgContractId { get; set; }
+        public PersonnelId PersonnelId { get; }
+
+
+        public class Handler : IRequestHandler<GetContractPersonnelItem, QueryContractPersonnel>
+        {
+            private readonly ResourcesDbContext db;
+            private readonly IFusionProfileResolver profileResolver;
+            private readonly IProjectOrgResolver orgResolver;
+
+            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver, IProjectOrgResolver orgResolver)
+            {
+                this.db = db;
+                this.profileResolver = profileResolver;
+                this.orgResolver = orgResolver;
+            }
+
+            public async Task<QueryContractPersonnel> Handle(GetContractPersonnelItem request, CancellationToken cancellationToken)
+            {
+                var query = db.ContractPersonnel.Where(p => p.Contract.OrgContractId == request.OrgContractId);
+                query = request.PersonnelId.Type switch
+                {
+                    PersonnelId.IdentifierType.UniqueId => db.ContractPersonnel.Where(c => c.PersonId == request.PersonnelId.UniqueId || c.Person.AzureUniqueId == request.PersonnelId.UniqueId),
+                    _ => db.ContractPersonnel.Where(c => c.Person.Mail == request.PersonnelId.Mail)
+                };
+
+                var item = await query
+                    .Include(i => i.Contract)
+                    .Include(i => i.Project)
+                    .Include(i => i.UpdatedBy)
+                    .Include(i => i.CreatedBy)
+                    .Include(i => i.Person).ThenInclude(p => p.Disciplines)
+                    .FirstOrDefaultAsync();
+
+                if (item == null)
+                    return null;
+
+                var returnItem = new QueryContractPersonnel(item);
+
+                await ExpandRequestsAsync(returnItem);
+                await ExpandPositionsAsync(returnItem);
+
+                return returnItem;
+            }
+
+            private async Task ExpandPositionsAsync(QueryContractPersonnel personnelItem)
+            {
+                if (personnelItem.AzureUniqueId == null)
+                    return;
+
+                var profile = await profileResolver.ResolvePersonFullProfileAsync(personnelItem.AzureUniqueId.Value);
+                personnelItem.Positions = profile.Contracts.SelectMany(c => c.Positions.Select(p => new QueryOrgPositionInstance(c, p))).ToList();
+            }
+
+            private async Task ExpandRequestsAsync(QueryContractPersonnel personnelItem)
+            {
+
+                var requests = await db.ContractorRequests
+                    .Include(r => r.Person)
+                    .Include(r => r.Contract)
+                    .Include(r => r.Project)
+                    .Where(r => r.Person.Person.Id == personnelItem.Id)
+                    .ToListAsync();
+
+                var basePositions = await Task.WhenAll(requests
+                    .Select(q => q.Position.BasePositionId)
+                    .Distinct()
+                    .Select(bp => orgResolver.ResolveBasePositionAsync(bp))
+                );
+
+                var positions = requests.Select(p =>
+                {
+                    var position = new QueryPositionRequest(p.Position)
+                        .WithResolvedBasePosition(basePositions.FirstOrDefault(bp => bp.Id == p.Position.BasePositionId));
+
+                    return new QueryPersonnelRequestReference(p, position);
+                }).ToList();
+
+
+                personnelItem.Requests = positions;
+            }
+        }
+    }
+
+
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelItem.cs
@@ -38,14 +38,8 @@ namespace Fusion.Resources.Domain
 
             public async Task<QueryContractPersonnel> Handle(GetContractPersonnelItem request, CancellationToken cancellationToken)
             {
-                var query = db.ContractPersonnel.Where(p => p.Contract.OrgContractId == request.OrgContractId);
-                query = request.PersonnelId.Type switch
-                {
-                    PersonnelId.IdentifierType.UniqueId => db.ContractPersonnel.Where(c => c.PersonId == request.PersonnelId.UniqueId || c.Person.AzureUniqueId == request.PersonnelId.UniqueId),
-                    _ => db.ContractPersonnel.Where(c => c.Person.Mail == request.PersonnelId.Mail)
-                };
-
-                var item = await query
+                var item = await db.ContractPersonnel
+                    .GetById(request.OrgContractId, request.PersonnelId)
                     .Include(i => i.Contract)
                     .Include(i => i.Project)
                     .Include(i => i.UpdatedBy)
@@ -80,7 +74,7 @@ namespace Fusion.Resources.Domain
                     .Include(r => r.Person)
                     .Include(r => r.Contract)
                     .Include(r => r.Project)
-                    .Where(r => r.Person.Person.Id == personnelItem.Id)
+                    .Where(r => r.Person.Person.Id == personnelItem.PersonnelId)
                     .ToListAsync();
 
                 var basePositions = await Task.WhenAll(requests


### PR DESCRIPTION
Added support for fetching additional information on personnel.

**Positions**
Fetched using the resolved full profile. Only contract positions are included.
In list these can be included by ?$expand=positions.

**Requests**
Includes all requests the personnel item is included in. These can be different contracts/projects.
In list these can be included by ?$expand=requests.

Added endpoint for fetching a single personnel item. This can be referenced by using the mail/azure id or the personnel id. This is the id of the external personnel person item, not the personnel in contract relation id.