### PR TITLE
added person info to use when user does not have azureId

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/EditablePositionDetails/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/EditablePositionDetails/index.tsx
@@ -10,12 +10,26 @@ import {
 import classNames from 'classnames';
 import useBasePositions from '../../../../../../hooks/useBasePositions';
 import AzureAdStatusIcon from '../../pages/ManagePersonnelPage/components/AzureAdStatus';
+import { PersonDetails } from '@equinor/fusion';
 
 type EditablePositionDetailsProps = {
     person: Personnel;
     edit?: boolean;
     setField?: (field: keyof Personnel) => (value: string | PersonnelDiscipline[]) => void;
 };
+
+const getPersonDetails = (person: Personnel): PersonDetails => ({
+    azureUniqueId: person.azureUniquePersonId || '',
+    name: `${person.firstName} ${person.lastName}`,
+    mail: person.mail,
+    jobTitle: person.jobTitle,
+    department: '',
+    mobilePhone: person.phoneNumber,
+    officeLocation: '',
+    upn: '',
+    accountType: 'External',
+    company: { id: '', name: '' },
+});
 
 const createTextField = (
     label: string,
@@ -81,6 +95,7 @@ const EditablePositionDetails: React.FC<EditablePositionDetailsProps> = ({
                     <PersonPhoto
                         hideTooltip={true}
                         personId={person.azureUniquePersonId}
+                        person={getPersonDetails(person)}
                         size={'xlarge'}
                     />
                 </div>


### PR DESCRIPTION
When user didnt have azureId, PersonPhoto uses some default data on the picture hover.
Added personnel data to the person prop, that will be used when there is no azureID supplied.
