### PR TITLE
Request and position side sheet - Closes on reload even tough id is specified in the url search string

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/PositionDetailsSideSheet/hooks/useCurrentPosition.ts
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/PositionDetailsSideSheet/hooks/useCurrentPosition.ts
@@ -4,7 +4,7 @@ import { parseQueryString } from '../../../../../../../api/utils';
 
 export default (positions: Position[] | null) => {
     const history = useHistory();
-    const [currentPosition, setCurrentPosition] = React.useState<Position | null>(null);
+    const [currentPosition, setCurrentPosition] = React.useState<Position | null>();
 
     React.useEffect(() => {
         if (!positions) {
@@ -16,13 +16,13 @@ export default (positions: Position[] | null) => {
     }, [history.location.search, positions]);
 
     React.useEffect(() => {
-        if(currentPosition === null){
+        if (currentPosition === null) {
             history.push({
                 pathname: history.location.pathname,
-                search: "",
+                search: '',
             });
         }
-    },[currentPosition])
+    }, [currentPosition]);
 
-    return {currentPosition, setCurrentPosition};
+    return { currentPosition: currentPosition || null, setCurrentPosition };
 };

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/RequestDetailsSideSheet/hooks/useCurrentRequest.ts
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/components/RequestDetailsSideSheet/hooks/useCurrentRequest.ts
@@ -5,7 +5,7 @@ import { parseQueryString } from '../../../../../../../api/utils';
 
 export default (requests: PersonnelRequest[] | null) => {
     const history = useHistory();
-    const [currentRequest, setCurrentRequest] = React.useState<PersonnelRequest | null>(null);
+    const [currentRequest, setCurrentRequest] = React.useState<PersonnelRequest | null>();
 
     React.useEffect(() => {
         if (!requests) {
@@ -17,13 +17,13 @@ export default (requests: PersonnelRequest[] | null) => {
     }, [history.location.search, requests]);
 
     React.useEffect(() => {
-        if(currentRequest === null){
+        if (currentRequest === null) {
             history.push({
                 pathname: history.location.pathname,
-                search: "",
+                search: '',
             });
         }
-    },[currentRequest])
+    }, [currentRequest]);
 
-    return {currentRequest, setCurrentRequest};
+    return { currentRequest: currentRequest || null, setCurrentRequest };
 };


### PR DESCRIPTION
### Issue:
Selected position/request initial state was null. A useEffect that removes the search string triggeres every time the state is null:
### Solution:
Set initial state to undefined and the useEffect will not trigger