### PR TITLE
Api - Fixed non-nullable taskowner on create request

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/ApiModels/ApiPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/ApiModels/ApiPerson.cs
@@ -13,8 +13,8 @@ namespace Fusion.Resources.Api.Controllers
             AzureUniquePersonId = profile.AzureUniqueId;
             Mail = profile.Mail;
             Name = profile.Name;
-            PhoneNumber = profile.MobilePhone;
-            JobTitle = profile.JobTitle;
+            PhoneNumber = profile.MobilePhone ?? string.Empty;
+            JobTitle = profile.JobTitle ?? string.Empty;
             AccountType = profile.AccountType;
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
@@ -69,7 +69,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var contractsToReturn = orgContracts
                 .Where(c => c != null)
-                .Where(c => allocatedContracts.Any(ac => ac.OrgContractId == c.Id))
+                .Where(c => allocatedContracts.Any(ac => ac.OrgContractId == c!.Id))
                 .ToList();
 
 
@@ -77,11 +77,11 @@ namespace Fusion.Resources.Api.Controllers
             switch (User.GetUserAccountType())
             {
                 case FusionAccountType.External:
-                    contractsToReturn.RemoveAll(c => User.IsInContract(c.ContractNumber) == false);
+                    contractsToReturn.RemoveAll(c => User.IsInContract(c!.ContractNumber) == false);
                     break;
             } 
 
-            var collection = new ApiCollection<ApiContract>(contractsToReturn.Select(c => new ApiContract(c)));
+            var collection = new ApiCollection<ApiContract>(contractsToReturn.Select(c => new ApiContract(c!)));
             return collection;
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/ContractPersonnelRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/ContractPersonnelRequestRequest.cs
@@ -32,7 +32,7 @@ namespace Fusion.Resources.Api.Controllers
             public DateTime AppliesTo { get; set; }
             public string? Obs { get; set; } 
 
-            public TaskOwnerReference TaskOwner { get; set; } = null!;
+            public TaskOwnerReference? TaskOwner { get; set; }
             public double Workload { get; set; }
         }
 
@@ -57,7 +57,7 @@ namespace Fusion.Resources.Api.Controllers
                 RuleFor(x => x.Position.BasePosition).BeValidBasePosition(projectOrgResolver)
                     .When(x => x.Position != null);
 
-                RuleFor(x => x.Position.TaskOwner.PositionId).BeExistingContractPositionId(projectOrgResolver)
+                RuleFor(x => x.Position.TaskOwner!.PositionId).BeExistingContractPositionId(projectOrgResolver)
                     .When(x => x.Position != null && x.Position.TaskOwner != null);
 
                 RuleFor(x => x.OriginalPositionId).BeValidChangeRequestPosition(projectOrgResolver)


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When nullable reference types are enabled, asp.net core validates non-nullable references on input models. The TaskOwner property on the position object was not marked as nullable, hence the default validator rejected the request.

Fixes AB#11362

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Simple fix, should not need testing.


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review


