### PR TITLE
Bug 11638: Active requests - Make approval buttons available

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resources",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resources",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "resources",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Manage resources in pro org chart contracts",
     "main": "src/index.tsx",
     "repository": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "resources",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Manage resources in pro org chart contracts",
     "main": "src/index.tsx",
     "repository": {

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ActiveRequestsPage/index.tsx
@@ -136,43 +136,36 @@ const ActiveRequestsPage: React.FC = () => {
                         </div>
 
                         <div className={styles.buttonContainer}>
-                            {canReject && (
-                                <Button
-                                    outlined
-                                    disabled={!canReject}
-                                    onClick={() => setRejectRequest(selectedRequests)}
-                                >
-                                    <div className={styles.buttonIcon}>
-                                        {isRejecting ? (
-                                            <Spinner small inline />
-                                        ) : (
-                                            <CloseCircleIcon
-                                                width={styling.numericalGrid(2)}
-                                                height={styling.numericalGrid(2)}
-                                            />
-                                        )}
-                                    </div>
-                                    Reject
-                                </Button>
-                            )}
-                            {canApprove && (
-                                <Button
-                                    disabled={!canApprove}
-                                    onClick={() => canApprove && approve()}
-                                >
-                                    <div className={styles.buttonIcon}>
-                                        {isApproving ? (
-                                            <Spinner small inline />
-                                        ) : (
-                                            <CheckCircleIcon
-                                                width={styling.numericalGrid(2)}
-                                                height={styling.numericalGrid(2)}
-                                            />
-                                        )}
-                                    </div>
-                                    Approve
-                                </Button>
-                            )}
+                            <Button
+                                outlined
+                                disabled={!canReject}
+                                onClick={() => setRejectRequest(selectedRequests)}
+                            >
+                                <div className={styles.buttonIcon}>
+                                    {isRejecting ? (
+                                        <Spinner small inline />
+                                    ) : (
+                                        <CloseCircleIcon
+                                            width={styling.numericalGrid(2)}
+                                            height={styling.numericalGrid(2)}
+                                        />
+                                    )}
+                                </div>
+                                Reject
+                            </Button>
+                            <Button disabled={!canApprove} onClick={() => canApprove && approve()}>
+                                <div className={styles.buttonIcon}>
+                                    {isApproving ? (
+                                        <Spinner small inline />
+                                    ) : (
+                                        <CheckCircleIcon
+                                            width={styling.numericalGrid(2)}
+                                            height={styling.numericalGrid(2)}
+                                        />
+                                    )}
+                                </div>
+                                Approve
+                            </Button>
                             <div className={styles.helpButton}>
                                 <Link target="_blank" to="/help">
                                     <IconButton ref={helpIconRef}>


### PR DESCRIPTION
In active requests is where you're supposed to approve or reject the request. but now these buttons are way too hidden as is.
So what we need to do is: Make these buttons available at all times, these buttons should be inactive as long as no rows have been choosen. Once a row is chosen, then buttons should be set to active.
