### PR TITLE
Preventing Personnel with position begin overwritten by personnel without positions

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
@@ -55,7 +55,7 @@ const ManagePersonnelPage: React.FC = () => {
         }
 
         try {
-            const result = apiClient.getPersonnelAsync(projectId, contractId);
+            const result = await apiClient.getPersonnelAsync(projectId, contractId);
             getPersonnelWithPositionsAsync();
             return result;
         } catch (error) {


### PR DESCRIPTION
In managed personnel, it happens that "getPersonnelWithPositionsAsync" finnished before "getPersonnelAsync". 
And you end up with a dataset without positions. 

The fix I have added here works fine, but im unsure if its good for the long term.
With bigger datasets the final update/render might be delayed by alot. 

If you got any ideas on how this could be done better. 
Or a solution to explore im all ears. 

I have tried with a "flag" for getPersonnelWithPositionsAsync. 
So that if personnelwithPosition has sendt its dispatch. 
getPersonnelAsync will not return its result. 
That means that the fetchPersonnelAsync callback needs to listen to this flag. 
which leads to the function begin update and useReducerCollection will rerun the fetching. 

