### PR TITLE
Adjustment to contract Overview and fix create/edit position input

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@equinor/fusion-components": {
-      "version": "1.1.69",
-      "resolved": "https://registry.npmjs.org/@equinor/fusion-components/-/fusion-components-1.1.69.tgz",
-      "integrity": "sha512-jpG4dWqmSUTI6gOtSLqWYyH2gRrRU+46Q+kM26fncqZyif54r1xj1sYhZuJu5QtUIkif6ywWnwdJsBuItfU9Mw=="
+      "version": "1.1.70",
+      "resolved": "https://registry.npmjs.org/@equinor/fusion-components/-/fusion-components-1.1.70.tgz",
+      "integrity": "sha512-PYFUL6NS9j1oYng46LQlukNDktwQTl5ztdHwY0S91/NG6/luuOQHFaP6wYI8SpIivbbHVkkWkga6UzSTRyExxA=="
     },
     "@hot-loader/react-dom": {
       "version": "16.12.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@equinor/fusion": "^1.1.2",
-        "@equinor/fusion-components": "^1.1.69",
+        "@equinor/fusion-components": "^1.1.70",
         "@types/classnames": "^2.2.9",
         "@types/deep-equal": "^1.0.1",
         "classnames": "^2.2.6",

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/EditableTable/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/EditableTable/index.tsx
@@ -61,11 +61,12 @@ function EditableTable<T>({
     const tableContainerRef = React.useRef<HTMLDivElement | null>(null);
 
     const onChange = (key: any, accessKey: keyof T, value: any) => {
-        const updatedPersons = [...formState].map(stateItem =>
-            stateItem[rowIdentifier] === key
-                ? { ...stateItem, [accessKey]: value || null }
-                : stateItem
-        );
+        const updatedPersons = [...formState].map(stateItem => {
+            const nullValue = typeof stateItem[accessKey] === 'string' ? '' : null;
+            return stateItem[rowIdentifier] === key
+                ? { ...stateItem, [accessKey]: value || nullValue }
+                : stateItem;
+        });
         setFormState(updatedPersons);
     };
 
@@ -156,21 +157,24 @@ function EditableTable<T>({
         setSelectedItems(selectedItems.length === formState.length ? [] : formState);
     }, [formState, selectedItems]);
 
-    const scrollToTableCell = React.useCallback((tableCell: HTMLTableCellElement | null) => {
-        if (!tableContainerRef.current || !tableCell) {
-            return;
-        }
-        const header = tableContainerRef.current;
+    const scrollToTableCell = React.useCallback(
+        (tableCell: HTMLTableCellElement | null) => {
+            if (!tableContainerRef.current || !tableCell) {
+                return;
+            }
+            const header = tableContainerRef.current;
 
-        if (header.scrollWidth === header.offsetWidth) {
-            return;
-        }
-        header.scrollTo(
-            tableCell.offsetLeft - header.offsetWidth / 2 + tableCell.offsetWidth / 2,
-            0
-        );
-    },[tableContainerRef]);
-    
+            if (header.scrollWidth === header.offsetWidth) {
+                return;
+            }
+            header.scrollTo(
+                tableCell.offsetLeft - header.offsetWidth / 2 + tableCell.offsetWidth / 2,
+                0
+            );
+        },
+        [tableContainerRef]
+    );
+
     React.useEffect(() => {
         scrollToTableCell(activeTableCell);
     }, [activeTableCell]);
@@ -248,7 +252,7 @@ function EditableTable<T>({
     }, [columns, formState, selectedItems, setActiveTableCell]);
 
     return (
-        <div className={styles.editableTable} >
+        <div className={styles.editableTable}>
             <Taskbar
                 onAddItem={onAddItem}
                 selectedItems={selectedItems}

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ContractDetailsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ContractDetailsPage/index.tsx
@@ -63,7 +63,7 @@ const PositionCardSkeleton = () => (
 const getCurrentInstance = (position: Position) => {
     const now = new Date();
     return position.instances.find(i => i.appliesFrom <= now && i.appliesTo >= now);
-}
+};
 
 const renderPosition = (position: Position | null) =>
     position ? (
@@ -124,8 +124,8 @@ const ContractDetailsPage = () => {
                     <ToDate />
                 </div>
                 <div className={styles.row}>
-                    <EquinorContractResponsible />
                     <EquinorCompanyRep />
+                    <EquinorContractResponsible />
                 </div>
                 <div className={styles.row}>
                     <ExternalCompanyRep />


### PR DESCRIPTION
Bug 10758 :
Adjustment for Contract overview. 
Switched place off equinor company rep with equinor contract responisble.
Making the external and equinor version of these align. 

Bug 10761: 
edit/create request, if you remove thje workload the page crashes. 
This bug was created when fixing the same problem with Task owner. 
Sending inn empty string crashes task owener. 
But sending in null crashes workload. 
Fixes this by checking what null value to use. 
empty string for string values and null for other. 

Root of the problem is the TextInput "inputTextContentClasses". 
The value.length check here causing a crash when you send inn null. 


