### PR TITLE
fixed error in console regarding missing list child keys

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/PersonnelInfoSideSheet/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/PersonnelInfoSideSheet/index.tsx
@@ -94,12 +94,16 @@ const PersonnelInfoSideSheet: React.FC<PersonnelInfoSideSheetProps> = ({
         if (activeTabKey !== 'general') return [];
         return editMode
             ? [
-                  <IconButton disabled={!isFormValid} onClick={savePersonChangesAsync}>
+                  <IconButton
+                      key="DoneButton"
+                      disabled={!isFormValid}
+                      onClick={savePersonChangesAsync}
+                  >
                       <DoneIcon />
                   </IconButton>,
               ]
             : [
-                  <IconButton onClick={() => setEditMode(true)}>
+                  <IconButton key="EditButton" onClick={() => setEditMode(true)}>
                       <EditIcon />
                   </IconButton>,
               ];


### PR DESCRIPTION
When you opened Managed personnel. 
There was a "Each child in a list should have a unique "key" prop" in the console.

Added keys to the header buttons array on the Personnelinfosidesheet.
Fixing the problem, and removing the error. 