### PR TITLE
Bug 10659 - Contract - Previous does not work when edit contract

### DIFF
--- a/src/frontend/src/pages/ProjectPage/components/EditContractWizard/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/components/EditContractWizard/index.tsx
@@ -20,7 +20,7 @@ import CreateOrEditExternalPositionButton from './components/CreateOrEditExterna
 import { formatDate, useTelemetryLogger, useNotificationCenter } from '@equinor/fusion';
 import CompanyPicker from './components/CompanyPicker';
 import useContractAllocationAutoFocus from './hooks/useContractAllocationAutoFocus';
-import useActiveStepKey from './hooks/useActiveStepKey';
+import useActiveStepKey, { StepKey } from './hooks/useActiveStepKey';
 import useContractPersister from './hooks/useContractPersister';
 
 export { default as ContractWizardSkeleton } from './components/ContractWizardSkeleton';
@@ -77,11 +77,13 @@ const EditContractWizard: React.FC<EditContractWizardProps> = ({
         }
     }, [formState, resetForm, setFormField, saveAsync]);
 
-    const { activeStepKey, gotoContract, gotoContractDetails, gotoExteral } = useActiveStepKey(
-        isEdit,
-        formState,
-        onSave
-    );
+    const {
+        setActiveStepKey,
+        activeStepKey,
+        gotoContract,
+        gotoContractDetails,
+        gotoExteral,
+    } = useActiveStepKey(isEdit, formState, onSave);
 
     const {
         contractNumberRef,
@@ -127,6 +129,10 @@ const EditContractWizard: React.FC<EditContractWizardProps> = ({
         }
     }, [saveAsync, onSubmit]);
 
+    const handleChange = React.useCallback((stepKey: string) => {
+        setActiveStepKey(stepKey as StepKey);
+    }, []);
+
     return (
         <div className={styles.container}>
             <header className={styles.header}>
@@ -151,7 +157,7 @@ const EditContractWizard: React.FC<EditContractWizardProps> = ({
                     )}
                 </Button>
             </header>
-            <Stepper hideNavButtons activeStepKey={activeStepKey}>
+            <Stepper hideNavButtons activeStepKey={activeStepKey} onChange={handleChange}>
                 <Step
                     title="Select contract"
                     stepKey="select-contract"


### PR DESCRIPTION
added onChange handle when moving between pages in the stepper directly. else previous button didnt get mapped correctly


https://dev.azure.com/statoil-proview/Fusion/_backlogs/backlog/Fusion%20Team/Epics/?showParents=true&workitem=10659