### PR TITLE
Use set instead of merge when fetching entire sets

### DIFF
--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
@@ -67,7 +67,8 @@ const ActiveRequestsPage: React.FC = () => {
         contractState,
         dispatchContractAction,
         'activeRequests',
-        fetchRequestsAsync
+        fetchRequestsAsync,
+        'set'
     );
 
     React.useEffect(() => {
@@ -85,7 +86,7 @@ const ActiveRequestsPage: React.FC = () => {
     const editRequest = React.useCallback(
         (copy?: boolean) => {
             const requests: PersonnelRequest[] = copy
-                ? selectedRequests.map(s => ({
+                ? selectedRequests.map((s) => ({
                       ...s,
                       id: '',
                       originalPositionId: null,
@@ -110,7 +111,7 @@ const ActiveRequestsPage: React.FC = () => {
                             <IconButton onClick={requestPersonnel} ref={addRequestTooltipRef}>
                                 <AddIcon />
                             </IconButton>
-                            
+
                             <IconButton
                                 onClick={() => editRequest(true)}
                                 disabled={selectedRequests.length <= 0}
@@ -204,7 +205,7 @@ const ActiveRequestsPage: React.FC = () => {
                 <RejectPersonnelSideSheet
                     requests={rejectRequest}
                     setRequests={setRejectRequest}
-                    onReject={reason => reject(reason)}
+                    onReject={(reason) => reject(reason)}
                 />
             </ResourceErrorMessage>
         </div>

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActualMppPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActualMppPage/index.tsx
@@ -52,7 +52,8 @@ const ActualMppPage: React.FC = () => {
         contractState,
         dispatchContractAction,
         'actualMpp',
-        fetchMppAsync
+        fetchMppAsync,
+        'set'
     );
 
     const getPersonnelWithPositionsAsync = async () => {

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/CompletedRequestsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/CompletedRequestsPage/index.tsx
@@ -34,7 +34,8 @@ const CompletedRequestsPage: React.FC = () => {
         contractState,
         dispatchContractAction,
         'completedRequests',
-        fetchRequestsAsync
+        fetchRequestsAsync,
+        'set'
     );
 
     const completedRequests = React.useMemo(

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ManagePersonnelPage/index.tsx
@@ -37,7 +37,7 @@ const ManagePersonnelPage: React.FC = () => {
 
         const result = await apiClient.getPersonnelWithPositionsAsync(projectId, contractId);
         dispatchContractAction({
-            verb: 'merge',
+            verb: 'set',
             collection: 'personnel',
             payload: result,
         });
@@ -59,7 +59,8 @@ const ManagePersonnelPage: React.FC = () => {
         contractState,
         dispatchContractAction,
         'personnel',
-        fetchPersonnelAsync
+        fetchPersonnelAsync,
+        'set'
     );
 
     const { sortedData, setSortBy, sortBy, direction } = useSorting<Personnel>(

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ProvisioningRequestsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ProvisioningRequestsPage/index.tsx
@@ -44,7 +44,8 @@ const ProvisioningRequestsPage: React.FC = () => {
         contractState,
         dispatchContractAction,
         'completedRequests',
-        fetchRequestsAsync
+        fetchRequestsAsync,
+        'set'
     );
     const provisioningRequests = React.useMemo(
         () =>


### PR DESCRIPTION
Replace entire collection of items instead of merge when fetching the entire collection from the backend