### PR TITLE
10719 Actual MPP - Change request - Scroll on fly out

### DIFF
--- a/src/frontend/src/components/RequestProgressSidesheet/index.tsx
+++ b/src/frontend/src/components/RequestProgressSidesheet/index.tsx
@@ -220,43 +220,45 @@ function RequestProgressSidesheet<TRequest, TResponse>({
                     </div>
                 </div>
             )}
-            <Accordion>
-                {pendingRequests.length > 0 && (
-                    <AccordionItem
-                        label={`In progress (${pendingRequests.length})`}
-                        isOpen={isPendingRequestsOpen}
-                        onChange={() => setIsPendingRequestsOpen(!isPendingRequestsOpen)}
-                    >
-                        <div className={styles.progressList}>
-                            {pendingRequests.map((request, index) => (
-                                <PendingRequestProgressItem
-                                    key={index.toString()}
-                                    request={request}
-                                    renderRequest={renderRequest}
-                                />
-                            ))}
-                        </div>
-                    </AccordionItem>
-                )}
-                {successfulRequests.length > 0 && (
-                    <AccordionItem
-                        label={`Successful (${successfulRequests.length})`}
-                        isOpen={isSuccessfulRequestsOpen}
-                        onChange={() => setIsSuccessfulRequestsOpen(!isSuccessfulRequestsOpen)}
-                    >
-                        <div className={styles.progressList}>
-                            {successfulRequests.map((request, index) => (
-                                <SuccesfulRequestProgressItem
-                                    key={index.toString()}
-                                    request={request.item}
-                                    response={request.response}
-                                    renderRequest={renderRequest}
-                                />
-                            ))}
-                        </div>
-                    </AccordionItem>
-                )}
-            </Accordion>
+            <div className={styles.accordionContainer}>
+                <Accordion>
+                    {pendingRequests.length > 0 && (
+                        <AccordionItem
+                            label={`In progress (${pendingRequests.length})`}
+                            isOpen={isPendingRequestsOpen}
+                            onChange={() => setIsPendingRequestsOpen(!isPendingRequestsOpen)}
+                        >
+                            <div className={styles.progressList}>
+                                {pendingRequests.map((request, index) => (
+                                    <PendingRequestProgressItem
+                                        key={index.toString()}
+                                        request={request}
+                                        renderRequest={renderRequest}
+                                    />
+                                ))}
+                            </div>
+                        </AccordionItem>
+                    )}
+                    {successfulRequests.length > 0 && (
+                        <AccordionItem
+                            label={`Successful (${successfulRequests.length})`}
+                            isOpen={isSuccessfulRequestsOpen}
+                            onChange={() => setIsSuccessfulRequestsOpen(!isSuccessfulRequestsOpen)}
+                        >
+                            <div className={styles.progressList}>
+                                {successfulRequests.map((request, index) => (
+                                    <SuccesfulRequestProgressItem
+                                        key={index.toString()}
+                                        request={request.item}
+                                        response={request.response}
+                                        renderRequest={renderRequest}
+                                    />
+                                ))}
+                            </div>
+                        </AccordionItem>
+                    )}
+                </Accordion>
+            </div>
         </ModalSideSheet>
     );
 }

--- a/src/frontend/src/components/RequestProgressSidesheet/styles.less
+++ b/src/frontend/src/components/RequestProgressSidesheet/styles.less
@@ -69,3 +69,7 @@
         margin: 0;
     }
 }
+
+.accordionContainer {
+    width: 100%;
+}


### PR DESCRIPTION
Accordion takes up 100% of the height of its parent regardless of its own size. 
causing it to create a scroll even when empty, if there was failed/invalid attempts. 

Added a div around the accordian, so that is now scales more in height according to its own size. 
