### PR TITLE
Changed status code to 400 from 404 on missing project master

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
@@ -65,7 +65,7 @@ namespace Fusion.Resources.Api.Controllers
             }
             catch (ContextResolverExtensions.ProjectMasterNotFoundError ex)
             {
-                return ApiErrors.NotFound(ex.Message);
+                return ApiErrors.InvalidOperation(ex);
             }
 
             var commonlibClient = httpClientFactory.CreateClient(HttpClientNames.AppCommonLib);


### PR DESCRIPTION
Will give this response when project master not found now

```
{
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "Invalid Operation",
  "status": 400,
  "detail": "Unable to find project master for 'Query test project (01302859-f803-42a8-b6fa-4973bce5bc6b)'",
  "error": {
    "code": "ProjectMasterNotFoundError",
    "message": "Unable to find project master for 'Query test project (01302859-f803-42a8-b6fa-4973bce5bc6b)'"
  }
}
```