### PR TITLE
Added fusion-libraries to nuget config

### DIFF
--- a/src/backend/nuget.config
+++ b/src/backend/nuget.config
@@ -3,5 +3,6 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Fusion-Public" value="https://statoil-proview.pkgs.visualstudio.com/5309109e-a734-4064-a84c-fbce45336913/_packaging/Fusion-Public/nuget/v3/index.json" />
+    <add key="Fusion-Libraries" value="https://statoil-proview.pkgs.visualstudio.com/_packaging/Fusion-Libraries/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Resources Functions uses Fusion.Events.Azure.Functions.Extensions which is published to the Fusion-Libraries feed. The build is failing as of now because of missing package.