### PR TITLE
Delete position & integration test pilot

### DIFF
--- a/src/backend/Directory.Build.props
+++ b/src/backend/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="_ResolveCopyLocalNuGetPackagePdbsAndXml" Condition="$(CopyLocalLockFileAssemblies) == true" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths 
+        Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdb')"
+        Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != '' and Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
+      <ReferenceCopyLocalPaths
+        Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')"
+        Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != '' and Exists('%(RootDir)%(Directory)%(Filename).xml')" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/backend/Fusion.Resources.sln
+++ b/src/backend/Fusion.Resources.sln
@@ -31,7 +31,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fusion.Resources.Logic.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fusion.Resources.Api.Tests", "tests\Fusion.Resources.Api.Tests\Fusion.Resources.Api.Tests.csproj", "{FC455F0E-0880-4272-AFFE-38D8EF358B6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fusion.Resources.Test.Core", "tests\Fusion.Resources.Test.Core\Fusion.Resources.Test.Core.csproj", "{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fusion.Resources.Test.Core", "tests\Fusion.Resources.Test.Core\Fusion.Resources.Test.Core.csproj", "{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fusion.Testing.Authentication", "tests\Fusion.Testing.Authentication\Fusion.Testing.Authentication.csproj", "{50C5830A-ED39-4B58-9947-53AB41A98C4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fusion.Testing.Core", "tests\Fusion.Testing.Core\Fusion.Testing.Core.csproj", "{348E5E93-D975-457D-8DC4-9579B936E53B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fusion.Testing.Mocks.ProfileService", "tests\Fusion.Testing.Mocks.ProfileService\Fusion.Testing.Mocks.ProfileService.csproj", "{471EBA1F-067D-44D5-92B8-FB80016D7290}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fusion.Testing.Mocks.OrgService", "tests\Fusion.Testing.Mocks.OrgService\Fusion.Testing.Mocks.OrgService.csproj", "{A54602CE-2240-40AC-9B7C-CB47BC9EF999}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fusion.Testing.Mocks.ContextService", "tests\Fusion.Testing.Mocks.ContextService\Fusion.Testing.Mocks.ContextService.csproj", "{77835023-8755-4A75-B395-7CBD6BAA3D70}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +93,26 @@ Global
 		{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50C5830A-ED39-4B58-9947-53AB41A98C4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50C5830A-ED39-4B58-9947-53AB41A98C4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50C5830A-ED39-4B58-9947-53AB41A98C4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50C5830A-ED39-4B58-9947-53AB41A98C4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{348E5E93-D975-457D-8DC4-9579B936E53B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{348E5E93-D975-457D-8DC4-9579B936E53B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{348E5E93-D975-457D-8DC4-9579B936E53B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{348E5E93-D975-457D-8DC4-9579B936E53B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{471EBA1F-067D-44D5-92B8-FB80016D7290}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{471EBA1F-067D-44D5-92B8-FB80016D7290}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{471EBA1F-067D-44D5-92B8-FB80016D7290}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{471EBA1F-067D-44D5-92B8-FB80016D7290}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A54602CE-2240-40AC-9B7C-CB47BC9EF999}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A54602CE-2240-40AC-9B7C-CB47BC9EF999}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A54602CE-2240-40AC-9B7C-CB47BC9EF999}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A54602CE-2240-40AC-9B7C-CB47BC9EF999}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77835023-8755-4A75-B395-7CBD6BAA3D70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77835023-8755-4A75-B395-7CBD6BAA3D70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77835023-8755-4A75-B395-7CBD6BAA3D70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77835023-8755-4A75-B395-7CBD6BAA3D70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -99,6 +129,11 @@ Global
 		{7BE089A8-F824-4273-9312-3D32E064569E} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
 		{FC455F0E-0880-4272-AFFE-38D8EF358B6F} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
 		{BA3A0B0E-5D2B-43DA-AA71-A72A5642B340} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
+		{50C5830A-ED39-4B58-9947-53AB41A98C4D} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
+		{348E5E93-D975-457D-8DC4-9579B936E53B} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
+		{471EBA1F-067D-44D5-92B8-FB80016D7290} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
+		{A54602CE-2240-40AC-9B7C-CB47BC9EF999} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
+		{77835023-8755-4A75-B395-7CBD6BAA3D70} = {D12DC33D-BB83-40E4-9F36-18F59351A21D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F47D8FDB-3919-45C8-8C08-486405ECEC01}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
@@ -52,5 +52,27 @@ namespace Fusion.Resources.Api.Controllers.Mpp
             return NoContent();
         }
 
+        [HttpOptions("/projects/{projectIdentifier}/contracts/{contractIdentifier}/mpp/positions")]
+        public async Task<ActionResult> CheckDeleteAccess([FromRoute] ProjectIdentifier projectIdentifier, Guid contractIdentifier)
+        {
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+
+                r.AnyOf(or =>
+                {
+                    or.ContractAccess(ContractRole.AnyExternalRole, projectIdentifier, contractIdentifier);
+                    or.DelegatedContractAccess(DelegatedContractRole.AnyExternalRole, projectIdentifier, contractIdentifier);
+                });
+            });
+
+            if (authResult.Success)
+                Response.Headers.Add("Allow", "DELETE");
+            else
+                Response.Headers.Add("Allow", "");
+
+            return NoContent();
+        }
+
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
@@ -1,0 +1,56 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.AspNetCore.FluentAuthorization;
+using Fusion.Resources.Api.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Controllers.Mpp
+{
+    [Authorize]
+    [ApiController]
+    public class MppController : ResourceControllerBase
+    {
+
+        [HttpDelete("/projects/{projectIdentifier}/contracts/{contractIdentifier}/mpp/positions/{positionId}")]
+        public async Task<ActionResult> DeleteContractPosition([FromRoute] ProjectIdentifier projectIdentifier, Guid contractIdentifier, Guid positionId)
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+
+                r.AnyOf(or =>
+                {
+                    or.ContractAccess(ContractRole.AnyExternalRole, projectIdentifier, contractIdentifier);
+                    or.DelegatedContractAccess(DelegatedContractRole.AnyExternalRole, projectIdentifier, contractIdentifier);
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            try
+            {
+                await Commands.DispatchAsync(new Domain.Commands.DeleteContractPosition(projectIdentifier.ProjectId, contractIdentifier, positionId));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return ApiErrors.InvalidOperation(ex);
+            }
+            catch (OrgApiError apiEx)
+            {
+                return ApiErrors.FailedFusionRequest(Fusion.Integration.FusionEndpoint.ProOrganisation, apiEx.Error?.Message ?? apiEx.Message);
+            }
+
+            return NoContent();
+        }
+
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -21,9 +21,10 @@
   <ItemGroup>
     <!--<PackageReference Include="FluentValidation" Version="8.5.0" />-->
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
-    
+
     <PackageReference Include="Bogus" Version="30.0.4" />
     <PackageReference Include="Fusion.Integration" Version="3.5.4" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.5.4" />
     <PackageReference Include="Fusion.Integration.Authorization" Version="3.2.1" />
     <PackageReference Include="Fusion.Integration.Org" Version="3.2.2" />
     <PackageReference Include="Fusion.Integration.Roles" Version="1.1.2" />

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     
     <PackageReference Include="Bogus" Version="30.0.4" />
-    <PackageReference Include="Fusion.Integration" Version="3.5.0" />
+    <PackageReference Include="Fusion.Integration" Version="3.5.4" />
     <PackageReference Include="Fusion.Integration.Authorization" Version="3.2.1" />
     <PackageReference Include="Fusion.Integration.Org" Version="3.2.2" />
     <PackageReference Include="Fusion.Integration.Roles" Version="1.1.2" />
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />    
 
-    <PackageReference Include="Fusion.AspNetCore" Version="3.1.6" />
+    <PackageReference Include="Fusion.AspNetCore" Version="3.1.7" />
     
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.0.0" />
     <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="5.0.0" />

--- a/src/backend/api/Fusion.Resources.Api/Program.cs
+++ b/src/backend/api/Fusion.Resources.Api/Program.cs
@@ -20,13 +20,16 @@ namespace Fusion.Resources.Api
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((ctx, configBuilder) =>
                 {
-                    configBuilder.AddJsonFile("/app/secrets/appsettings.secrets.yaml", optional: true);
+                    if (ShouldLoadConfiguration())
+                    {
+                        configBuilder.AddJsonFile("/app/secrets/appsettings.secrets.yaml", optional: true);
 
-                    AddKeyVault(ctx, configBuilder);
+                        AddKeyVault(ctx, configBuilder);
 
-                    // Override key vault
-                    if (ctx.HostingEnvironment.IsDevelopment())
-                        configBuilder.AddUserSecrets<Program>(); 
+                        // Override key vault
+                        if (ctx.HostingEnvironment.IsDevelopment())
+                            configBuilder.AddUserSecrets<Program>();
+                    }
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
@@ -51,6 +54,19 @@ namespace Fusion.Resources.Api
             {
                 Console.WriteLine("Skipping key vault as url is empty.");
             }
+        }
+
+        private static bool ShouldLoadConfiguration()
+        {
+            var integrationTestMarker = Environment.GetEnvironmentVariable("INTEGRATION_TEST_RUN");
+            
+            if (string.IsNullOrEmpty(integrationTestMarker))
+                return true;
+
+            if (string.Equals(integrationTestMarker, "true", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return true;
         }
 
     }

--- a/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
+++ b/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
 
   </ItemGroup>
 

--- a/src/backend/api/Fusion.Resources.Database/Authentication/AzureTokenAuthenticationManager.cs
+++ b/src/backend/api/Fusion.Resources.Database/Authentication/AzureTokenAuthenticationManager.cs
@@ -42,7 +42,7 @@ namespace Fusion.Resources.Database.Authentication
         {
             var connection = new SqlConnection(connectionString);
 
-            if (connectionMode == ConnectionMode.Tokens)
+            if (connection.ConnectionString.Contains("database.windows.net") && connectionMode == ConnectionMode.Tokens)
             {
                 if (accessToken == null)
                 {

--- a/src/backend/api/Fusion.Resources.Domain/Commands/MPP/DeleteContractPosition.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/MPP/DeleteContractPosition.cs
@@ -1,0 +1,67 @@
+﻿using Fusion.Integration.Org;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable 
+
+namespace Fusion.Resources.Domain.Commands
+{
+
+    public class DeleteContractPosition : TrackableRequest
+    {
+        public DeleteContractPosition(Guid projectId, Guid contractIdentifier, Guid positionId)
+        {
+            OrgProjectId = projectId;
+            OrgContractId = contractIdentifier;
+            OrgPositionId = positionId;
+        }
+
+        public Guid OrgContractId { get; set; }
+        public Guid OrgProjectId { get; set; }
+        public Guid OrgPositionId { get; set; }
+
+
+        public class Handler : AsyncRequestHandler<DeleteContractPosition>
+        {
+            private readonly IOrgApiClient client;
+
+            public Handler(IOrgApiClientFactory apiClientFactory)
+            {
+                client = apiClientFactory.CreateClient(ApiClientMode.Application);
+            }
+
+            protected override async Task Handle(DeleteContractPosition request, CancellationToken cancellationToken)
+            {
+                /*
+                 * Special cases:
+                 * - Deleted position is a REP position
+                 * 
+                 * */
+
+                var positionResponse = await client.GetPositionV2Async(request.OrgProjectId, request.OrgContractId, request.OrgPositionId);
+
+                if (positionResponse.IsSuccessStatusCode)
+                {
+                    await client.DeletePositionV2Async(positionResponse.Value, force: true);
+                } 
+                else
+                {
+                    switch (positionResponse.StatusCode)
+                    {
+                        case System.Net.HttpStatusCode.NotFound:
+                            throw new InvalidOperationException("Position was not located in org chart.");
+                    }
+
+                    throw new InvalidOperationException("Unknown error when trying to comunicate with org api.");
+                }
+            }
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -21,27 +21,11 @@ namespace Fusion.Resources.Api.Tests.Fixture
 
         /// <summary>
         /// Will use the admin account to delegate admin to the provided account, then returns a 'auth' scope for the delegated admin.
-        /// Delegates access to the specified account.
-        /// </summary>
-        public async Task<TestClientScope> CreateExternalDelegatedAdminScopeAsync(Guid projectId, Guid contractId, ApiPersonProfileV3 delegatedAdmin)
-        {
-            var client = ApiFactory.CreateClient();
-
-            using (var adminScope = AdminScope())
-            {
-                await client.DelegateExternalAdminAccessAsync(projectId, contractId, delegatedAdmin.AzureUniqueId.Value);
-            }
-
-            return UserScope(delegatedAdmin);
-        }
-
-        /// <summary>
-        /// Will use the admin account to delegate admin to the provided account, then returns a 'auth' scope for the delegated admin.
         /// Creats a new random user that will get the delegated role.
         /// 
         /// This new profile can be accessed through scope.Profile.
         /// </summary>
-        public async Task<TestClientScope> CreateExternalDelegatedAdminScopeAsync(Guid projectId, Guid contractId)
+        public async Task<ApiPersonProfileV3> NewDelegatedAdminAsync(Guid projectId, Guid contractId)
         {
             var delegatedAdmin = AddProfile(FusionAccountType.External);
 
@@ -52,7 +36,7 @@ namespace Fusion.Resources.Api.Tests.Fixture
                 await client.DelegateExternalAdminAccessAsync(projectId, contractId, delegatedAdmin.AzureUniqueId.Value);
             }
 
-            return UserScope(delegatedAdmin);
+            return delegatedAdmin;
         }
 
         public ResourceApiFixture()

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -6,6 +6,7 @@ using Fusion.Integration.Profile.ApiClient;
 using Fusion.Testing.Mocks.ContextService;
 using Fusion.Integration.Profile;
 using Fusion.Testing;
+using System.Threading.Tasks;
 
 namespace Fusion.Resources.Api.Tests.Fixture
 {
@@ -18,6 +19,41 @@ namespace Fusion.Resources.Api.Tests.Fixture
         public TestClientScope AdminScope() => new TestClientScope(AdminUser);
         public TestClientScope UserScope(ApiPersonProfileV3 profile) => new TestClientScope(profile);
 
+        /// <summary>
+        /// Will use the admin account to delegate admin to the provided account, then returns a 'auth' scope for the delegated admin.
+        /// Delegates access to the specified account.
+        /// </summary>
+        public async Task<TestClientScope> CreateExternalDelegatedAdminScopeAsync(Guid projectId, Guid contractId, ApiPersonProfileV3 delegatedAdmin)
+        {
+            var client = ApiFactory.CreateClient();
+
+            using (var adminScope = AdminScope())
+            {
+                await client.DelegateExternalAdminAccessAsync(projectId, contractId, delegatedAdmin.AzureUniqueId.Value);
+            }
+
+            return UserScope(delegatedAdmin);
+        }
+
+        /// <summary>
+        /// Will use the admin account to delegate admin to the provided account, then returns a 'auth' scope for the delegated admin.
+        /// Creats a new random user that will get the delegated role.
+        /// 
+        /// This new profile can be accessed through scope.Profile.
+        /// </summary>
+        public async Task<TestClientScope> CreateExternalDelegatedAdminScopeAsync(Guid projectId, Guid contractId)
+        {
+            var delegatedAdmin = AddProfile(FusionAccountType.External);
+
+            var client = ApiFactory.CreateClient();
+
+            using (var adminScope = AdminScope())
+            {
+                await client.DelegateExternalAdminAccessAsync(projectId, contractId, delegatedAdmin.AzureUniqueId.Value);
+            }
+
+            return UserScope(delegatedAdmin);
+        }
 
         public ResourceApiFixture()
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -1,0 +1,48 @@
+﻿using Fusion.Resources.Database;
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Fusion.Testing.Mocks.ProfileService;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Testing.Mocks.ContextService;
+using Fusion.Integration.Profile;
+using Fusion.Testing;
+
+namespace Fusion.Resources.Api.Tests.Fixture
+{
+    public class ResourceApiFixture : IDisposable
+    {
+        public readonly ResourcesApiWebAppFactory ApiFactory;
+
+        public ApiPersonProfileV3 AdminUser { get; }
+
+        public TestClientScope AdminScope() => new TestClientScope(AdminUser);
+        public TestClientScope UserScope(ApiPersonProfileV3 profile) => new TestClientScope(profile);
+
+
+        public ResourceApiFixture()
+        {
+            ApiFactory = new ResourcesApiWebAppFactory();
+            AdminUser = PeopleServiceMock.AddTestProfile()
+                .WithRoles("Fusion.Resources.FullControl")
+                .SaveProfile();
+
+        }
+
+        public ContextResolverMock ContextResolver => ApiFactory.contextResolverMock;
+
+        public void Dispose()
+        {
+            using var scope = ApiFactory.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ResourcesDbContext>();
+            db.Database.EnsureDeleted();
+        }
+
+        internal ApiPersonProfileV3 AddProfile(FusionAccountType accountType)
+        {
+            var account = new FusionTestUserBuilder(accountType)                
+                .SaveProfile();
+
+            return account;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
@@ -1,0 +1,108 @@
+﻿using Fusion.Resources.Database;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.TestHost;
+using System.Net.Http;
+using Moq;
+using Fusion.Testing.Mocks.ProfileService;
+using Fusion.Testing.Mocks.OrgService;
+using Fusion.Integration.Org;
+using Fusion.Testing.Mocks.OrgService.Resolvers;
+using Fusion.Testing.Mocks.ContextService;
+using Fusion.Integration;
+using Fusion.Resources.Api.Tests.FusionMocks;
+using Fusion.Integration.Notification;
+using Fusion.Integration.Roles;
+using Fusion.Testing;
+
+namespace Fusion.Resources.Api.Tests.Fixture
+{
+    public class ResourcesApiWebAppFactory : WebApplicationFactory<Startup>
+    {
+
+        public readonly PeopleServiceMock peopleServiceMock;
+        public readonly OrgServiceMock orgServiceMock;
+        public readonly ContextResolverMock contextResolverMock;
+        internal readonly NotificationClientMock notificationMock;
+        internal readonly RolesClientMock roleClientMock;
+
+        private string resourceDbConnectionString = TestDbConnectionStrings.LocalDb($"resources-app-{DateTime.Now:yyyy-MM-dd-HHmmss}");
+
+        public ResourcesApiWebAppFactory()
+        {
+            Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII = true;
+
+            Environment.SetEnvironmentVariable("INTEGRATION_TEST_RUN", "true");
+            Environment.SetEnvironmentVariable("AzureAd__ClientId", TestConstants.APP_CLIENT_ID);
+            Environment.SetEnvironmentVariable("FORWARD_JWT", "True");
+            Environment.SetEnvironmentVariable("FORWARD_COOKIE", "True");
+
+            peopleServiceMock = new PeopleServiceMock();
+            orgServiceMock = new OrgServiceMock();
+            contextResolverMock = new ContextResolverMock();
+            notificationMock = new NotificationClientMock();
+            roleClientMock = new RolesClientMock();
+
+            EnsureDatabase();
+        }
+
+        private void EnsureDatabase()
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<ResourcesDbContext>(options =>
+            {
+                options.UseSqlServer(resourceDbConnectionString);
+            });
+
+            using (var sp = services.BuildServiceProvider())
+            using (var scope = sp.CreateScope())
+            {
+                ResourcesDbContext dbContext = scope.ServiceProvider.GetRequiredService<ResourcesDbContext>();
+                dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(5));
+
+                dbContext.Database.EnsureCreated();
+            }
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration(cfgBuilder =>
+            {               
+                cfgBuilder.AddInMemoryCollection( new Dictionary<string, string>()
+                {
+                    { $"ConnectionStrings:{nameof(ResourcesDbContext)}", resourceDbConnectionString }
+                });
+            });
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddIntegrationTestingAuthentication();
+
+                services.TryRemoveImplementationService("PeopleEventReceiver");
+                services.TryRemoveImplementationService("OrgEventReceiver");
+                services.TryRemoveImplementationService("ContextEventReceiver");
+                
+                services.AddSingleton<IProjectOrgResolver>(sp => new OrgResolverMock());
+                services.AddSingleton<IFusionContextResolver>(sp => contextResolverMock);
+                services.AddSingleton<IFusionNotificationClient>(sp => notificationMock);
+                services.AddSingleton<IFusionRolesClient>(Span => roleClientMock);
+
+                services.AddSingleton(sp =>
+                {
+                    var clientFactoryMock = new Mock<IHttpClientFactory>();
+
+                    clientFactoryMock.Setup(cfm => cfm.CreateClient(Fusion.Integration.Http.HttpClientNames.ApplicationPeople)).Returns(peopleServiceMock.CreateHttpClient());
+                    clientFactoryMock.Setup(cfm => cfm.CreateClient(Fusion.Integration.Org.OrgConstants.HttpClients.Application)).Returns(orgServiceMock.CreateHttpClient());
+
+                    return clientFactoryMock.Object;
+                });
+            });
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/TestConstants.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/TestConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Fusion.Resources.Api.Tests.Fixture
+{
+    public static class TestConstants
+    {
+        /// <summary>
+        /// This one is created and does not exist.
+        /// </summary>
+        public const string APP_CLIENT_ID = "5a842df8-3238-415d-b168-9f16a6a6031b"; //"1af94d9a-d948-44dc-959c-372ddc3abe1f";
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
@@ -8,16 +8,24 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\api\Fusion.Resources.Api\Fusion.Resources.Api.csproj" />
     <ProjectReference Include="..\Fusion.Resources.Test.Core\Fusion.Resources.Test.Core.csproj" />
+    <ProjectReference Include="..\Fusion.Testing.Authentication\Fusion.Testing.Authentication.csproj" />
+    <ProjectReference Include="..\Fusion.Testing.Core\Fusion.Testing.Core.csproj" />
+    <ProjectReference Include="..\Fusion.Testing.Mocks.ContextService\Fusion.Testing.Mocks.ContextService.csproj" />
+    <ProjectReference Include="..\Fusion.Testing.Mocks.OrgService\Fusion.Testing.Mocks.OrgService.csproj" />
+    <ProjectReference Include="..\Fusion.Testing.Mocks.ProfileService\Fusion.Testing.Mocks.ProfileService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/NotificationClientMock.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/NotificationClientMock.cs
@@ -1,0 +1,24 @@
+﻿using Fusion.Integration.Notification;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Tests.FusionMocks
+{
+    internal class NotificationClientMock : IFusionNotificationClient
+    {
+        public Task<IEnumerable<FusionNotification>> CreateNotificationAsync(Action<FusionNotificationBuilder> notificationBuilder)
+        {
+            var items = new List<FusionNotification>();
+            return Task.FromResult(items.AsEnumerable());
+        }
+
+        public Task<IEnumerable<FusionNotification>> CreateNotificationAsync(INotificationBuilder notificationFactory)
+        {
+            var items = new List<FusionNotification>();
+            return Task.FromResult(items.AsEnumerable());
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/RolesClientMock.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/RolesClientMock.cs
@@ -1,0 +1,59 @@
+﻿using Fusion.Integration.Profile;
+using Fusion.Integration.Roles;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Tests.FusionMocks
+{
+    internal class RolesClientMock : IFusionRolesClient
+    {
+        public Task<FusionRoleAssignment> AssignRoleAsync(Guid personAzureUniqueId, RoleAssignment role)
+        {
+            return Task.FromResult(default(FusionRoleAssignment));
+        }
+
+        public Task<FusionRoleAssignment> AssignRoleAsync(Guid personAzureUniqueId, Action<RoleAssignment> roleBuilder)
+        {
+            var builder = new RoleAssignment();
+            roleBuilder(builder);
+
+            return Task.FromResult(default(FusionRoleAssignment));
+        }
+
+        public Task<IEnumerable<FusionRoleAssignment>> DeleteRoleByIdentifierAsync(string externalIdentifier)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FusionRoleAssignment>> DeleteRolesAsync(Action<RolesApiODataQuery> query)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FusionRoleAssignment>> DeleteRolesAsync(PersonIdentifier person, Action<RolesApiODataQuery> query)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<FusionRoleAssignment> GetRoleByIdentifierAsync(string externalIdentifier)
+        {
+            return Task.FromResult(default(FusionRoleAssignment));
+        }
+
+        public Task<IEnumerable<FusionRoleAssignment>> GetRolesAsync(Action<RolesApiODataQuery> query)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<FusionRoleAssignment> UpdateRoleAsync(Guid roleId, Action<RoleUpdateBuilder> updateRole)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<FusionRoleAssignment> UpdateRoleByIdentifierAsync(string externalIdentifier, Action<RoleUpdateBuilder> updateRole)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -1,0 +1,25 @@
+﻿using Fusion.Testing;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Tests
+{
+    internal static class ApiHelpers
+    {
+
+        public static async Task DelegateExternalAdminAccessAsync(this HttpClient client, Guid projectId, Guid contractId, Guid peronUniqueId)
+        {
+            var resp = await client.TestClientPostAsync($"/projects/{projectId}/contracts/{contractId}/delegated-roles", new
+            {
+                person = new { AzureUniquePersonId = peronUniqueId },
+                classification = "External",
+                type = "CR"
+            });
+
+            resp.Should().BeSuccessfull();
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Configuration/AuthenticationSchemeOptionsExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Configuration/AuthenticationSchemeOptionsExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Authentication;
+
+namespace Fusion.Testing.Authentication.Configuration
+{
+
+    public static class AuthenticationSchemeOptionsExtensions
+    {
+        /// <summary>
+        /// Enable authentication forwards. Debug build is required for option to have any effect, 
+        /// and the environment integration test marker must be set ("INTEGRATION_TEST_RUN")
+        /// </summary>
+        /// <param name="options"></param>
+        public static void EnableIntegrationTestForward(this AuthenticationSchemeOptions options)
+        {
+             options.ForwardAuthenticate = IntegrationTestAuthDefaults.AuthenticationScheme;
+        }
+
+
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Configuration/FusionAuthenticationBuilderExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Configuration/FusionAuthenticationBuilderExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Fusion.Testing.Authentication;
+using Fusion.Testing.Authentication.Configuration;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class FusionAuthenticationBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the integration test authentication handler. 
+        /// This will only be added if the EnvSettings.IsIntegrationTesting variable is set.
+        /// </summary>
+        /// <returns></returns>
+        //public static FusionAuthenticationBuilder AddIntegrationTestingAuthentication(this FusionAuthenticationBuilder builder)
+        //{
+        //    builder.authBuilder.AddScheme<IntegrationTestAuthOptions, IntegrationTestAuthHandler>(IntegrationTestAuthDefaults.AuthenticationScheme, opts => { });
+
+        //    return builder;
+        //}
+
+        public static IServiceCollection AddIntegrationTestingAuthentication(this IServiceCollection services)
+        {
+            var builder = services.AddAuthentication();
+
+            builder.AddScheme<IntegrationTestAuthOptions, IntegrationTestAuthHandler>(IntegrationTestAuthDefaults.AuthenticationScheme, opts => { });
+
+            if (Environment.GetEnvironmentVariable("FORWARD_JWT") != null)
+                services.PostConfigureAll<JwtBearerOptions>(o => o.ForwardAuthenticate = IntegrationTestAuthDefaults.AuthenticationScheme);
+
+            if (Environment.GetEnvironmentVariable("FORWARD_COOKIE") != null)
+                services.PostConfigureAll<CookieAuthenticationOptions>(o => o.ForwardAuthenticate = IntegrationTestAuthDefaults.AuthenticationScheme);
+
+            return services;
+        }
+    }
+
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// This option will turn on forwarding of authentication for the JWT bearer layer to the integration test handler. 
+        /// 
+        /// The forward will ONLY occur when the application is built with DEBUG configuration and the integration marker is set in environment variables.
+        /// </summary>
+        public static IServiceCollection InterceptBearerAuthentication(this IServiceCollection services)
+        {
+
+            services.Configure<JwtBearerOptions>(options =>
+            {
+                options.EnableIntegrationTestForward();
+            });
+
+            return services;
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Constants/FusionClaimTypes.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Constants/FusionClaimTypes.cs
@@ -1,0 +1,39 @@
+﻿namespace Fusion.Testing.Authentication
+{
+    internal class FusionClaimTypes
+    {
+        public const string UserPrincipalName = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn";
+
+        public const string AzureUniquePersonId = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+
+        public const string ApplicationId = "appid";
+
+        public const string Mail = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+
+        public const string TransformationMarker = "http://schemas.fusion.equinor.com/identity/claims/transformationMarker";
+
+        public const string FusionPeronId = "http://schemas.fusion.equinor.com/identity/claims/fusionpersonid";
+
+        public const string LocalPersonId = "http://schemas.fusion.equinor.com/identity/claims/localpersonid";
+
+        public const string Department = "http://schemas.fusion.equinor.com/identity/claims/department";
+
+        public const string Company = "http://schemas.fusion.equinor.com/identity/claims/company";
+
+        public const string CompanyId = "http://schemas.fusion.equinor.com/identity/claims/companyid";
+
+        public const string JobTitle = "http://schemas.fusion.equinor.com/identity/claims/jobtitle";
+
+        public const string AccountType = "http://schemas.fusion.equinor.com/identity/claims/accounttype";
+
+        public const string AADApplicationName = "http://schemas.fusion.equinor.com/identity/claims/aadappname";
+
+        public const string PositionDiscipline = "http://schemas.fusion.equinor.com/identity/claims/discipline";
+
+        public const string FusionContract = "http://schemas.fusion.equinor.com/identity/claims/contract";
+
+        public const string ProjectDomain = "http://schemas.fusion.equinor.com/identity/claims/projectdomain";
+
+        public const string FusionProjectOrgChart = "http://schemas.fusion.equinor.com/identity/claims/orgprojectid";
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Constants/IntgTestEnvVariables.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Constants/IntgTestEnvVariables.cs
@@ -1,0 +1,8 @@
+﻿namespace Fusion.Testing.Authentication
+{
+    public static class IntgTestEnvVariables
+    {
+        public const string DEFAULT_APPID = "FUSION_INTGTESTING_DEFAULT_APPID";
+        public const string INTEGRATION_TEST_MARKER = "INTEGRATION_TEST_RUN";
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
+++ b/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.5.4" />
+    <PackageReference Include="Fusion.ApiClients.People" Version="2.0.0-preview-1" />
+    <PackageReference Include="Fusion.Infrastructure.Authentication" Version="1.0.0" />
+
+  </ItemGroup>
+
+</Project>

--- a/src/backend/tests/Fusion.Testing.Authentication/IntegrationTestingEnvSettings.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/IntegrationTestingEnvSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Fusion.Testing.Authentication
+{
+    public static class IntegrationTestingEnvSettings
+    {
+        public static bool IsIntegrationTest()
+        {
+            string environmentVariable = Environment.GetEnvironmentVariable(IntgTestEnvVariables.INTEGRATION_TEST_MARKER);
+            return !string.IsNullOrEmpty(environmentVariable);
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthDefaults.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthDefaults.cs
@@ -1,0 +1,7 @@
+﻿namespace Fusion.Testing.Authentication
+{
+    internal class IntegrationTestAuthDefaults
+    {
+        public const string AuthenticationScheme = "IntgTestAuth";
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthHandler.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthHandler.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace Fusion.Testing.Authentication
+{
+
+    internal class IntegrationTestAuthHandler : AuthenticationHandler<IntegrationTestAuthOptions>
+    {
+        private readonly IConfiguration config;
+        private readonly IServiceProvider services;
+
+        public IntegrationTestAuthHandler(IOptionsMonitor<IntegrationTestAuthOptions> options, 
+            IConfiguration config,
+            ILoggerFactory logger, 
+            UrlEncoder encoder, 
+            ISystemClock clock, 
+            IServiceProvider services) 
+            : base(options, logger, encoder, clock)
+        {
+            this.config = config;
+            this.services = services;
+        }
+
+        private enum AuthType { Application, Delegated }
+
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            try
+            {
+                var claims = await GatherTestUserClaimsAsync();
+
+                var testIdentity = new ClaimsIdentity(claims, IntegrationTestAuthDefaults.AuthenticationScheme);
+                var testUser = new ClaimsPrincipal(testIdentity);
+
+                var ticket = new AuthenticationTicket(testUser, new AuthenticationProperties(), IntegrationTestAuthDefaults.AuthenticationScheme);
+
+                // Don't think there is any scenario we want to return 401, as if headers is set, the user is requested.
+                return AuthenticateResult.Success(ticket);
+            }
+            catch (Exception ex)
+            {
+                return AuthenticateResult.Fail(ex);
+            }
+        }
+
+        private async Task<List<Claim>> GatherTestUserClaimsAsync()
+        {
+            var tokenDeserialized = new
+            {
+                UniqueAzurePersonId = Guid.Empty,
+                Name = string.Empty,
+                UPN = string.Empty,
+                Roles = new[] { string.Empty },
+                IsAppToken = false,
+                AppId = (Guid?)null,
+                ProjectIds = new [] { Guid.Empty }
+            };
+
+            try
+            {
+                var token = Request.Headers["Authorization"].ToString();
+                var tokenPart = token.Split(' ')[1];
+                var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(tokenPart));
+                tokenDeserialized = JsonConvert.DeserializeAnonymousType(decoded, tokenDeserialized);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Unable to extract test auth token from [Authorization] header. See inner exception for details.", ex);
+            }
+
+            string uniqueId = tokenDeserialized.UniqueAzurePersonId.ToString();
+            var authType = tokenDeserialized.IsAppToken ? AuthType.Application : AuthType.Delegated;
+
+            var claims = new List<Claim>
+            {
+                new Claim(FusionClaimTypes.AzureUniquePersonId, uniqueId)
+            };
+
+            switch (authType)
+            {
+                case AuthType.Delegated:
+                    if (tokenDeserialized.Roles != null)
+                    {
+                        foreach (var role in tokenDeserialized.Roles)
+                        {
+                            claims.Add(new Claim(ClaimTypes.Role, role));
+                        }
+                    }
+
+                    if (tokenDeserialized.ProjectIds != null)
+                    {
+                        foreach (var projectId in tokenDeserialized.ProjectIds)
+                        {
+                            claims.Add(new Claim(FusionClaimTypes.FusionProjectOrgChart, $"{projectId}"));
+                        }
+                    }
+
+                    var peopleClientFactory = services.GetService<IPeopleApiClientFactory>();
+
+                    if (peopleClientFactory != null)
+                    {
+                        var peopleClient = peopleClientFactory.CreateApplicationClient();
+
+                        var person = await peopleClient.GetPersonAsync(uniqueId);
+
+                        AddNameClaims(claims, person.Name);
+                        claims.Add(new Claim(ClaimTypes.Name, person.Mail));
+                        claims.Add(new Claim(FusionClaimTypes.UserPrincipalName, person.UPN));
+                        claims.Add(new Claim(FusionClaimTypes.Mail, person.Mail));
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(tokenDeserialized.Name))
+                            throw new ArgumentException("Missing name property in token");
+
+                        AddNameClaims(claims, tokenDeserialized.Name);
+                        claims.Add(new Claim(ClaimTypes.Name, tokenDeserialized.UPN));
+                        claims.Add(new Claim(FusionClaimTypes.UserPrincipalName, tokenDeserialized.UPN));
+                    }
+
+                    break;
+                case AuthType.Application:
+                    if (tokenDeserialized.Roles != null)
+                    {
+                        foreach (var role in tokenDeserialized.Roles)
+                        {
+                            claims.Add(new Claim(ClaimTypes.Role, role));
+                        }
+                    }
+
+                    if (tokenDeserialized.AppId.HasValue)
+                        claims.Add(new Claim(FusionClaimTypes.ApplicationId, $"{tokenDeserialized.AppId.Value}"));
+                    else
+                    {
+                        // Try look for configured 
+                        var appId = config[IntgTestEnvVariables.DEFAULT_APPID];
+
+                        if (string.IsNullOrEmpty(appId))
+                            throw new InvalidOperationException($"Application test users must include an appid claim or set the env variable {IntgTestEnvVariables.DEFAULT_APPID}");
+
+                        claims.Add(new Claim(FusionClaimTypes.ApplicationId, $"{appId}"));
+                    }
+                    break;
+            }
+
+            return claims;
+        }
+
+        private void AddNameClaims(List<Claim> claims, string fullName)
+        {
+            var tokens = fullName.Split(' ');
+            if (tokens.Length > 1)
+            {
+                claims.Add(new Claim(ClaimTypes.Surname, tokens.Last()));
+
+                var givenName = string.Join(" ", tokens.Take(tokens.Length - 1));
+                claims.Add(new Claim(ClaimTypes.GivenName, givenName));
+            }
+            else
+            {
+                claims.Add(new Claim(ClaimTypes.GivenName, fullName));
+            }
+
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthOptions.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/Schemas/IntegrationTest/IntegrationTestAuthOptions.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authentication;
+
+namespace Fusion.Testing.Authentication
+{
+    internal class IntegrationTestAuthOptions : AuthenticationSchemeOptions
+    {
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/User/AuthTokenUtilities.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/User/AuthTokenUtilities.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Text;
+
+namespace Fusion.Testing.Authentication.User
+{
+    public static class AuthTokenUtilities
+    {
+        /// <summary>
+        /// Converts <paramref name="bearerToken"/> from base64, UTF-8 encoded string and then deserializes it to <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">The type you wish to attempt to deserialize to</typeparam>
+        /// <param name="bearerToken">The token as it appears in the Authorization header</param>
+        /// <param name="anonymousType">Instance of the anonymous type you are deserializing to</param>
+        /// <returns>Deserialized object of type <typeparamref name="T"/></returns>
+        public static T UnwrapAuthToken<T>(string bearerToken, T anonymousType) where T : class
+        {
+            var tokenPart = bearerToken.Split(' ')[1];
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(tokenPart));
+            var deserialized = JsonConvert.DeserializeAnonymousType(decoded, anonymousType);
+
+            return deserialized;
+        }
+
+        /// <summary>
+        /// Wraps <typeparamref name="T"/> by serializing, encoding and then converting to base 64 string. 
+        /// "Bearer" is also added, making it ready to be added as Authorization header
+        /// </summary>
+        /// <typeparam name="T">The type of the class that is serialized</typeparam>
+        /// <param name="tokenClass">The instance of the token to be wrapped</param>
+        /// <returns>Serialized, encoded string ready for authorization header</returns>
+        public static string WrapAuthToken<T>(T tokenClass) where T : class
+        {
+            var serialized = JsonConvert.SerializeObject(tokenClass);
+            var tokenBytes = Encoding.UTF8.GetBytes(serialized);
+            var tokenString = Convert.ToBase64String(tokenBytes);
+
+            return $"Bearer {tokenString}";
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/User/HttpClientExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/User/HttpClientExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Fusion.Testing.Authentication.User
+{
+    public static class HttpClientExtensions
+    {
+
+        public static TestUserBuilder WithTestUser(this HttpClient client, Integration.Profile.ApiClient.ApiPersonProfileV3 testUser)
+        {
+            var builder = new TestUserBuilder(client);
+
+            builder.AzureUniqueId = testUser.AzureUniqueId.Value;
+            builder.Name = testUser.Name;
+            builder.Mail = testUser.Mail;
+            builder.AuthType = AuthType.Delegated;
+
+            return builder;
+        }
+
+        public static void AddTestUserToken(this HttpRequestMessage message, Integration.Profile.ApiClient.ApiPersonProfileV3 testUser, Guid? appId)
+        {
+            var testToken = new TestToken
+            {
+                UniqueAzurePersonId = testUser.AzureUniqueId.Value,
+                Name = testUser.Name,
+                UPN = testUser.Mail,                
+                IsAppToken = false,
+                AppId = appId
+            };
+
+            message.Headers.Add("Authorization", AuthTokenUtilities.WrapAuthToken(testToken));
+        }
+
+       
+
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/User/TestToken.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/User/TestToken.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Fusion.Testing.Authentication.User
+{
+    public class TestToken
+    {
+        public Guid UniqueAzurePersonId { get; set; }
+        public string Name { get; set; }
+        public string UPN { get; set; }
+        public string[] Roles { get; set; }
+        public bool IsAppToken { get; set; }
+        public Guid? AppId { get; set; }
+        public Guid[] ProjectIds { get; set; }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/User/TestUserBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/User/TestUserBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Fusion.Testing.Authentication.User
+{
+    public enum AccountType { Employee, Consultant, External, Internal }
+    public enum AuthType
+    {
+        Delegated,
+        Application
+    }
+
+    public class TestUserBuilder
+    {
+        public HttpClient Client { get; private set; }
+
+        public List<TestUserRole> Roles { get; private set; } = new List<TestUserRole>();
+        public string Name { get; set; }
+        public Guid AzureUniqueId { get; set; }
+        public AccountType? AccountType { get; set; }
+        public string Mail { get; set; }
+        public AuthType AuthType { get; set; } = AuthType.Delegated;
+        public Guid? AppId { get; set; }
+
+        public TestUserBuilder(HttpClient client)
+        {
+            Client = client;
+        }
+
+
+
+        public HttpClient AddTestAuthToken()
+        {
+            TestToken testToken = null;
+
+            switch (AuthType)
+            {
+                case AuthType.Delegated:
+                    testToken = new TestToken
+                    {
+                        UniqueAzurePersonId = AzureUniqueId,
+                        Name = Name,
+                        UPN = Mail,
+                        Roles = Roles.Select(r => r.Name).ToArray(),
+                        IsAppToken = false
+                    };
+
+                    break;
+
+                case AuthType.Application:  // Add scopes when relevant...
+                    testToken = new TestToken
+                    {
+                        UniqueAzurePersonId = AzureUniqueId,
+                        Roles = Roles.Select(r => r.Name).ToArray(),
+                        IsAppToken = true,
+                        AppId = AppId
+                    };
+
+                    break;
+            }
+            if (Client.DefaultRequestHeaders.Authorization != null)
+                Client.DefaultRequestHeaders.Remove("Authorization");
+
+            Client.DefaultRequestHeaders.Add("Authorization", AuthTokenUtilities.WrapAuthToken(testToken));
+
+            return Client;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Authentication/User/TestUserRole.cs
+++ b/src/backend/tests/Fusion.Testing.Authentication/User/TestUserRole.cs
@@ -1,0 +1,10 @@
+﻿namespace Fusion.Testing.Authentication.User
+{
+    public sealed class TestUserRole
+    {
+        public string Name { get; set; }
+
+        public static TestUserRole DevOps = new TestUserRole { Name = "ProView.Admin.DevOps" };
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Core/Assertion/TestClientHttpResponseAssertions.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Assertion/TestClientHttpResponseAssertions.cs
@@ -1,0 +1,143 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+
+namespace Fusion.Testing
+{
+    public class TestClientHttpResponseAssertions<T> : ReferenceTypeAssertions<TestClientHttpResponse<T>, TestClientHttpResponseAssertions<T>>
+    {
+        public TestClientHttpResponseAssertions(TestClientHttpResponse<T> instance)
+        {
+            Subject = instance;
+        }
+
+        protected override string Identifier => "directory";
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeSuccessfull(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.IsSuccessStatusCode)
+                .FailWith($"Expected successfull http response but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.Method}: {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> HaveAllowHeaders(params HttpMethod[] methods)
+        {
+
+            var containsHeaders = false;
+
+            IEnumerable<string> allowedMethods = new List<string>();
+
+            if (Subject.Response.Content.Headers.TryGetValues("Allow", out allowedMethods))
+            {
+                containsHeaders = methods.All(m => allowedMethods.Any(h => StringComparer.OrdinalIgnoreCase.Equals(m.ToString(), h)));
+            }
+
+            Execute.Assertion
+                .BecauseOf("")
+                .ForCondition(containsHeaders)
+                .FailWith($"Expected Allow header to contain {string.Join(", ", methods.Select(m => m.ToString()))} but found {string.Join(", ", allowedMethods)}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeUnauthorized(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.Unauthorized || Subject.Response.StatusCode == HttpStatusCode.Forbidden)
+                .FailWith($"Expected Unauthorized, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeBadRequest(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.BadRequest)
+                .FailWith($"Expected BadRequest, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeConflict(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.Conflict)
+                .FailWith($"Expected Conflict, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeNotFound(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.NotFound)
+                .FailWith($"Expected NotFound, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeNotModified(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.NotModified)
+                .FailWith($"Expected NotModified, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeCreated(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.Created)
+                .FailWith($"Expected Created, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeNoContent(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.NoContent)
+                .FailWith($"Expected NoContent, but found {Subject.Response.StatusCode}. {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeFailedDependency(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition((int)Subject.Response.StatusCode == 424)
+                .FailWith($"Expected Failed Dependency (424), but found {Subject.Response.StatusCode} ({(int)Subject.Response.StatusCode}). {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+
+        public AndConstraint<TestClientHttpResponseAssertions<T>> BeAccepted(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.Response.StatusCode == HttpStatusCode.Accepted)
+                .FailWith($"Expected Accepted (202), but found {Subject.Response.StatusCode} ({(int)Subject.Response.StatusCode}). {Subject.Response.RequestMessage.RequestUri}");
+
+            return new AndConstraint<TestClientHttpResponseAssertions<T>>(this);
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Core/Assertion/TestClientHttpResponseExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Assertion/TestClientHttpResponseExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Fusion.Testing
+{
+    public static class TestClientHttpResponseExtensions
+    {
+        public static TestClientHttpResponseAssertions<T> Should<T>(this TestClientHttpResponse<T> instance)
+        {
+            return new TestClientHttpResponseAssertions<T>(instance);
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Core/Class1.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Class1.cs
@@ -1,0 +1,7 @@
+﻿namespace Fusion.Testing
+{
+    public class Class1
+    {
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Core/Diagnostics/TestLogger.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Diagnostics/TestLogger.cs
@@ -1,0 +1,7 @@
+﻿namespace Fusion.Testing
+{
+    public class TestLogger
+    {
+        public static void TryLog(string message) => TestLoggingScope.Current?.WriteLine(message);
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Core/Diagnostics/TestLoggingScope.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Diagnostics/TestLoggingScope.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace Fusion.Testing
+{
+    public class TestLoggingScope : IDisposable
+    {
+        private static AsyncLocal<ITestOutputHelper> Logger = new AsyncLocal<ITestOutputHelper>();
+
+        public static ITestOutputHelper Current => Logger.Value;
+
+        public TestLoggingScope(ITestOutputHelper logger)
+        {
+            Logger.Value = logger;
+        }
+
+        public void Dispose()
+        {
+            Logger.Value = null;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
+++ b/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />-->
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.5.4" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fusion.Testing.Authentication\Fusion.Testing.Authentication.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
@@ -539,7 +539,7 @@ namespace Fusion.Testing
             var resp = await client.SendAsync(message);
             var respObj = await TestClientHttpResponse<dynamic>.CreateResponseAsync<dynamic>(resp);
 
-            TestLogger.TryLog($"PATCH {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            TestLogger.TryLog($"OPTIONS {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
             if (!resp.IsSuccessStatusCode)
             {
                 var respContent = await resp.Content.ReadAsStringAsync();

--- a/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
@@ -109,6 +109,8 @@ namespace Fusion.Testing
             return this;
         }
 
+        public ApiPersonProfileV3 Profile => CurrentUser.Value;
+
         public void Dispose()
         {
             CurrentUser.Value = null;

--- a/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
+++ b/src/backend/tests/Fusion.Testing.Core/Http/TestClientHttpResponse.cs
@@ -1,0 +1,552 @@
+﻿using Fusion.Integration.Profile.ApiClient;
+using Fusion.Testing.Authentication.User;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Testing
+{
+    public class TestClientHttpResponse<TResp>
+    {
+        public string Content { get; set; }
+        public HttpResponseMessage Response { get; set; }
+        public string HttpReason { get; set; }
+
+        public TResp Value { get; set; }
+
+        public TestClientHttpResponse(HttpResponseMessage response)
+        {
+            Response = response;
+            HttpReason = response.ReasonPhrase;
+        }
+
+        public static async Task<TestClientHttpResponse<T>> CreateResponseAsync<T>(HttpResponseMessage response, bool skipDeserialization = false)
+        {
+            var respObject = new TestClientHttpResponse<T>(response)
+            {
+                Content = await response.Content.ReadAsStringAsync()
+            };
+
+            try
+            {
+                if (skipDeserialization && typeof(T) == typeof(string))
+                    respObject.Value = (T)(object)respObject.Content;
+                else
+                    respObject.Value = JsonConvert.DeserializeObject<T>(respObject.Content);
+            }
+            catch (Exception ex)
+            {
+                TestLogger.TryLog($"Unable to deserialize to type '{typeof(T).Name}'");
+                TestLogger.TryLog(ex.ToString());
+            }
+
+            return respObject;
+        }
+
+        public static async Task<TestClientHttpResponse<T>> CreateResponseAsync<T>(HttpResponseMessage response, T anonymousType)
+        {
+            var respObject = new TestClientHttpResponse<T>(response)
+            {
+                Content = await response.Content.ReadAsStringAsync()
+            };
+
+            try
+            {
+                respObject.Value = JsonConvert.DeserializeAnonymousType<T>(respObject.Content, anonymousType);
+            }
+            catch (Exception ex)
+            {
+                TestLogger.TryLog($"Unable to deserialize to type '{typeof(T).Name}'");
+                TestLogger.TryLog(ex.ToString());
+            }
+
+            return respObject;
+        }
+    }
+
+    public class TestClientScope : IDisposable
+    {
+        private static AsyncLocal<ApiPersonProfileV3> CurrentUser = new AsyncLocal<ApiPersonProfileV3>();
+        private static AsyncLocal<Guid?> CurrentAppId = new AsyncLocal<Guid?>();
+        private static AsyncLocal<List<KeyValuePair<string, string>>> CurrentHeaders = new AsyncLocal<List<KeyValuePair<string, string>>>();
+
+        public TestClientScope(ApiPersonProfileV3 profile)
+        {
+            CurrentUser.Value = profile;
+        }
+        public TestClientScope(string name, string value)
+        {
+            AddHeader(name, value);
+        }
+
+        public TestClientScope SetUser(ApiPersonProfileV3 profile)
+        {
+            CurrentUser.Value = profile;
+            return this;
+        }
+        public TestClientScope SetSigninAppId(Guid? appId)
+        {
+            CurrentAppId.Value = appId;
+            return this;
+        }
+
+        public TestClientScope AddHeader(string name, string value)
+        {
+
+            if (CurrentHeaders.Value == null)
+            {
+                CurrentHeaders.Value = new List<KeyValuePair<string, string>>();
+            }
+            CurrentHeaders.Value.Add(new KeyValuePair<string, string>(name, value));
+
+            return this;
+        }
+
+        public void Dispose()
+        {
+            CurrentUser.Value = null;
+            CurrentHeaders.Value = null;
+            CurrentAppId.Value = null;
+        }
+
+        public static void AddHeaders(HttpRequestMessage message)
+        {
+            if (CurrentHeaders.Value != null)
+            {
+                foreach (var header in CurrentHeaders.Value)
+                    message.Headers.Add(header.Key, header.Value);
+            }
+
+            if (CurrentUser.Value != null)
+            {
+                message.AddTestUserToken(CurrentUser.Value, CurrentAppId.Value);
+            }
+        }
+    }
+
+    public static class TestHttpClientExtensions
+    {
+        #region GET
+        public static async Task<TestClientHttpResponse<TResp>> TestClientGetAsync<TResp>(this HttpClient client, string requestUri)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<TResp>.CreateResponseAsync<TResp>(resp);
+
+            TestLogger.TryLog($"GET {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+                TestLogger.TryLog(respObj.Content);
+
+            return respObj;
+        }
+        public static async Task<TestClientHttpResponse<TResp>> TestClientGetAsync<TResp>(this HttpClient client, string requestUri, TResp returnType)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<TResp>.CreateResponseAsync<TResp>(resp, returnType);
+
+            TestLogger.TryLog($"GET {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+                TestLogger.TryLog(respObj.Content);
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<string>> TestClientGetStringAsync(this HttpClient client, string requestUri)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<string>.CreateResponseAsync<string>(resp, skipDeserialization: true);
+
+            TestLogger.TryLog($"GET {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+                TestLogger.TryLog(respObj.Content);
+
+            return respObj;
+        }
+        #endregion
+
+        #region POST
+        public static async Task<TestClientHttpResponse<T>> TestClientPostAsync<T>(this HttpClient client, string requestUri, object value)
+        {
+            string content = JsonConvert.SerializeObject(value, new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = stringContent;
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<T>.CreateResponseAsync<T>(resp);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<dynamic>> TestClientPostAsync(this HttpClient client, string requestUri, object value)
+        {
+            string content = JsonConvert.SerializeObject(value, new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = stringContent;
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<dynamic>.CreateResponseAsync<dynamic>(resp);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<T>> TestClientPostAsync<T>(this HttpClient client, string requestUri, object value, T responseType)
+        {
+            string content = JsonConvert.SerializeObject(value, new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = stringContent;
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<T>.CreateResponseAsync<T>(resp, responseType);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<T>> TestClientPostNoPayloadAsync<T>(this HttpClient client, string requestUri)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<T>.CreateResponseAsync<T>(resp);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<T>> TestClientPostNoPayloadAsync<T>(this HttpClient client, string requestUri, T returnType)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<T>.CreateResponseAsync<T>(resp, returnType);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<TResp>> TestClientPostMultipartAsync<TResp>(this HttpClient client, string requestUri, MultipartFormDataContent form, TResp respType)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = form;
+
+            TestClientScope.AddHeaders(request);
+
+            var resp = await client.SendAsync(request);
+            var respObj = await TestClientHttpResponse<TResp>.CreateResponseAsync<TResp>(resp, respType);
+
+            TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                TestLogger.TryLog(respObj.Content);
+                TestLogger.TryLog($"Request payload: -- form data --");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientPostFileAsync<TResponse>(this HttpClient client, string requestUri, Stream documentStream, string contentType, TResponse respType)
+        {
+
+            using (var streamContent = new StreamContent(documentStream))
+            {
+                streamContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                streamContent.Headers.ContentLength = documentStream.Length;
+
+                var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+                request.Content = streamContent;
+                TestClientScope.AddHeaders(request);
+
+                var resp = await client.SendAsync(request);
+                var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp, respType);
+
+                TestLogger.TryLog($"POST {resp.RequestMessage.RequestUri} [CT: {contentType}] -> {resp.StatusCode}");
+                if (!resp.IsSuccessStatusCode)
+                {
+                    var respContent = await resp.Content.ReadAsStringAsync();
+                    TestLogger.TryLog(respContent);
+                }
+
+                return respObj;
+            }
+        }
+
+        #endregion
+
+        #region PATCH
+
+        public static async Task<TestClientHttpResponse<TResponse>> PatchAsJsonAsync<TResponse>(this HttpClient client, string requestUri, object value)
+        {
+            string content = JsonConvert.SerializeObject(value);
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Patch, requestUri)
+            {
+                Content = stringContent
+            };
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp);
+
+            TestLogger.TryLog($"PATCH {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientPatchAsync<TResponse>(this HttpClient client, string requestUri, object value, TResponse response)
+        {
+            string content = JsonConvert.SerializeObject(value);
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Patch, requestUri)
+            {
+                Content = stringContent
+            };
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp, response);
+
+            TestLogger.TryLog($"PATCH {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        #endregion
+
+        #region PUT
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientPutAsync<TResponse>(this HttpClient client, string requestUri, object value)
+        {
+            string content = JsonConvert.SerializeObject(value);
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = stringContent
+            };
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp);
+
+            TestLogger.TryLog($"PUT {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientPutAsync<TResponse>(this HttpClient client, string requestUri, object value, TResponse response)
+        {
+            string content = JsonConvert.SerializeObject(value);
+            StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
+
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = stringContent
+            };
+            
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp, response);
+
+            TestLogger.TryLog($"PUT {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+                TestLogger.TryLog($"Request payload: {content}");
+            }
+
+            return respObj;
+        }
+
+        #endregion
+
+        #region DELETE
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientDeleteAsync<TResponse>(this HttpClient client, string requestUri)
+        {
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp);
+
+            TestLogger.TryLog($"DELETE {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<TResponse>> TestClientDeleteAsync<TResponse>(this HttpClient client, string requestUri, TResponse response)
+        {
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<TResponse>.CreateResponseAsync<TResponse>(resp, response);
+
+            TestLogger.TryLog($"DELETE {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        public static async Task<TestClientHttpResponse<dynamic>> TestClientDeleteAsync(this HttpClient client, string requestUri)
+        {
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<dynamic>.CreateResponseAsync<dynamic>(resp);
+
+            TestLogger.TryLog($"DELETE {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        #endregion
+
+        #region OPTIONS
+
+        public static async Task<TestClientHttpResponse<dynamic>> TestClientOptionsAsync(this HttpClient client, string requestUri)
+        {
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Options, requestUri);
+
+            TestClientScope.AddHeaders(message);
+
+            var resp = await client.SendAsync(message);
+            var respObj = await TestClientHttpResponse<dynamic>.CreateResponseAsync<dynamic>(resp);
+
+            TestLogger.TryLog($"PATCH {resp.RequestMessage.RequestUri} -> {resp.StatusCode}");
+            if (!resp.IsSuccessStatusCode)
+            {
+                var respContent = await resp.Content.ReadAsStringAsync();
+                TestLogger.TryLog(respContent);
+            }
+
+            return respObj;
+        }
+
+        #endregion
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Core/IServiceCollectionExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Core/IServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+﻿
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Linq;
+
+namespace Fusion.Testing
+{
+    public static class IServiceCollectionExtensions
+    {
+        public static IServiceCollection TryRemoveImplementationService<TService>(this IServiceCollection services)
+        {
+            var descriptor = services.FirstOrDefault(sd => sd.ImplementationType == typeof(TService));
+            if (descriptor != null)
+                services.Remove(descriptor);
+
+            return services;
+        }
+
+        public static IServiceCollection TryRemoveImplementationService(this IServiceCollection services, string typeName)
+        {
+            var descriptor = services.FirstOrDefault(sd => sd.ImplementationType?.Name == typeName);
+            if (descriptor != null)
+                services.Remove(descriptor);
+
+            return services;
+        }
+
+        public static IServiceCollection TryRemoveTransientEventHandlers(this IServiceCollection services)
+        {
+
+            var hostedServices = services
+                .Where(sd => sd.ServiceType == typeof(IHostedService) && sd.ImplementationFactory != null)
+                .Where(sd => sd.ImplementationFactory.Method.Name.Contains("AddFusionEventHandler"))
+                .ToList();
+
+            hostedServices.ForEach(s => services.Remove(s));
+
+            services.TryRemoveImplementationService("EventHandlerFactory");
+
+            return services;
+        }
+
+        public static IServiceCollection AddSingletonIfFound<T, TType>(this IServiceCollection services)
+            where T : class
+            where TType : class, T
+        {
+            var descriptor = services.FirstOrDefault(sd => sd.ServiceType == typeof(T));
+            if (descriptor == null)
+                return services;
+
+            services.AddSingleton<T, TType>();
+            return services;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Core/TestDbConnectionStrings.cs
+++ b/src/backend/tests/Fusion.Testing.Core/TestDbConnectionStrings.cs
@@ -1,0 +1,9 @@
+﻿namespace Fusion.Testing
+{
+    public class TestDbConnectionStrings
+    {
+        public static string LocalDb(string db, string mdfPath) => $"Server=(localdb)\\mssqllocaldb;Database={db};Trusted_Connection=True;MultipleActiveResultSets=true;AttachDBFileName={mdfPath}";
+        public static string LocalDb(string db) => $"Server=(localdb)\\mssqllocaldb;Database={db};Trusted_Connection=True;MultipleActiveResultSets=true";
+
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/ContextResolverMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/ContextResolverMock.cs
@@ -1,0 +1,123 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.AspNetCore.OData;
+using Fusion.Integration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Fusion.Testing.Mocks.ContextService
+{
+    public class ContextResolverMock : IFusionContextResolver
+    {
+        public List<FusionContext> AvailableContexts { get; } = new List<FusionContext>();
+
+
+        public Task<FusionContext> GetContextAsync(Guid contextId)
+        {
+            var context = AvailableContexts.FirstOrDefault(c => c.Id == contextId);
+            
+            if (context is null)
+                throw new ContextNotFoundError(contextId);
+
+            return Task.FromResult(context);
+        }
+
+        public Task<IEnumerable<FusionContext>> GetContextRelationsAsync(Guid contextId, FusionContextType contextType = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FusionRelatedContext>> QueryContextRelationssAsync(FusionContext context, Action<ContextApiQuery> query = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FusionContext>> QueryContextsAsync(Action<ContextApiQuery> query)
+        {
+            var apiQuery = new ContextApiQuery();
+            query(apiQuery);
+
+            var queryString = apiQuery.QueryString;
+            var match = Regex.Match(queryString ?? "", @"\$filter=([^&]*)");
+
+            var filter = Fusion.AspNetCore.OData.ODataParser.Parse(match.Groups[1].Value);
+            var odataQuery = new ODataQueryParams() { Filter = filter };
+
+            var contextQuery = AvailableContexts.AsQueryable();
+
+            contextQuery = contextQuery.ApplyODataFilters(odataQuery, m =>
+            {
+                m.MapField("id", c => c.Id);
+                m.MapField("title", c => c.Title);
+                m.MapField("externalid", c => c.ExternalId);
+                m.MapField("type", c => c.Type);
+
+                if (filter.GetFilters().Any(f => f.Field.StartsWith("value.")))
+                    throw new NotImplementedException();
+
+                // Map all value.* to json support
+                //message.Query.Filter.GetFilters().Where(f => f.Field.StartsWith("value."))
+                //    .ToList()
+                //    .ForEach(f =>
+                //    {
+                //        m.MapJsonField(f, nameof(ContextBase.Value), "value.");
+                //    });
+            });
+
+            var contexts = contextQuery.ToList();
+            return Task.FromResult(contexts.AsEnumerable());
+        }
+
+        public Task<FusionContext> ResolveContextAsync(Guid contextId)
+        {
+            var context = AvailableContexts.FirstOrDefault(c => c.Id == contextId);
+            return Task.FromResult(context);
+        }
+
+        public Task<FusionContext> ResolveContextAsync(ContextIdentifier identifier, FusionContextType type = null)
+        {
+            var ctx = default(FusionContext);
+
+            switch (identifier.Type)
+            {
+                case ContextIdentifier.IdentifierType.ContextId:
+                    ctx = AvailableContexts.FirstOrDefault(c => c.Id == identifier.UniqueId);
+                    break;
+
+                case ContextIdentifier.IdentifierType.ExternalId:
+                    ctx = AvailableContexts.Where(c => type == null || string.Equals(c.Type.Name, type.Name, StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault(c => string.Equals(c.ExternalId, identifier.Identifier, StringComparison.OrdinalIgnoreCase));
+                    break;
+
+                case ContextIdentifier.IdentifierType.Ambiguous:
+                    ctx = AvailableContexts.FirstOrDefault(c => c.Id == identifier.UniqueId);
+
+                    if (ctx is null)
+                    {
+                        ctx = AvailableContexts.Where(c => type == null || string.Equals(c.Type.Name, type.Name, StringComparison.OrdinalIgnoreCase))
+                            .FirstOrDefault(c => string.Equals(c.ExternalId, identifier.Identifier, StringComparison.OrdinalIgnoreCase));
+                    }
+                    break;
+            }
+
+            return Task.FromResult(ctx);
+            
+        }
+
+        public ContextResolverMock AddContext(ApiProjectV2 orgChart)
+        {
+            AvailableContexts.Add(new FusionContext()
+            {
+                ExternalId = $"{orgChart.ProjectId}",
+                Id = Guid.NewGuid(),
+                Title = orgChart.Name,
+                Source = "OrgChart",
+                Type = FusionContextType.OrgChart,
+                Value = new { }
+            });
+            return this;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fusion.AspNetCore" Version="3.1.7" />
+    <PackageReference Include="Fusion.Integration.Context" Version="3.5.0" />
+    <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="3.5.0" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="3.1.2" />
+
+  </ItemGroup>
+
+</Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Fusion.Integration.Profile.ApiClient;
+using System.Linq;
+using Fusion.ApiClients.Org;
+
+namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
+{
+
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public class PositionsController : ControllerBase
+    {
+
+        [ApiVersion("2.0")]
+        [HttpGet("/positions/{positionId}")]
+        public ActionResult<ApiPositionV2> LookupPosition(Guid positionId)
+        {
+            var position = OrgServiceMock.positions.Union(OrgServiceMock.contractPositions)
+                .FirstOrDefault(p => p.Id == positionId);
+
+            if (position is null)
+                return FusionApiError.NotFound(positionId, "Could not locate position");
+
+            return Ok(position);
+        }
+
+
+        [MapToApiVersion("2.0")]
+        [HttpGet("/persons/{personIdentifier}/positions")]
+        public ActionResult<List<ApiPositionV2>> GetPersonPositions(string personIdentifier)
+        {
+            if (Guid.TryParse(personIdentifier, out Guid azureUniqueId))
+            {
+                return OrgServiceMock.positions.Where(p => p.Instances != null && p.Instances.Any(i => i.AssignedPerson?.AzureUniqueId == azureUniqueId)).ToList();
+            }
+            else
+            {
+                return OrgServiceMock.positions.Where(p => p.Instances != null && p.Instances.Any(i => i.AssignedPerson?.Mail.ToLower() == personIdentifier.ToLower())).ToList();
+            }
+        }
+
+        [MapToApiVersion("2.0")]
+        [HttpGet("/projects/{projectId}/positions/{positionId}")]
+        public ActionResult<ApiPositionV2> GetPosition(string projectId, Guid positionId)
+        {
+            var position = OrgServiceMock.positions.FirstOrDefault(p => p.Id == positionId);
+
+            if (position != null)
+                return position;
+
+            return NotFound();
+        }
+
+        [MapToApiVersion("2.0")]
+        [HttpGet("/projects/{projectId}/contracts/{contractId}/positions/{positionId}")]
+        public ActionResult<ApiPositionV2> GetPosition([FromRoute] ProjectIdentifier projectIdentifier, Guid contractId, Guid positionId)
+        {
+            var position = OrgServiceMock.contractPositions.FirstOrDefault(p => p.Id == positionId);
+
+            if (position != null)
+                return position;
+
+            return NotFound();
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -67,5 +67,19 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
 
             return NotFound();
         }
+
+        [MapToApiVersion("2.0")]
+        [HttpDelete("/projects/{projectId}/contracts/{contractId}/positions/{positionId}")]
+        public ActionResult<ApiPositionV2> DeleteContractPosition([FromRoute] ProjectIdentifier projectIdentifier, Guid contractId, Guid positionId)
+        {
+            var position = OrgServiceMock.contractPositions.FirstOrDefault(p => p.Id == positionId);
+
+            if (position == null)
+                return NotFound();
+
+            OrgServiceMock.contractPositions.Remove(position);
+
+            return NoContent();
+        }
     }
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/ProjectIdentifier.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/ProjectIdentifier.cs
@@ -1,0 +1,87 @@
+﻿using Fusion.ApiClients.Org;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fusion.Testing.Mocks.OrgService.Api
+{
+    [ModelBinder(typeof(ProjectResolver))]
+    public struct ProjectIdentifier
+    {
+        public ProjectIdentifier(Guid projectId, bool exists)
+        {
+            ProjectId = projectId;
+            DomainId = null;
+            IsUniqueId = true;
+            Exists = exists;
+        }
+
+        public ProjectIdentifier(string domainId, bool exists)
+        {
+            ProjectId = null;
+            DomainId = domainId;
+            IsUniqueId = false;
+            Exists = exists;
+        }
+
+        public Guid? ProjectId { get; }
+        public string DomainId { get; }
+
+        public bool IsUniqueId { get; }
+        public bool Exists { get; }
+
+        
+    }
+
+    public class ProjectResolver : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.FieldName);
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                return Task.CompletedTask;
+            }
+
+            //bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+            var value = valueProviderResult.FirstValue;
+
+            // Check if the argument value is null or empty
+            if (string.IsNullOrEmpty(value))
+            {
+                return Task.CompletedTask;
+            }
+
+
+            // Resolve the project 
+
+            var isUniqueId = Guid.TryParse(value, out Guid uniqueId);
+
+            if (isUniqueId)
+            {
+                bindingContext.Result = ModelBindingResult.Success(new ProjectIdentifier(uniqueId, OrgServiceMock.projects.Any(p => p.ProjectId == uniqueId)));
+            }
+            else
+            {
+                var exists = OrgServiceMock.projects.Any(p => string.Equals(p.DomainId, value, StringComparison.OrdinalIgnoreCase));
+                bindingContext.Result = ModelBindingResult.Success(new ProjectIdentifier(value, exists));
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public static class ProjectIdentifierExtensions
+    {
+        public static ApiProjectV2 GetProjectOrDefault(this ProjectIdentifier projectIdentifier)
+        {
+            return projectIdentifier.IsUniqueId switch
+            {
+                true => OrgServiceMock.projects.FirstOrDefault(p => p.ProjectId == projectIdentifier.ProjectId),
+                false => OrgServiceMock.projects.FirstOrDefault(p => string.Equals(p.DomainId, projectIdentifier.DomainId, StringComparison.OrdinalIgnoreCase))
+            };
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/ProjectsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/ProjectsController.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fusion.ApiClients.Org;
+using Fusion.AspNetCore.Api;
+
+namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
+{
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    public class ProjectsController : ControllerBase
+    {
+        [HttpGet("/projects/{projectIdentifier}")]
+        public ActionResult<ApiProjectV2> GetProject([FromRoute] ProjectIdentifier projectIdentifier)
+        {
+            var project = projectIdentifier.GetProjectOrDefault();
+
+            if (project != null)
+                return project;
+
+            return NotFound();
+        }
+
+        [HttpGet("/projects/{projectIdentifier}/contracts")]
+        public ActionResult<List<ApiProjectContractV2>> GetContracts([FromRoute] ProjectIdentifier projectIdentifier)
+        {
+            var project = projectIdentifier.GetProjectOrDefault();
+
+            if (project is null)
+                return NotFound(new { error = new { message = "Could not locate project" } });
+
+            if (!OrgServiceMock.contracts.TryGetValue(project.ProjectId, out List<ApiProjectContractV2> contracts))
+                contracts = new List<ApiProjectContractV2>();
+
+            return contracts;
+        }
+
+        [HttpGet("/projects/{projectIdentifier}/contracts/{contractId}")]
+        public ActionResult<ApiProjectContractV2> GetContract([FromRoute] ProjectIdentifier projectIdentifier, Guid contractId)
+        {
+            var project = projectIdentifier.GetProjectOrDefault();
+
+            if (project is null)
+                return NotFound(new { error = new { message = "Could not locate project" } });
+
+            if (!OrgServiceMock.contracts.TryGetValue(project.ProjectId, out List<ApiProjectContractV2> contracts))
+                contracts = new List<ApiProjectContractV2>();
+
+            var contract = contracts.FirstOrDefault(c => c.Id == contractId);
+            
+            if (contract is null)
+                return NotFound(new { error = new { message = "Could not locate contract" } });
+
+            return contract;
+        }
+
+
+
+        [HttpPost("/projects/{projectIdentifier}/contracts")]
+        public ActionResult<ApiProjectContractV2> CreateContract([FromRoute] ProjectIdentifier projectIdentifier, NewContractRequest request)
+        {
+            var project = projectIdentifier.GetProjectOrDefault();
+
+            if (project is null)
+                return NotFound(new { error = new { message = "Could not locate project" } });
+
+            var company = request.CompanyId == null ? null : OrgServiceMock.companies.FirstOrDefault(c => c.Id == request.CompanyId);
+            var contract = new ApiProjectContractV2()
+            {
+                Id = Guid.NewGuid(),
+                Name = request.Name,
+                ContractNumber = request.ContractNumber,
+                Company = company,
+                Description = request.Description,
+                StartDate = request.StartDate,
+                EndDate = request.EndDate
+            };
+
+            if (!OrgServiceMock.contracts.TryGetValue(project.ProjectId, out List<ApiProjectContractV2> contracts))
+            {
+                OrgServiceMock.contracts[project.ProjectId] = new List<ApiProjectContractV2>() { contract };
+            } 
+            else
+            {
+                contracts.Add(contract);
+            }
+
+            return contract;
+        }
+
+        [HttpPatch("/projects/{projectIdentifier}/contracts/{contractId}")]
+        public ActionResult<ApiProjectContractV2> PatchContract([FromRoute] ProjectIdentifier projectIdentifier, Guid contractId, [FromBody]PatchContractRequest request)
+        {
+            var project = projectIdentifier.GetProjectOrDefault();
+
+            if (project is null)
+                return NotFound(new { error = new { message = "Could not locate project" } });
+
+
+            if (!OrgServiceMock.contracts.TryGetValue(project.ProjectId, out List<ApiProjectContractV2> projectContracts))
+                projectContracts = new List<ApiProjectContractV2>();
+
+            var contract = projectContracts.FirstOrDefault(c => c.Id == contractId);
+
+            if (request.CompanyId.HasValue)
+            {
+                var company = request.CompanyId.Value == null ? null : OrgServiceMock.companies.FirstOrDefault(c => c.Id == request.CompanyId.Value);
+                contract.Company = company;
+            }
+
+            if (request.Name.HasValue)
+                contract.Name = request.Name.Value;
+
+
+            if (request.ContractNumber.HasValue)
+                contract.ContractNumber = request.ContractNumber.Value;
+
+            if (request.Description.HasValue)
+                contract.Description = request.Description.Value;
+
+            if (request.StartDate.HasValue)
+                contract.StartDate = request.StartDate.Value;
+
+            if (request.EndDate.HasValue)
+                contract.EndDate = request.EndDate.Value;
+
+            if (request.CompanyRepId.HasValue)
+                contract.CompanyRep = FindContractPosition(request.CompanyRepId.Value);
+
+            if (request.ContractRepId.HasValue)
+                contract.ContractRep = FindContractPosition(request.ContractRepId.Value);
+
+            if (request.ExternalCompanyRepId.HasValue)
+                contract.ExternalCompanyRep = FindContractPosition(request.ExternalCompanyRepId.Value);
+
+            if (request.ExternalContractRepId.HasValue)
+                contract.ExternalContractRep = FindContractPosition(request.ExternalContractRepId.Value);
+
+            return contract;
+        }
+
+        private static ApiPositionV2 FindContractPosition(Guid? positionId) => OrgServiceMock.contractPositions.FirstOrDefault(p => p.Id == positionId);
+
+        public class NewContractRequest
+        {
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string ContractNumber { get; set; }
+
+            public DateTime? StartDate { get; set; }
+            public DateTime? EndDate { get; set; }
+
+            public Guid? CompanyRepPositionId { get; set; }
+            public Guid? ContractRepPositionId { get; set; }
+            public Guid? CompanyId { get; set; }
+        }
+
+        public class PatchContractRequest : PatchRequest
+        {
+            public PatchProperty<string> Name { get; set; }
+            public PatchProperty<string> ContractNumber { get; set; }
+            public PatchProperty<string> Description { get; set; }
+
+            public PatchProperty<DateTime?> StartDate { get; set; }
+            public PatchProperty<DateTime?> EndDate { get; set; }
+
+            public PatchProperty<Guid?> CompanyId { get; set; }
+            public PatchProperty<Guid?> CompanyRepId { get; set; }
+            public PatchProperty<Guid?> ContractRepId { get; set; }
+
+            public PatchProperty<Guid?> ExternalCompanyRepId { get; set; }
+            public PatchProperty<Guid?> ExternalContractRepId { get; set; }
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Program.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Fusion.Testing.Mocks.OrgService.Api
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Startup.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Startup.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fusion.Testing.Mocks.OrgService.Api
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers()
+                .AddNewtonsoftJson();
+
+            services.AddApiVersioning(s =>
+            {
+                s.ReportApiVersions = true;
+                s.AssumeDefaultVersionWhenUnspecified = true;
+                s.DefaultApiVersion = new ApiVersion(2, 0);
+                s.ApiVersionReader = ApiVersionReader.Combine(new HeaderApiVersionReader(new[] { "api-version" }), new QueryStringApiVersionReader()); // The default is api-version
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Data/BasePositions.csv
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Data/BasePositions.csv
@@ -1,0 +1,390 @@
+ID;Position Name;Discipline;Department;Inactive
+6972e5ec-51c5-4d32-aadf-406bf7713f16;Asset Owner Representative;Asset;Asset;FALSE
+a9f3dea2-5fca-450c-ba10-a506e5ba60cc;Authority Handling;Asset;Asset;FALSE
+00b7add9-ce4f-41c2-922a-4f3723946eb3;Crane/Store;Operation;DPN JOS;FALSE
+aaf1cb08-0c17-404c-908c-867dbc54044f;Support Operations;;DPN JOS;FALSE
+7217a939-0cd2-4b2a-b5cb-fe57c408155b;Operations resources DG1-DG2;Operation;DPN JOS CCO;FALSE
+d68a69d1-5a3d-4712-9183-37ca5e62f159;Operations resources DG2-DG3;Operation;DPN JOS CCO;FALSE
+eed136bc-a1cf-4958-bf15-1fe44140c6fb;Operations resources DG3-DG4;Operation;DPN JOS CCO;FALSE
+c9ebed23-60c2-48a2-b5e8-587116227caf;POB coordinator;Operation;DPN JOS CCO;TRUE
+d4a738fa-1fd9-41df-8e03-b6544e35b86d;Commercial manager;Asset;DPN OS AD;TRUE
+e6677214-e0c8-4390-b4be-58d59508ef83;LCI Engineer;LCI;DPN OTE OPA;FALSE
+54b59d16-3637-41de-b0db-5bdac0d8c4e9;LCI Lead;LCI;DPN OTE OPA;FALSE
+3cc8471c-f87a-49b7-8687-22210293c666;Operations Manager;Operation;DPN OTE OPA;FALSE
+2fb50d36-56ba-4f15-a285-b9de8a33890f;Petec leader;Petech;DPN OTE PETECH;FALSE
+4fb50506-b6ef-43f8-9a18-472346c09a7d;Petech resources DG1-DG2;Petech;DPN OTE PETECH;FALSE
+4c4dca98-a7ed-4189-a66c-e5e29fd63ee7;Petech Resources DG2-DG3;Petech;DPN OTE PETECH;FALSE
+891f164e-2439-45a0-af66-cd24bcd68505;Petech Resources DG3-DG4;Petech;DPN OTE PETECH;FALSE
+4fa55f5d-b4ba-44ab-89d0-e9e4e05991f7;Petro physicist;Petech;DPN OTE PETECH;FALSE
+4bc7968e-72a7-4cc8-b3b9-57d626af29ab;Support Petech;;DPN OTE PETECH;FALSE
+eb2d0128-f716-4862-b7ba-76ad7e7a3d9c;Financial Analyst;Asset;DPN OTE PPM;FALSE
+ac1b082c-704a-4f2a-9456-9b8063cfa3b6;Production enginer;Petech;DPN OTE PTC;FALSE
+865b6c61-74f2-43c2-ac8d-00c08d94dda1;3rd Party Coordinator;Drilling;Operations;TRUE
+5fc6cdc3-bdd0-4fd2-9e04-29221117b958;Project Manager Operation;Operation;Operations;FALSE
+9fc47047-aef7-444d-89be-ca37d48f3838;HR Consultant;X Exclude from reporting;Other;FALSE
+7c9af7c6-dae0-4e8b-a8b0-71f5efc1b11f;IM/IT Lead;X Exclude from reporting;Other;TRUE
+b00c598c-90d2-46e9-b144-b249f8275d6a;IT analyst;X Exclude from reporting;Other;TRUE
+440ef89f-b0f8-42c5-93d8-34d3d6fdfdfe;IT coordinator;X Exclude from reporting;Other;FALSE
+589a56c9-799d-4fb9-9a2d-dd59e866d06f;Leave;;Other;FALSE
+20870c5e-8488-4527-b461-275f758ed6fc;Logistic;Operation;Other;TRUE
+eba5938e-cbc5-4cd5-954d-e3da64d5311a;Main safety delegate;X Exclude from reporting;Other;FALSE
+cc9ef6ec-182d-4871-834e-f68ed9157766;Multi-discipline engineer ;;Other;FALSE
+b220cda1-fe12-49a6-a874-2262a8f82803;Structural Inspector;Structural;Other;FALSE
+6881a72e-2905-40c6-8efe-d850426551d4;Support outside PRD;;Other;FALSE
+572298cf-c601-4e5f-af19-74019cd2fb59;Geologist/Geophysicist;Petech;Petech (PTC);FALSE
+905f0eb5-4687-4954-8528-5470891848b9;Project Manager Petech;Petech;Petech (PTC);FALSE
+a96852b6-f4fa-4bd7-b5bc-854b3fc66a65;Reservoir Engineer;Petech;Petech (PTC);FALSE
+b3a27240-f64a-4b45-8659-65aad01c0402;D&W Economist;Drilling;TPD D&W;FALSE
+d8326525-8d65-4b62-8cab-6df0140fabd6;D&W Manager;Drilling;TPD D&W;FALSE
+dbef15a1-2a6c-4463-b884-3fc294de0b42;D&W resources DG1-DG2;Drilling;TPD D&W;FALSE
+8a8e5ad6-f58f-464a-84d7-2b88dceb7e54;D&W resources DG2-DG3;Drilling;TPD D&W;FALSE
+74f365d9-8cee-4c3b-90ec-c54dab31bd06;D&W resources DG3-DG4;Drilling;TPD D&W;FALSE
+acc20698-8e42-4c10-9e69-ecf618d21f86;Day Supervisor rig;Drilling;TPD D&W;FALSE
+bb1278ad-5be8-4959-81c4-aa5755534be7;Drilling Engineer;Drilling;TPD D&W;FALSE
+b6f614dd-c336-4ee9-90ec-f18396adab73;Drilling Superintendent;Drilling;TPD D&W;FALSE
+2b6d46b3-288d-4e9d-bf99-45de8e01c4db;Night Supervisor rig;Drilling;TPD D&W;FALSE
+482e09a6-9d8c-49a0-8479-c5e40ccb1e4a;Project Manager D&W;Drilling;TPD D&W;FALSE
+58153e38-5f02-4250-862a-deeb4f430a61;Subsea Vertical System Engineer;Drilling;TPD D&W;FALSE
+8fe3a775-7c6c-47e6-be38-acb7a3d24063;Support D&W;;TPD D&W;FALSE
+6e038786-abe4-4ad5-b5ff-76bf5487d1c4;Well Completion Engineer;Drilling;TPD D&W;FALSE
+7f0e4392-9bd7-430c-8bdd-61ce2378fa93;Well Engineer;Drilling;TPD D&W;FALSE
+77b84506-18e0-4333-9603-cf7aedf83cc5;Well Intervention Engineer;Drilling;TPD D&W;FALSE
+1cb8c0ad-a035-4aef-8444-734f54e35b8c;Wellhead System Engineer;Drilling;TPD D&W;FALSE
+90c32c02-488f-49d5-84e5-4bc3b4469937;Workover System Engineer;Drilling;TPD D&W;TRUE
+3ffed341-63c4-40d8-98af-3876fdaeb0a4;XT System Engineer;Drilling;TPD D&W;FALSE
+a6f87307-7e03-4904-aa5e-186dd6b44541;Economic Analyst;Finance & Economy;TPD FC;FALSE
+73ba3fea-2e07-4bc8-979a-2310ca7aeb79;Financial Controller;Finance & Economy;TPD FC;FALSE
+efea104a-5abf-4c2b-bd47-15facff194f4;HR Manager;P&L;TPD PL PD;FALSE
+23736fd2-1d2c-485e-a18e-9893bbc76dcf;Advisor;;TPD PRD;FALSE
+3eb2b3c1-96d5-4189-97b3-bae76e84ed49;Chief Engineer;X Exclude from reporting;TPD PRD;TRUE
+9bc6562e-da18-4d1c-a4d9-96f5cb145404;Company Representative;;TPD PRD;TRUE
+af5cb517-fe40-4c8b-85c0-05544b076d7f;Facilities resources DG1-DG2;Facility;TPD PRD;TRUE
+6dbff9d8-adb9-472b-bed1-2869aa4d50d7;Facilities resources DG2 -DG3;Facility;TPD PRD;TRUE
+af1015be-ab7b-4a5f-a9c8-c00b63c602b0;Facilities resources DG3 -DG4;Facility;TPD PRD;FALSE
+248fefd3-11c1-4032-a052-636f8586a2ba;Home Support;;TPD PRD;TRUE
+bb577fcb-e338-48bf-9874-354dc3dc65dc;Internal assignments;;TPD PRD;FALSE
+fc7b216f-49f7-4f66-af34-dc239ab284a8;Leading Advisor;;TPD PRD;TRUE
+22bf5cd7-2d95-4276-883a-8b899532ec32;Management;;TPD PRD;FALSE
+0dcc4c6e-cffb-4431-816a-162bbe35f5fd;Project Support;;TPD PRD;TRUE
+3cd60bc6-44b1-40e8-bb5f-8fd5174e6719;Resource Owner;;TPD PRD;FALSE
+bd8f02d8-97ca-404d-bb4a-f60f38fe6360;Specialist;;TPD PRD;TRUE
+2ab4a929-317a-4cc9-88bf-4a737c89e557;Support;;TPD PRD;TRUE
+8feb5ff4-7ac1-45ae-8128-bba2259838cc;Support Facility;;TPD PRD;FALSE
+23df8810-d321-41e7-ab82-030db21634c6;T&I Manager;;TPD PRD;FALSE
+58596b10-08df-491d-91dc-c74f5c5d0f35;Business Efficiency responsible;X Exclude from reporting;TPD PRD BE;TRUE
+79c30e7e-993c-4287-a398-735afc0b8f91;Cost Estimator;Estimation;TPD PRD EP EST;FALSE
+67664174-200a-4a65-93fc-35ffe73f110c;Lead Estimator;Estimation;TPD PRD EP EST;FALSE
+b2e0fe85-8a9d-49e8-abba-5f5467a1a5b6;Weight Control Engineer;Estimation;TPD PRD EP EST;FALSE
+752d67f8-65b0-4256-a5ff-d63920692af5;Weight Estimator ;Estimation;TPD PRD EP EST;FALSE
+124cf1b2-d885-4abf-b577-9a5b843f6cd9;Area Lead;;TPD PRD FE;FALSE
+3f9d1ad1-7938-4073-9aaf-d3a3faffa834;Field Engineer Preservation;Material;TPD PRD FE;TRUE
+c2977352-08d5-4030-a7c8-790e53cf8295;Production technology;Process and Flow;TPD PRD FE;TRUE
+dfe48713-b58c-4028-b04b-b2b0e0100bcc;Quality Surveillance Engineer;Material;TPD PRD FE;FALSE
+44fee613-e177-475f-83bb-9f22815f8e29;Automation;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+d2cc138e-7e32-4fb1-84cc-b011362ba5bb;Automation engineer;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+46716a55-ae95-4917-b21f-345cf0ede26f;Automation lead;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+6681f877-1431-4258-a0b6-4d0226c5b791;Automation operation rep;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+fc628d1e-1388-405e-9c4d-47c1739da2ce;Discipline Engineer Automation ;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+20023f92-c3e2-4e6a-ae8c-22b84e66b5d1;Discipline Engineer Electrical;Electro;TPD PRD FE EA;TRUE
+a63caab5-dceb-4011-bfaa-c9b8bde52473;Discipline Engineer Instrument ;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+32c3b661-f61d-4d9b-9314-0cfec94c14ec;Discipline Engineer Telecom ;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+a7852787-8f08-447e-81c9-81631f56c8e8;Discipline Lead Automation;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+acbb18f4-59d7-4f47-b48e-c1327e2f56bc;Discipline Lead Electrical;Electro;TPD PRD FE EA;TRUE
+5b0392ff-6e86-4f85-8600-66d695d08894;Discipline Lead Instrument;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+20805a11-d288-46ec-9f1b-2da3748476e7;Discipline Lead Telecom ;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+7cb500e1-6f50-47de-b2c3-f0b64d23006a;Electrical engineer;Electro;TPD PRD FE EA;FALSE
+0d1186b7-f437-4b25-a5d6-563fe407fcfe;Electrical lead;Electro;TPD PRD FE EA;FALSE
+4ee1f5a1-d5dd-4849-9658-51dfc562d232;Field Engineer Electrical;Electro;TPD PRD FE EA;TRUE
+624e355b-5e2c-49d7-a3cf-4bf8ef8250b0;Field Engineer Instrument;Aut/Inst/Tele;TPD PRD FE EA;TRUE
+bc19b8c8-6902-4ff7-9404-3d92dd014e1b;Instrument engineer;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+96d45de5-b2bb-4997-89bf-e26bf436c470;Instrument field engineer;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+15839050-d75f-498b-9aba-afd805b5eefb;Instrument lead;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+7b74fdd1-73fe-46a0-a136-64c315bf0098;SAS;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+d50e2b2c-d3f4-4123-b58c-b01afd167f25;Telecom engineer;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+3b3e6b83-f60c-4a7f-801c-0a63df901944;Telecom lead ;Aut/Inst/Tele;TPD PRD FE EA;FALSE
+b97703e6-cdc8-4a3f-a889-21a1d375422f;Area Manager ;;TPD PRD FE EM;FALSE
+c52c13d2-164e-4c5c-abe5-e5b52dc22787;Company Representative (FE);;TPD PRD FE EM;TRUE
+a9dd775d-fe9e-4d52-8505-84245eb7f3c7;Engineering Manager;Engineering Management;TPD PRD FE EM;FALSE
+21e73b7f-6540-4dc3-b45b-44efb266360c;Project engineer;;TPD PRD FE EM;FALSE
+28a22a4a-51ad-4b52-ab0f-59b8d9413aad;Site Manager (FE);Engineering Management;TPD PRD FE EM;FALSE
+95287af2-62e2-434c-9844-e4bfa6733278;Technical interface coordinator;Engineering Management;TPD PRD FE EM;FALSE
+13356141-5516-40f6-99e5-1c4301563682;Technical Manager;Engineering Management;TPD PRD FE EM;FALSE
+38f238c3-10da-4010-92c3-c6a7f70431e7;Discipline Engineer Material;Material;TPD PRD FE MMS MAT;TRUE
+a2609346-8e7f-4672-b830-417be336aabe;Discipline Lead Material;Material;TPD PRD FE MMS MAT;TRUE
+4bcdd9c5-63aa-41ba-923c-0f44b8e180ee;Field Engineer Insulation;Material;TPD PRD FE MMS MAT;TRUE
+b2a29170-39ce-45f6-9938-bcef74af04c0;Field Engineer Surface Protection;Material;TPD PRD FE MMS MAT;TRUE
+ac076cd7-5be5-4470-9594-6ee3cf003e09;Field Engineer Welding;Material;TPD PRD FE MMS MAT;TRUE
+05da84f9-bc58-4917-b043-850d289d6077;Field Engineer Welding and NDE;Material;TPD PRD FE MMS MAT;TRUE
+d9da42cc-7c3c-4591-9c9d-a3a7786099a4;Insulation Field Engineer ;Material;TPD PRD FE MMS MAT;FALSE
+99e2fa8c-501e-41a4-b1c9-d2188422e9c5;Insulation Lead;Material;TPD PRD FE MMS MAT;FALSE
+114811bd-9480-4d23-8765-130bf9f49c7c;Material Engineer;Material;TPD PRD FE MMS MAT;FALSE
+1d94bdf6-eb40-4686-9363-dbab98b15ccc;Material Lead;Material;TPD PRD FE MMS MAT;FALSE
+c80b1b6d-6533-46b9-bedb-bfbf071d720c;Structure and welding field engineer;Material;TPD PRD FE MMS MAT;FALSE
+24b2dc44-f78c-4879-8be9-73bbf8ed2381;Surface Protection Field Engineer ;Material;TPD PRD FE MMS MAT;FALSE
+a6887cc3-8266-40e9-9a98-1963b70e4f68;Welding and NDE Field Engineer ;Material;TPD PRD FE MMS MAT;TRUE
+a6439abb-e088-4a95-bec4-3ac3629ba086;Crane Lifting Field Engineer;Mechanical;TPD PRD FE MMS MEC;TRUE
+47aef703-86c7-4e69-ab26-e63da3c611d5;Discipline Engineer Architect ;Mechanical;TPD PRD FE MMS MEC;TRUE
+31077d22-ce49-4939-8a1d-2e3dafc49cec;Discipline Engineer Civil ;Mechanical;TPD PRD FE MMS MEC;TRUE
+3af88aaa-d72b-44ff-b2ae-b296686954f2;Discipline Engineer Civil and Structures;Mechanical;TPD PRD FE MMS MEC;TRUE
+d3f38e8c-90a1-4f64-8943-3558481c842a;Discipline Engineer HVAC;Mechanical;TPD PRD FE MMS MEC;TRUE
+ca2499cb-5c23-4c5c-93d3-0a99ecda8fea;Discipline Engineer Material Handling;Mechanical;TPD PRD FE MMS MEC;TRUE
+947a746a-24e9-4265-b185-40a46650deb2;Discipline Engineer Mechanical;Mechanical;TPD PRD FE MMS MEC;TRUE
+b9d040a0-a796-4964-91bf-f635d1f6bfbd;Discipline Engineer Piping and Layout ;Mechanical;TPD PRD FE MMS MEC;TRUE
+9ca93826-10dc-4dc8-a2bc-86c18987ce02;Discipline Lead Architect;Mechanical;TPD PRD FE MMS MEC;TRUE
+f1bff6f5-1cd9-4719-bf5a-ebb8c299bbfb;Discipline Lead Civil;Mechanical;TPD PRD FE MMS MEC;TRUE
+40ba2d2d-5e9e-46c8-9719-d705e1112231;Discipline lead Civil and Structures;Mechanical;TPD PRD FE MMS MEC;TRUE
+524d9e8d-99bb-4cda-b9a7-eabce3b1ce01;Discipline Lead HVAC;Mechanical;TPD PRD FE MMS MEC;TRUE
+3b69fca5-41a2-4755-919e-08df892a8aaf;Discipline Lead Mechanical ;Mechanical;TPD PRD FE MMS MEC;TRUE
+802289ba-f95b-41c3-a6d2-2cf0fd21b173;Discipline Lead Piping and Layout;Mechanical;TPD PRD FE MMS MEC;TRUE
+b0262594-0559-48bb-8a94-ad58bc3f3d86;Field Engineer Architect;Mechanical;TPD PRD FE MMS MEC;TRUE
+ef8e1924-e8cb-4c40-9fbb-6362605c0a2a;Field Engineer Crane Lifting;Mechanical;TPD PRD FE MMS MEC;TRUE
+04fa1176-108b-45be-8dbd-30de99bc7403;Field Engineer HVAC;Mechanical;TPD PRD FE MMS MEC;TRUE
+c6c61c99-d85c-49ac-9fb1-d81ccb6cdab2;Field Engineer Mechanical ;Mechanical;TPD PRD FE MMS MEC;TRUE
+475ddd06-d455-4edd-9f9e-fae4ad9634c2;Field Engineer Piping;Mechanical;TPD PRD FE MMS MEC;TRUE
+254d9ee5-46c9-45a6-94db-e857a9d4e1f3;Field Engineer Scaffolding;Mechanical;TPD PRD FE MMS MEC;TRUE
+afb4dced-27d7-4790-b723-5f7514169a4d;HVAC Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+124475ae-d553-4eee-bfd6-94fc5ad561fe;HVAC Field Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+c6c893e8-7620-4a0b-a8a4-0453f2a09bf2;HVAC Lead;Mechanical;TPD PRD FE MMS MEC;FALSE
+55d55034-fd40-4c23-9118-f934d024d76f;Manager Civil;Mechanical;TPD PRD FE MMS MEC;TRUE
+a51b7b75-9c0a-46b3-912d-315750487918;Mechanical  engineer;Mechanical;TPD PRD FE MMS MEC;TRUE
+58824092-274e-44f6-abdf-57161b8ec000;Mechanical Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+55571084-33ec-4933-bdde-3f400c8b0181;Mechanical Field Engineer ;Mechanical;TPD PRD FE MMS MEC;FALSE
+e619d893-9cff-4c46-996a-f67bd148db9d;Mechanical Lead;Mechanical;TPD PRD FE MMS MEC;FALSE
+c513d654-408e-4974-9dba-e4699412be50;Offshore Architect ;Mechanical;TPD PRD FE MMS MEC;FALSE
+d0773997-a408-4973-8afe-7c68b0fe116d;Offshore Architect Field Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+dedaa1c0-3368-4455-8cf2-cd04c7eb897c;Offshore Architect Lead;Mechanical;TPD PRD FE MMS MEC;FALSE
+7155fefe-fd3c-4e05-bc92-bd4ee024c6f3;Onshore Civil Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+5ce029d2-91e8-4b7d-a5d4-9c551502f35a;Onshore Civil Lead;Mechanical;TPD PRD FE MMS MEC;FALSE
+0da454b6-6384-4627-8a88-5fe36fee7daf;Onshore Civil Manager;Mechanical;TPD PRD FE MMS MEC;TRUE
+47782a6a-57af-4abc-b3b3-ae86bd16653c;Piping and Layout Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+67c07071-9e62-4aa4-8000-f9981f795d6d;Piping and Layout Lead;Mechanical;TPD PRD FE MMS MEC;FALSE
+1952d2ca-4e65-4d8d-b287-7ab6f165ce41;Piping Field Engineer;Mechanical;TPD PRD FE MMS MEC;FALSE
+648f6e15-c260-4882-a3a0-f5ea158f52af;Valve Engineer;;TPD PRD FE MMS MEC;FALSE
+9b3f98f4-119a-4239-99aa-96589cec58ee;Discipline Engineer Marine Structures ;Structural;TPD PRD FE MMS STR;TRUE
+bbd52c90-d592-4e60-bb78-660148db8aa2;Discipline Engineer Structure;Structural;TPD PRD FE MMS STR;TRUE
+1cc21844-b477-43a0-8d30-c1a3195afd81;Discipline Lead Marine Structures;Structural;TPD PRD FE MMS STR;TRUE
+539923d2-a978-4099-9b50-8b1ceaeeb03d;Discipline Lead Structural;Structural;TPD PRD FE MMS STR;TRUE
+367afa8c-fe66-42d4-a742-61bfd5767ce9;Floater Lead;Structural;TPD PRD FE MMS STR;TRUE
+4e7ee589-bddc-4828-b61c-11cadd4bd364;Jacket Lead;Structural;TPD PRD FE MMS STR;TRUE
+4630fbec-85d7-4332-aa70-520a94e4dd40;Structural Engineer;Structural;TPD PRD FE MMS STR;FALSE
+885a3144-1d60-43a7-a88f-b04121f6c401;Structural Lead;Structural;TPD PRD FE MMS STR;FALSE
+c5b6198e-8330-4335-b071-99f8b23c29da;Mooring;Marine;TPD PRD FE MO;TRUE
+77610d3f-e1eb-4a0a-94b4-e08a5b039eee;Platform Marine;Marine;TPD PRD FE MO;TRUE
+05994b76-291e-4923-ad98-9fd5218cd33f;Survey;Marine;TPD PRD FE MO;TRUE
+33561bc0-5e91-42f7-8ebd-e93b1fd791f9;Geotechnical/Survey;Marine;TPD PRD FE MO GMS;TRUE
+5182bf73-e490-4d3e-8f75-29d48e5b8ca1;Discipline Engineer Marine Systems;Marine;TPD PRD FE MO MAR;TRUE
+bf4c3325-7967-44db-bcb6-0df7cc357097;Discipline Engineer Platform Marine Operation ;Marine;TPD PRD FE MO MAR;TRUE
+e65f447d-6f1a-409f-93bc-875cea17fb62;Discipline Lead Marine Systems;Marine;TPD PRD FE MO MAR;TRUE
+854fada2-a756-4bce-bc1d-2f4f99e55622;Discipline Lead Platform Marine Operation;Marine;TPD PRD FE MO MAR;TRUE
+aa700c19-d27f-4fbf-a606-07aeda6449fa;Discipline Lead Subsea Marine Operations ;Marine;TPD PRD FE MO MAR;TRUE
+9bf1ec57-000a-4854-94a9-2d8a67c76122;Manager Pipeline and Subsea Marine Operations;Marine;TPD PRD FE MO MAR;TRUE
+e483f960-c199-4441-890d-d6c286c2149d;Manager Subsea Marine Operations ;Marine;TPD PRD FE MO MAR;TRUE
+ece1410e-b4ac-49f8-9503-34474db31336;Marine Systems Engineer;Marine;TPD PRD FE MO MAR;TRUE
+0294b109-7f6d-425f-aec1-2ac0f905901b;Marine Systems Lead;Marine;TPD PRD FE MO MAR;TRUE
+c082aabd-efd3-4267-97e2-18c267b06e9a;Platform Marine Operation Engineer;Marine;TPD PRD FE MO MAR;TRUE
+b3c1188a-d35c-47de-9582-1acc7b375406;Platform Marine Operation Lead;Marine;TPD PRD FE MO MAR;TRUE
+a701618b-d84c-4a57-b39a-3a3017cc2fad;Subsea Marine Operation Engineer;Marine;TPD PRD FE MO MAR;TRUE
+306cbb60-9b56-45eb-9624-ba450c2bc816;Subsea Marine Operation Lead;Marine;TPD PRD FE MO MAR;TRUE
+7bf4d146-b389-4c2d-8bbd-c13b54fab6c6;Vessel Rep;Marine;TPD PRD FE MO MAR;FALSE
+dab00ad7-42e7-4e5d-a2a8-b14882de8996;System Lead;Process and Flow;TPD PRD FE SE;FALSE
+6ce0e8c9-8c45-471c-86ed-b1566fad93fb;Systems Lead;Process and Flow;TPD PRD FE SE;TRUE
+5e35b0cd-d16a-4d39-b5d1-fc5c76cf3bc8;Flow Assurance Engineer ;Process and Flow;TPD PRD FE SE FA;FALSE
+968c22be-3f3e-43c4-b6c8-0761410d052a;Flow Assurance Lead;Process and Flow;TPD PRD FE SE FA;FALSE
+659c10b5-6be6-49a4-89c5-4622f89f159c;Discipline Engineer Flow assurance;Process and Flow;TPD PRD FE SE PF;TRUE
+0623edff-ae07-4fc3-91cf-065cdc8d618a;Discipline Engineer Process;Process and Flow;TPD PRD FE SE PF;TRUE
+6d654ac8-a6d6-4021-85d6-4309202e221b;Discipline Lead Process;Process and Flow;TPD PRD FE SE PF;TRUE
+d2e00c0a-9be0-4a6e-9230-a6fa7b14ab45;Process Engineer;Process and Flow;TPD PRD FE SE PR;FALSE
+3c72c8a1-c23e-4614-a2c1-ec573472e10f;Process Lead ;Process and Flow;TPD PRD FE SE PR;FALSE
+f2be28d7-7fdb-4f12-8055-4b991f0d0b82;Discipline Engineer Environment Technology;Sustainability;TPD PRD FE SE SUS;TRUE
+9f5e518a-9138-41eb-85d0-b249ef2ad83c;Discipline Engineer Impact Assessment;Sustainability;TPD PRD FE SE SUS;TRUE
+eed50489-dda8-459d-b222-7fa3c0a0cc10;Discipline Lead Environment Technology;Sustainability;TPD PRD FE SE SUS;TRUE
+b61c7459-38ed-4e26-8ede-8d6cc51a4062;Discipline Lead Impact Assessment;Sustainability;TPD PRD FE SE SUS;TRUE
+e600750e-b72e-4e92-b5fc-09d6292ba056;Environment Technology Lead;Sustainability;TPD PRD FE SE SUS;FALSE
+cc03fc34-a468-4a1b-8af0-ca1eb2b5c4c3;External environment Engineer;Sustainability;TPD PRD FE SE SUS;TRUE
+17c8ce95-cf50-4091-adbc-4dee74cde0a3;Impact Assessment Lead;Sustainability;TPD PRD FE SE SUS;FALSE
+41b64ae8-e5b8-4689-beb0-0ba474250fed;Sustainability Lead;Sustainability;TPD PRD FE SE SUS;FALSE
+3d946829-2034-4d25-850e-9646a62d5846;Discipline engineer Technical Safety;Technical Safety and Working Environment;TPD PRD FE SE TS;TRUE
+9d312b75-4242-4555-a5d9-aeeac548499d;Discipline lead Technical Safety;Technical Safety and Working Environment;TPD PRD FE SE TS;TRUE
+0d8cdd60-12f6-42ce-8589-52569c1d1a9e;Technical Safety Engineer;Technical Safety and Working Environment;TPD PRD FE SE TS;FALSE
+16069856-03a2-48f7-aa23-284778038ae3;Technical Safety Lead;Technical Safety and Working Environment;TPD PRD FE SE TS;FALSE
+04178a76-0ccf-41f6-b125-0d7d8c2a1f2c;Discipline engineer Working environment;Technical Safety and Working Environment;TPD PRD FE SE TWEE;TRUE
+a69956cf-f3f7-4302-98eb-3d9d57822686;Discipline lead Working environment;Technical Safety and Working Environment;TPD PRD FE SE TWEE;TRUE
+c7e74505-4b06-4e16-a52f-d8798195b767;Working Environment Engineer;Technical Safety and Working Environment;TPD PRD FE SE TWEE;FALSE
+df7ca0fd-0e51-45b1-8488-0042f2817b9b;Working Environment Lead;Technical Safety and Working Environment;TPD PRD FE SE TWEE;FALSE
+3edc7ca2-3fec-45e8-918f-784c7a1691c2;Discilpine engineer SURF;SURF;TPD PRD FE SP;TRUE
+b80bc938-9be3-434c-85da-34d29e97be45;Discipline engineer  Pipeline System;SURF;TPD PRD FE SP;TRUE
+c202f160-0f18-4b9d-a8f3-3119696d62e1;Discipline engineer Dynamic Risers;SURF;TPD PRD FE SP;TRUE
+f8f9c068-c925-4714-b7a7-270597c4e357;Discipline engineer Pipeline Commissioning (RFO);SURF;TPD PRD FE SP;TRUE
+ee358152-44ce-42e6-a8c7-fa95817cd65c;Discipline engineer Pipeline Construction;SURF;TPD PRD FE SP;TRUE
+c85721da-d336-467b-aec1-f6476c8feda8;Discipline engineer Pipeline Design;SURF;TPD PRD FE SP;TRUE
+2e70c7c8-9a66-4e18-8726-923b4bb7de49;Discipline engineer Pipeline System ;SURF;TPD PRD FE SP;TRUE
+2e06319b-6e67-4d8f-9a2d-329b2ace3541;Discipline engineer Pipeline Tie-in and repair;SURF;TPD PRD FE SP;TRUE
+1b44b6cc-811b-48c1-ab1b-60db871089ae;Discipline engineer Subsea Control System;SURF;TPD PRD FE SP;TRUE
+acfcbaca-8c15-41c7-8037-002f47ca991c;Discipline engineer Subsea Electrical Technology;SURF;TPD PRD FE SP;TRUE
+810ef4c0-fe05-4148-8d63-aa2a54be5cca;Discipline engineer Subsea Intervention System ;SURF;TPD PRD FE SP;TRUE
+4afdceac-0ed2-4085-a0ba-79727a714081;Discipline engineer Subsea Marine Operations;SURF;TPD PRD FE SP;TRUE
+ec2b50d5-78d5-4a16-91c1-1b2959e17d0c;Discipline engineer Subsea Processing;SURF;TPD PRD FE SP;TRUE
+e944515d-c2f9-47d5-9c43-2310c2378b6a;Discipline engineer Subsea Production System;SURF;TPD PRD FE SP;TRUE
+52cf1fe9-bf92-486b-9ab3-5e73ba844bf7;Discipline engineer Subsea Structure & Valves;SURF;TPD PRD FE SP;TRUE
+f2098bc4-5684-4af7-ba96-949d8dfef90b;Discipline engineer Subsea Umbilical and Power Cab;SURF;TPD PRD FE SP;TRUE
+9e6e36ce-ebca-4d9a-88d6-304259dc293a;Discipline Lead Dynamic Risers ;SURF;TPD PRD FE SP;TRUE
+20870bbd-8d7a-4c80-ab57-24e7d5891327;Discipline Lead Pipeline System ;SURF;TPD PRD FE SP;TRUE
+5117aa15-f2c5-44b7-8a32-7bf83d2e8f89;Discipline Lead Subsea Production System;SURF;TPD PRD FE SP;TRUE
+96455514-5717-4ef1-ab84-adfc1cb96a80;Discipline Lead SURF;SURF;TPD PRD FE SP;TRUE
+70d1968c-ab21-49b8-86f4-5b9a0315059f;Discipline Lead Umbilical and Cables ;SURF;TPD PRD FE SP;TRUE
+69172557-60bc-48b1-8d10-96e0600e1bf1;Dynamic Riser;SURF;TPD PRD FE SP;FALSE
+f41366d5-89b1-4a6b-b628-bc78148cf1b6;Dynamic Riser lead;SURF;TPD PRD FE SP;TRUE
+07119c0b-4a1f-41fc-ace6-d431d943962e;Dynamic Riser manager;SURF;TPD PRD FE SP;TRUE
+caef351b-1188-4751-aadd-d691d8ce2db3;Manager Pipeline System ;SURF;TPD PRD FE SP;TRUE
+2ae9da05-b33a-44f6-95ae-c98e3b83f0e6;Manager Subsea Production System;SURF;TPD PRD FE SP;TRUE
+e3330feb-0259-4c1c-99a9-1f36a7182570;Manager SURF ;SURF;TPD PRD FE SP;TRUE
+abe329ae-2c53-4915-b42c-718b2c0684cb;Pipeline & Marine manager;SURF;TPD PRD FE SP;TRUE
+08c46178-0595-497f-b538-0cbbbb947304;Pipeline and Marine Operations;SURF;TPD PRD FE SP;FALSE
+74d98fb5-d5fb-4d54-9b09-6e3abcbb48e4;Pipeline Commissioning (PCO);SURF;TPD PRD FE SP;FALSE
+1826f025-19b6-451b-990d-fcbde4688d4c;Pipeline Commissioning (PCO) lead;SURF;TPD PRD FE SP;TRUE
+f35ac7ea-6378-4f32-ac21-f7289eae9e37;Pipeline Commissioning (RFO) lead;SURF;TPD PRD FE SP;TRUE
+d29bdfb7-e92c-4cf0-9ead-0e75f878f003;Pipeline Construction and Installation;SURF;TPD PRD FE SP;FALSE
+0d337443-85c5-418d-9629-55acc063ce49;Pipeline Construction and Installation manager;SURF;TPD PRD FE SP;TRUE
+f4212256-0d15-4ac9-8fc2-017c7da6ccab;Pipeline Design engineer;SURF;TPD PRD FE SP;FALSE
+27c75f95-a3f7-48b6-972d-2e172046f42f;Pipeline Installation engineer;SURF;TPD PRD FE SP;TRUE
+8203e407-014c-45db-9c2f-36c517b021c6;Pipeline manager;SURF;TPD PRD FE SP;FALSE
+5e63e699-09d8-4c44-9e9a-5e8635b50272;Pipeline Structures;SURF;TPD PRD FE SP;FALSE
+80421947-082f-448e-a640-39f8e0f38568;Pipeline System engineer;SURF;TPD PRD FE SP;FALSE
+eed42c55-725b-48cd-a4cd-5c1aeee00d25;Pipeline System lead;SURF;TPD PRD FE SP;FALSE
+3b52b8c5-0c19-47bc-a7fb-c961579fc17e;Pipeline System manager;SURF;TPD PRD FE SP;TRUE
+bd446f90-aaee-4b50-9469-66983e803b7c;Pipeline Tie-in engineer ;SURF;TPD PRD FE SP;TRUE
+42d60bae-7455-47ba-81d2-a03dbfd2189a;RFO Engineer;SURF;TPD PRD FE SP;TRUE
+e6f7685e-7d91-47a1-94a5-bf01c8f862e2;Subsea & Flowlines manager;SURF;TPD PRD FE SP;TRUE
+376c7799-d737-462c-8789-8cccc9ceddf3;Subsea Installation;SURF;TPD PRD FE SP;FALSE
+21c19d94-c8d4-4046-b378-95b5611027ab;Subsea and Marine Operations lead;SURF;TPD PRD FE SP;TRUE
+c333e556-e0c2-43ab-ac86-f487e6649267;Subsea and Marine Operations manager;SURF;TPD PRD FE SP;TRUE
+fa29d558-3af7-4c30-a47d-7827cbdc359e;Subsea Control System;SURF;TPD PRD FE SP;FALSE
+2939aa85-5e17-440d-91e9-e174e9c132fb;Subsea Control System lead;SURF;TPD PRD FE SP;TRUE
+f3ae77e1-50b4-4e65-a4b0-edac38a9fdfc;Subsea Electrical engineer;;TPD PRD FE SP;TRUE
+16616966-fc30-4823-8ec4-a6e5c181ffe2;Subsea Facilities lead;SURF;TPD PRD FE SP;TRUE
+9349a7c5-c56f-4d03-a09c-406b6b15bb08;Subsea Processing;SURF;TPD PRD FE SP;FALSE
+e76753f5-2dd9-44e0-8568-c771f28d405c;Subsea Production System;SURF;TPD PRD FE SP;FALSE
+be7e4f91-c2d4-4a2c-8c63-3716a510e016;Subsea Production System lead;SURF;TPD PRD FE SP;TRUE
+4a33e6c0-fff1-4f3c-8058-88b5a3f7fbfc;Subsea Production System manager;SURF;TPD PRD FE SP;TRUE
+1b0b78cd-d695-4806-984c-6c96ae364207;Subsea Template and Manifold engineer;SURF;TPD PRD FE SP;TRUE
+79012267-d4af-41da-b333-85e649fbe453;Subsea Template, Manifold and Intervention enginee;SURF;TPD PRD FE SP;FALSE
+14f48163-476f-41d1-9033-5387b5937ba8;Subsea Umbilical and Cable;SURF;TPD PRD FE SP;FALSE
+5b75469a-c1bc-4a5b-9ef7-d0ca15e5cabe;Subsea Umbilical and Cable lead;SURF;TPD PRD FE SP;TRUE
+03d6f4a7-b9db-4a2c-a473-d6bda397a5b0;Subsea Umbilical and Cable manager;SURF;TPD PRD FE SP;TRUE
+60caed44-9108-4fe4-9453-c369abf8df86;Subsea Umbilical and Cables engineer;SURF;TPD PRD FE SP;TRUE
+eb733802-3403-4a9e-9ea7-98a67961f035;Subsea umbilical and cables manager;SURF;TPD PRD FE SP;TRUE
+34348486-9227-4e37-bd92-353f042de218;Subsea Valves;SURF;TPD PRD FE SP;FALSE
+0e8c724a-f066-4d7d-a000-33b6debe7f0b;Subsea, Commissioning & Interface;SURF;TPD PRD FE SP;TRUE
+8d84650c-1b45-4ac6-b8d5-22139b18b919;SURF System;SURF;TPD PRD FE SP;FALSE
+886da503-27ac-41a2-a003-b24507d6c08b;SURF manager;SURF;TPD PRD FE SP;FALSE
+b3ff131f-5c32-41af-b0d2-664a08575ab6;Technical Manager Subsea;SURF;TPD PRD FE SP;TRUE
+1d23234d-9f50-4037-b76f-f32e30733299;Tie-in and Repair engineer ;SURF;TPD PRD FE SP;TRUE
+8dd27140-19ba-4d77-a28f-f2624608b2ef;Umbilical and Cables lead;SURF;TPD PRD FE SP;TRUE
+7930538b-1462-4566-994d-1bd695609959;Cessation Lead;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+ba8254fb-be8a-4f3a-b344-3d0c5c109197;Cessation Manager;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+b29b5bf5-6539-49dc-b7b8-64467b8ab44c;Construction and Commissioning (CC) Lead;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+334367ed-c522-499e-951c-1792a8a681f8;Construction and Commissioning (CC) Manager;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+a8eacdf6-32ad-431b-b6a6-6769bdc8c347;Construction Coordinator ;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+111ab5ed-4fbc-4eb0-b569-d9a70b9c4f9d;Construction Lead;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+2492ebf1-b5f8-4697-b8c6-908893fc53e0;Construction Manager;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+dc4c0a58-5a58-48d5-8f76-220c01ef8aaf;Hook-Up Coordinator ;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+f86bad25-ab25-4fff-8fc7-588833156ab6;Hook-up Lead;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+f6ba1557-72ae-45b4-b3c1-21d0212563f0;Hook-Up Manager ;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+06852ca9-07f3-40ce-b78f-be8d1867358f;ICC Manager;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+6997e31a-fd38-4c2f-9535-24bf1907e4e2;ICC Supervisor;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+a10e9f99-d7d6-4e05-a301-96b5f72d6665;Mechanical Complete Coordinator;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+cdb98a2e-5e0c-42ac-a1e7-965ec05bfa4a;Preservation Engineer;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+927e0d12-94d5-4c1d-8e44-5e2031e18cef;Preservation Lead;Construction & Hook up;TPD PRD PMC CCH CHU;FALSE
+2cea793d-bf18-4812-94c3-1d50421a4dc7;Site manager;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+35c0a2f3-5d40-4940-b6d9-83d91ed352ad;Work Preparation Coordinator;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+70be51b7-065a-4046-8c36-4d17ea8a68e5;Work Preparation Manager;Construction & Hook up;TPD PRD PMC CCH CHU;TRUE
+85b6ae16-4980-43d5-bf6d-ea5e0354b9b0;Commissioning Engineer;Commissioning;TPD PRD PMC CCH CM;FALSE
+6075516c-2c6e-4399-8bf0-1909461d2ad9;Commissioning Engineer Electrical;Commissioning;TPD PRD PMC CCH CM;FALSE
+009d7a39-db6f-4242-96cb-cf2c7c9ca904;Commissioning Engineer HVAC;Commissioning;TPD PRD PMC CCH CM;FALSE
+6d0f85ba-f8da-4f22-846e-96196d492fb1;Commissioning Engineer Instrument/SAS;Commissioning;TPD PRD PMC CCH CM;FALSE
+de4193b2-392a-4ec1-9f92-d6c9ef080e33;Commissioning Handover Coordinator;Commissioning;TPD PRD PMC CCH CM;FALSE
+25562cbf-5c02-47d6-97d1-d860f435df0f;Commissioning Engineer Process/Mechanical;Commissioning;TPD PRD PMC CCH CM;FALSE
+74b6ba96-df2c-439c-8c1c-010f274efcdc;Commissioning Lead;Commissioning;TPD PRD PMC CCH CM;FALSE
+9f458ae8-ebed-44c6-8031-7e7412e871e0;Commissioning Manager;Commissioning;TPD PRD PMC CCH CM;FALSE
+ed984d64-f0bb-4010-9fe8-1a1e456b3cfb;Commissioning Supervisor;Commissioning;TPD PRD PMC CCH CM;FALSE
+5bf33690-fb5d-4077-bccd-246b89c3cd5b;Completion Engineer;Completion Prep;TPD PRD PMC CCH CM;TRUE
+a982605f-027a-4540-838d-689e3a949c3c;Completion Manager;Completion Prep;TPD PRD PMC CCH CM;TRUE
+4f40b5f9-abab-4c25-9720-89c925b3586f;Completion preparation Engineer;Completion Prep;TPD PRD PMC CCH CM;FALSE
+451a8465-20c8-475e-80df-d34fd570dde1;Completion preparation Lead;Completion Prep;TPD PRD PMC CCH CM;FALSE
+3fc851f1-ccc5-4de5-bf2d-ea06b068d59b;Completion preparation Manager;Completion Prep;TPD PRD PMC CCH CM;FALSE
+e20b5f5c-08f4-400b-af64-5adeacbb19b1;Completion Supervisor (byggeleder);Completion Prep;TPD PRD PMC CCH CM;TRUE
+9dc94028-626f-446f-91e2-d6ec1fae1d17;MC Subsea;SURF;TPD PRD PMC CCH CM;TRUE
+07c98c3d-3771-4e3d-b218-61f6542adcb7;Cost Controller;Project Control;TPD PRD PMC PCA;FALSE
+44727df8-39e7-4cf5-815d-c438e0398602;Cost Control Lead;Project Control;TPD PRD PMC PCA;FALSE
+73e334ff-40f6-410a-a137-1b80d71dd712;Lead Planner;Project Control;TPD PRD PMC PCA;TRUE
+300b3314-a095-4f9e-9826-34010d6475e1;Planner;Project Control;TPD PRD PMC PCA;FALSE
+2b1b98cb-204a-4a54-8333-deda2195f049;Planner Lead;Project Control;TPD PRD PMC PCA;FALSE
+76afdfa1-b67a-4b73-a896-7c7228bde4f2;Project Accountant;Project Control;TPD PRD PMC PCA;TRUE
+4cb8aa85-80c1-4050-a8cc-940969f3649f;Project Control;Project Control;TPD PRD PMC PCA;FALSE
+8cfad8c0-3a68-4d72-9188-c8d812d71d3b;Project Control Lead topside;Project Control;TPD PRD PMC PCA;TRUE
+ba97663e-79b2-49e5-b126-214b0143aa07;Project Control Manager;Project Control;TPD PRD PMC PCA;FALSE
+8c30e0b1-fc58-4d9f-9fb5-94a8f27de0a2;Project Control Manager Subsea;Project Control;TPD PRD PMC PCA;TRUE
+044aa7ec-0949-4d08-9fe1-46ccf5ed77fc;Project Economist;Project Control;TPD PRD PMC PCA;TRUE
+1476d2ab-6e30-483a-a088-10520b09d696;Quantity Surveyor;Project Control;TPD PRD PMC PCA;FALSE
+f942a973-9cac-4a96-8bc7-a9e41141f021;Project Director;Project Management;TPD PRD PMC PM;FALSE
+8eb8f366-65bd-4f67-880f-4bcbc8065e73;Project Manager;Project Management;TPD PRD PMC PM;TRUE
+df244e4e-bf9c-46a4-ad35-d14c62855f47;Project Manager Facilities;Project Management;TPD PRD PMC PM;FALSE
+c8007f66-3028-491e-bee9-ab8319f16573;Project Manager Modifications;Project Management;TPD PRD PMC PM;TRUE
+a05c3454-79a2-4e01-8152-c061167d6575;Study Manager;;TPD PRD PMC PM;TRUE
+84f7a3a2-70c9-4201-a18c-72c69883a17b;Topside Manager;Project Management;TPD PRD PMC PM;TRUE
+db83be0e-62c2-4d13-9390-4bd499427663;Administrative Consultant;Quality and Administration;TPD PRD PMC QA ADM;TRUE
+128c140f-df11-4130-890c-4a73b30414c6;Administrative Lead;Quality and Administration;TPD PRD PMC QA ADM;TRUE
+ac1331cc-3219-4e8f-97ad-e2a10678107d;Consultancy Invoicing Coordinator;Quality and Administration;TPD PRD PMC QA ADM;FALSE
+09005aea-0861-45b5-8893-fc2c5592160c;Document Controller;Quality and Administration;TPD PRD PMC QA DM;TRUE
+b83dfcc2-805d-4205-8d85-704fc1399125;Document Management Coordinator;Quality and Administration;TPD PRD PMC QA DM;TRUE
+79992189-ae0a-4a7e-bc5f-347560c515d2;Document Manager;Quality and Administration;TPD PRD PMC QA DM;TRUE
+a0c588f7-b150-4a7d-9fdf-a3ef34d238b6;QRM Coordinator;Quality and Administration;TPD PRD PMC QA QRM;TRUE
+b7b2981c-c0ea-4866-aad3-4c0a41e44c2c;QRM Engineer;Quality and Administration;TPD PRD PMC QA QRM;TRUE
+fc07f01a-b260-4761-a772-2d73d266ab75;QRM Lead;Quality and Administration;TPD PRD PMC QA QRM;FALSE
+1b0be017-bc0c-4372-a1c4-a82f284c0ff0;QRM Subsea;Quality and Administration;TPD PRD PMC QA QRM;TRUE
+c5dc58a9-8cd6-4a8a-8964-840de7c7921c;Quality & Risk Manager;Quality and Administration;TPD PRD PMC QA QRM;FALSE
+5653dd58-4a2e-4646-821c-29b1ce4d5deb;Stakeholder Management;Quality and Administration;TPD PRD PMC QA QRM;TRUE
+cf07d3e2-3c2e-4ab0-9a13-92f59fa3ac3f;External Resource Coordinator;Procurement;TPD PRD PMC QA RES;FALSE
+654b07f5-8631-4801-9ee7-fa72f81afaa0;Business Manager;;TPD PRO PMC Multidiscipline;TRUE
+9aadbc06-efa6-4013-927f-f7b5597d3a41;Project Control & Procurement;Project Control;TPD PRO PMC Multidiscipline;TRUE
+6e2acb95-47a8-4aa8-81f3-4e835102b81f;Quality, risk & HSE ;;TPD PRO PMC QM Multidiscipline;TRUE
+da02e761-13f4-4911-ae5f-8b9814ab13e1;Change and Interface Coordinator;;TPD PRO PMC QM PCI;TRUE
+2f534126-ca02-4e81-a556-c043d0061648;Change and Interface Manager;;TPD PRO PMC QM PCI;TRUE
+60946d0d-ee1e-4ac1-b92b-ec6de59c7087;Contract Coordinator;Procurement;TPD PSR PCP;TRUE
+d1348d29-22cf-4bc9-82cd-80ecf28775f6;Contract Manager;Procurement;TPD PSR PCP;FALSE
+db6f4aed-9a1a-4aa9-a580-2a95ddb968d4;Field Procurement Manager;Procurement;TPD PSR PCP;TRUE
+365579f4-5aa5-4c72-a626-5879d7698a1e;Portfolio Procurement Manager;Procurement;TPD PSR PCP;TRUE
+1cd2c4bd-848f-412a-b0f8-266115cced62;Procurement Flowline and Marine;Procurement;TPD PSR PCP;TRUE
+2e0e176b-c143-4fde-8e0e-6b5020ad9480;Procurement Manager;Procurement;TPD PSR PCP;TRUE
+be2ff936-fa90-46d3-bb84-b0f6eb7e2a5c;Procurement Marine/Heavylift;Procurement;TPD PSR PCP;TRUE
+76e1096a-0d40-4ffe-98b8-2e546276942c;Purchaser;Procurement;TPD PSR PCP;FALSE
+9a1603d6-e3b9-4fdd-aa90-7fd4f432766a;Purchasing Manager;Procurement;TPD PSR PCP;FALSE
+0bad4959-d0cf-4964-b52e-4b03e947fc86;Purchasing Studies;Procurement;TPD PSR PCP;TRUE
+318105e4-a6b1-4ce3-8ef5-1bf7d4a08f4b;Senior Contract Coordinator;Procurement;TPD PSR PCP;TRUE
+9c4affad-d224-48b0-9097-40fc5d5d93eb;Senior Purchaser ;Procurement;TPD PSR PCP;TRUE
+9bedc80a-7d65-49e6-87c2-9e0ed89f97ed;Support procurement;;TPD PSR PCP;TRUE
+4e5ed72f-147f-4eec-bd9f-76443d2bf34a;Topside Purchasing;Procurement;TPD PSR PCP;TRUE
+7e765f64-ce8e-4453-a19f-b7f88bde29de;HSE Engineer;Safety;TPD SSU;TRUE
+4619ade2-ebe7-4f19-a2f8-e95b9f79f494;HSE Manager Subsea;Safety;TPD SSU;TRUE
+66164e41-4864-44b5-9b3d-a0a978838808;HSE ooordinator;Safety;TPD SSU;TRUE
+ddd7b3ca-59f4-44c1-ac0e-96c1e40f95fe;Discipline engineer External environment;Sustainability;TPD SSU PRD;TRUE
+ae0ff980-2914-4e8b-b5f6-21f501299999;Discipline lead External Environment;Sustainability;TPD SSU PRD;TRUE
+17ce6e22-310b-494e-83cb-e9839ba9918b;SSU Inspector;SSU;TPD SSU PRD;FALSE
+dede1265-fef0-4110-8a19-f0d42b71362f;SSU Site Leader;SSU;TPD SSU PRD;FALSE
+b217f0ca-b6b7-4bde-82eb-f6664e70c183;SSU and Authority Manager;SSU;TPD SSU PRD;FALSE
+2b06ca34-d828-43e3-af2e-f68564f7e253;Procurement Responsible;Procurement;TPD PSR SEC;FALSE
+e9609ea2-a312-455d-8deb-dc046cc09780;Project Procurement Manager (PPM);Procurement;TPD PSR SEC;FALSE
+5b042f51-02ab-45e5-b272-4cf1b596aa80;Quality & Risk Engineer;Quality and Administration;TPD PRD PMC QA QRM;FALSE
+ec78b510-fccc-4fb6-874e-97bc2383124a;Document Manon Management;Quality and Administration;TPD PRD PMC QA DM;FALSE
+7b0eb805-74b3-4e12-9ba2-f0ef994247f0;Document Conon Management;Quality and Administration;TPD PRD PMC QA DM;FALSE
+3f743b4b-a1e1-414c-8dc9-a3652dab8eb1;Administration Management;Quality and Administration;TPD PRD PMC QA ADM;FALSE
+ec1ff733-321f-4758-b8b2-a65c43aba233;Quantity Surveyor;;TPD PRD PMC PCA;FALSE
+8a5886bb-7739-4d75-b49f-8cfeb9c4c532;Subsea TMI engineer;SURF;TPD PRD FE SP;FALSE
+c6a07905-e49e-41e1-9f91-a153a27ba426;Subsea Marine Operation ;SURF;TPD PRD FE MO MAR;FALSE
+67c8f74c-e5ef-4084-a62b-fb7cdf0d59c6;Marine Systems and Naval Architect;Marine;TPD PRD FE MO MAR;FALSE
+9ea6d5d5-d84f-4265-8db9-67b5766337a3;Platform Marine Operation;Marine;TPD PRD FE MO MAR;FALSE
+d6423442-a98f-4fb5-83e4-4a4c8557ff65;Map services and geographical information;;TPD PRD FE MO MAP;FALSE
+05b288f0-cef9-47bf-9f9d-cee6eedd9e84;Geotechnics;;TPD PRD FE MO GMS;FALSE
+4f497e6b-2086-4e4f-bc1a-67883af72d6d;Seabed intervention;;TPD PRD FE MO GMS;FALSE
+3bfd2e64-aa6d-4f2e-84b9-ef291daa9e32;Survey Lead;Marine;TPD PRD FE MO GMS;FALSE
+8ac1e0ba-cc8d-441a-b80a-9159419aeb11;Seabed Survey;;TPD PRD FE MO GMS;FALSE

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Data\BasePositions.csv" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Data\BasePositions.csv" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="30.0.4" />
+    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="3.2.2" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.5.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="3.1.2" />
+    <PackageReference Include="Fusion.AspNetCore" Version="3.1.7" />
+  </ItemGroup>
+  
+</Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestContractBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestContractBuilder.cs
@@ -1,0 +1,123 @@
+﻿using Bogus;
+using Fusion.ApiClients.Org;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class FusionTestContractBuilder
+    {
+        private readonly ApiProjectV2 project;
+        private readonly ApiProjectContractV2 contract;
+        private readonly List<ApiPositionV2> positions = new List<ApiPositionV2>();
+        private readonly Faker faker = new Faker();
+
+        public FusionTestContractBuilder()
+        {
+            project = OrgTestData.Project().Generate();
+            contract = OrgTestData.Contract().Generate();
+        }
+
+        public FusionTestContractBuilder(ApiProjectV2 project)
+        {
+            this.project = project;
+            contract = OrgTestData.Contract().Generate();
+        }
+
+        public ApiProjectContractV2 Contract => contract;
+        public IEnumerable<ApiPositionV2> Positions 
+        { 
+            get
+            {
+                var serialized = JsonConvert.SerializeObject(positions);
+                var deserialized = JsonConvert.DeserializeObject<List<ApiPositionV2>>(serialized);
+
+                deserialized.ForEach(p =>
+                {
+                    p.ContractId = contract.Id;
+                    p.Contract = new ApiContractReferenceV2
+                    {
+                        Company = contract.Company,
+                        Id = contract.Id,
+                        ContractNumber = contract.ContractNumber,
+                        Name = contract.Name
+                    };
+                    p.ProjectId = project.ProjectId;
+                    p.Project = new ApiProjectReferenceV2()
+                    {
+                        ProjectId = project.ProjectId,
+                        DomainId = project.DomainId,
+                        Name = project.Name,
+                        ProjectType = project.ProjectType
+                    };
+                });
+
+                return deserialized;
+            } 
+        }
+
+        public FusionTestContractBuilder(ApiProjectContractV2 contract)
+        {
+            this.contract = contract;
+        }
+
+        public FusionTestContractBuilder WithName(string name)
+        {
+            contract.Name = name;
+            return this;
+        }
+
+        public FusionTestContractBuilder WithNumber(string number)
+        {
+            contract.ContractNumber = number;
+            return this;
+        }
+
+        public FusionTestContractBuilder WithCompany(Guid id, string name)
+        {
+            contract.Company = new ApiCompanyV2 { Id = id, Name = name };
+            return this;
+        }
+        public FusionTestContractBuilder WithId(Guid id)
+        {
+            contract.Id = id;
+            return this;
+        }
+
+        public FusionTestContractBuilder WithPositions(int count) => WithPositions(count, count);
+        public FusionTestContractBuilder WithPositions(int min = 3, int max = 10)
+        {
+            var count = faker.Random.Int(min, max);
+            var newPositions = OrgTestData.Position().Generate(count);
+            positions.AddRange(newPositions);
+
+            return this;
+        }
+
+        public FusionTestContractBuilder WithCompanyRep(ApiPositionV2 position = null)
+        {
+            contract.CompanyRep = position ?? OrgTestData.Position();
+            return this;
+        }
+        public FusionTestContractBuilder WithContractRep(ApiPositionV2 position = null)
+        {
+            contract.ContractRep = position ?? OrgTestData.Position();
+            return this;
+        }
+        public FusionTestContractBuilder WithExternalCompanyRep(ApiPositionV2 position = null)
+        {
+            contract.ExternalCompanyRep = position ?? OrgTestData.Position();
+            positions.Add(position);            
+
+            return this;
+        }
+
+        public FusionTestContractBuilder WithExternalContractRep(ApiPositionV2 position = null)
+        {
+            contract.ExternalContractRep= position ?? OrgTestData.Position();
+            positions.Add(position);
+            return this;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -98,5 +98,33 @@ namespace Fusion.Testing.Mocks.OrgService
             OrgServiceMock.AddProject(this);
             return this;
         }
+
+        public ApiPositionV2 AddContractPosition(Guid contractId)
+        {
+            var position = PositionBuilder.NewPosition();
+
+            var contract = contracts.FirstOrDefault(c => c.Id == contractId);
+
+            position.ContractId = contractId;
+            position.Contract = new ApiContractReferenceV2()
+            {
+                Company = contract.Company,
+                ContractNumber = contract.ContractNumber,
+                Id = contract.Id,
+                Name = contract.Name
+            };
+            position.ProjectId = project.ProjectId;
+            position.Project = new ApiProjectReferenceV2
+            {
+                DomainId = project.DomainId,
+                Name = project.Name,
+                ProjectId = project.ProjectId,
+                ProjectType = project.ProjectType
+            };
+
+            var clone = position.JsonClone();
+            OrgServiceMock.contractPositions.Add(clone);
+            return clone;
+        }
     }
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -1,0 +1,102 @@
+﻿using Bogus;
+using Fusion.ApiClients.Org;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class FusionTestProjectBuilder
+    {
+
+        private readonly ApiProjectV2 project;
+        private readonly List<ApiPositionV2> positions = new List<ApiPositionV2>();
+        private readonly List<ApiProjectContractV2> contracts = new List<ApiProjectContractV2>();
+        private readonly Dictionary<Guid, List<ApiPositionV2>> contractPositions = new Dictionary<Guid, List<ApiPositionV2>>();
+        private readonly Faker faker = new Faker();
+
+        public FusionTestProjectBuilder()
+        {
+            project = OrgTestData.Project().Generate();
+            positions.Add(project.Director);
+        }
+
+        public ApiProjectV2 Project => project;
+        public IEnumerable<ApiPositionV2> Positions
+        {
+            get
+            {
+                var serialized = JsonConvert.SerializeObject(positions);
+                var deserialized = JsonConvert.DeserializeObject<List<ApiPositionV2>>(serialized);
+
+                deserialized.ForEach(p =>
+                {
+                    p.ProjectId = project.ProjectId;
+                    p.Project = new ApiProjectReferenceV2()
+                    {
+                        ProjectId = project.ProjectId,
+                        DomainId = project.DomainId,
+                        Name = project.Name,
+                        ProjectType = project.ProjectType
+                    };
+                });
+
+                return deserialized;
+            }
+        }
+
+        public ApiPositionV2 Director => project.Director;
+
+        public IEnumerable<ValueTuple<ApiProjectContractV2, List<ApiPositionV2>>> ContractsWithPositions =>
+            contractPositions.Select(kv => (contracts.First(c => c.Id == kv.Key), kv.Value));
+
+        public FusionTestProjectBuilder WithProjectId(Guid id)
+        {
+            project.ProjectId = id;
+
+            contractPositions.Values.SelectMany(v => v).ToList().ForEach(p =>
+            {
+                p.ProjectId = id;
+                p.Project.ProjectId = id;
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add a random contract without any positions.
+        /// </summary>
+        public FusionTestProjectBuilder WithContract() => WithContract(builder => { } );
+        public FusionTestProjectBuilder WithContractAndPositions() => WithContract(builder => builder.WithPositions() );
+
+        public FusionTestProjectBuilder WithContract(Action<FusionTestContractBuilder> contractSetup)
+        {
+            var contractBuilder = new FusionTestContractBuilder(project);
+            contractSetup(contractBuilder);
+
+            contracts.Add(contractBuilder.Contract);
+            contractPositions[contractBuilder.Contract.Id] = contractBuilder.Positions.ToList();
+
+            return this;
+        }
+
+
+        public FusionTestProjectBuilder WithPositions(int count) => WithPositions(count, count);
+        public FusionTestProjectBuilder WithPositions(int min = 3, int max = 10)
+        {
+            var count = faker.Random.Int(min, max);
+            var newPositions = OrgTestData.Position().Generate(count);
+
+            positions.AddRange(newPositions);
+
+            return this;
+        }
+
+        public FusionTestProjectBuilder AddToMockService()
+        {
+            OrgServiceMock.AddProject(this);
+            return this;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionInstanceExtensions.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionInstanceExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Integration.Profile.ApiClient;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public static class ApiPositionInstanceExtensions
+    {
+        public static ApiPositionInstanceV2 SetAssignedPerson(this ApiPositionInstanceV2 instance, string mail)
+        {
+            instance.AssignedPerson = new ApiPersonV2 { Mail = mail };
+            return instance;
+        }
+
+        public static ApiPositionInstanceV2 SetAssignedPerson(this ApiPositionInstanceV2 instance, ApiPersonProfileV3 person)
+        {
+            instance.AssignedPerson = new ApiPersonV2 { AzureUniqueId = person.AzureUniqueId, Mail = person.Mail };
+            return instance;
+        }
+
+        public static ApiPositionInstanceV2 SetExternalId(this ApiPositionInstanceV2 instance, string externalId)
+        {
+            instance.ExternalId = externalId;
+            return instance;
+        }
+        public static ApiPositionInstanceV2 SetParentPosition(this ApiPositionInstanceV2 instance, Guid? parentPositionId)
+        {
+            instance.ParentPositionId = parentPositionId;
+            return instance;
+        }
+        public static ApiPositionInstanceV2 AddTaskOwner(this ApiPositionInstanceV2 instance, Guid positionId)
+        {
+            if (instance.TaskOwnerIds == null)
+                instance.TaskOwnerIds = new List<Guid>();
+            instance.TaskOwnerIds.Add(positionId);
+            return instance;
+        }
+
+        public static ApiPositionInstanceV2 AddTaskOwner(this ApiPositionInstanceV2 instance, params Guid[] positionIds)
+        {
+            if (instance.TaskOwnerIds == null)
+                instance.TaskOwnerIds = new List<Guid>();
+
+            instance.TaskOwnerIds.AddRange(positionIds);
+            return instance;
+        }
+
+        public static ApiPositionInstanceV2 Clone(this ApiPositionInstanceV2 instance)
+        {
+            return JsonConvert.DeserializeObject<ApiPositionInstanceV2>(JsonConvert.SerializeObject(instance));
+        }
+
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
@@ -1,0 +1,110 @@
+﻿using Fusion.ApiClients.Org;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public static class ApiPositionV2Extensions
+    {
+        public static ApiPositionV2 WithBasePosition(this ApiPositionV2 position, string bpName)
+        {
+            var bp = PositionBuilder.AllBasePositions.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.Name, bpName));
+            if (bp == null)
+                throw new ArgumentException($"Unable to locate base position {bpName} when setting up test position");
+
+            bool hasBpName = position.Name == position.BasePosition.Name;
+
+            position.BasePosition = bp;
+            if (hasBpName)
+                position.Name = bp.Name;
+
+            return position;
+        }
+
+        public static ApiPositionV2 WithRandomBasePosition(this ApiPositionV2 position, string except = null)
+        {
+            var faker = new Bogus.Faker();
+
+            var bp = faker.PickRandom(PositionBuilder.AllBasePositions);
+
+            while (except != null && bp.Name == except && bp.Name == "Project Director")
+            {
+                bp = faker.PickRandom(PositionBuilder.AllBasePositions);
+            }
+
+            bool hasBpName = position.Name == position.BasePosition.Name;
+
+            position.BasePosition = bp;
+            if (hasBpName)
+                position.Name = bp.Name;
+
+            return position;
+        }
+
+        public static ApiPositionV2 WithInstances(this ApiPositionV2 position, Action<PositionInstanceBuilder> setup)
+        {
+            var builder = new PositionInstanceBuilder(position);
+            setup(builder);
+
+            return position;
+        }
+        public static ApiPositionV2 WithInstances(this ApiPositionV2 position, IEnumerable<ApiPositionInstanceV2> copyInstances)
+        {
+            var copiedInstances = copyInstances.Select(i => i.Clone()).ToList();
+
+            // Reset ids.
+            copiedInstances.ForEach(i => i.Id = Guid.Empty);
+
+            position.Instances = copiedInstances;
+
+            return position;
+        }
+
+        public static ApiPositionV2 WithInstances(this ApiPositionV2 position, int count)
+        {
+            var instances = PositionInstanceBuilder.CreateInstanceStack(5, count);
+            position.Instances = instances.Take(count).ToList();
+            return position;
+        }
+
+        /// <summary>
+        /// Assigns the person to all instances
+        /// </summary>
+        public static ApiPositionV2 WithAssignedPerson(this ApiPositionV2 position, Integration.Profile.ApiClient.ApiPersonProfileV3 person) => WithAssignedPerson(position, person.Mail);
+        public static ApiPositionV2 WithAssignedPerson(this ApiPositionV2 position, string personMail)
+        {
+            position.Instances.ForEach(i => i.AssignedPerson = new ApiPersonV2 { Mail = personMail });
+            return position;
+        }
+
+        public static ApiPositionV2 WithEnsuredFutureInstances(this ApiPositionV2 position)
+        {
+            // Already an instance with applies to past today
+            if (position.Instances.Any(i => i.AppliesTo > DateTime.UtcNow))
+                return position;
+
+            // Pick last instance and extend..
+            var lastInstance = position.Instances.OrderBy(i => i.AppliesTo).Last();
+            lastInstance.AppliesTo = DateTime.UtcNow.AddDays(10);
+
+            return position;
+        }
+
+        /// <summary>
+        /// Sets the parent position for all instances.
+        /// </summary>
+        public static ApiPositionV2 WithParentPosition(this ApiPositionV2 position, Guid? parentPoisitionId)
+        {
+            position.Instances.ForEach(i => i.ParentPositionId = parentPoisitionId);
+            return position;
+        }
+
+        public static ApiPositionV2 WithTaskOwner(this ApiPositionV2 position, Guid parentPoisitionId)
+        {
+            position.Instances.ForEach(i => i.AddTaskOwner(parentPoisitionId));
+            return position;
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/CloningUtils.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/CloningUtils.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public static class CloningUtils
+    {
+        /// <summary>
+        /// Will use JsonConvert to "round-trip" the object.
+        /// </summary>
+        public static T JsonClone<T>(this T item)
+        {
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(item));
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/PositionInstanceBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/PositionInstanceBuilder.cs
@@ -1,0 +1,98 @@
+﻿using Fusion.ApiClients.Org;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class PositionInstanceBuilder
+        {
+            private readonly ApiPositionV2 position;
+
+            public PositionInstanceBuilder(ApiPositionV2 position)
+            {
+                this.position = position;
+
+                // Clear instance auto generated
+                this.position.Instances = new List<ApiPositionInstanceV2>();
+            }
+
+            public ApiPositionInstanceV2 AddInstance(DateTime from, TimeSpan duration, Guid? parentPositionId = null)
+            {
+                var instance = CreateInstance().Generate();
+                instance.AppliesFrom = from;
+                instance.AppliesTo = from.Add(duration);
+                instance.ParentPositionId = parentPositionId;
+
+                position.Instances.Add(instance);
+
+                return instance;
+            }
+
+            public ApiPositionInstanceV2 AddInstance(TimeSpan duration, Guid? parentPositionId = null)
+            {
+                var lastInstance = position.Instances.OrderBy(i => i.AppliesTo).LastOrDefault();
+
+                var startDate = lastInstance?.AppliesTo.AddDays(1);
+
+                if (startDate == null)
+                {
+                    startDate = new Bogus.Faker().Date.Past(2);
+                }
+
+                var instance = CreateInstance().Generate();
+                instance.AppliesFrom = startDate.Value;
+                instance.AppliesTo = startDate.Value.Add(duration);
+                instance.ParentPositionId = parentPositionId;
+
+                position.Instances.Add(instance);
+
+                return instance;
+            }
+
+        public static List<ApiPositionInstanceV2> CreateInstanceStack(int maxCount = 4, int minCount = 1) => CreateInstanceStack(new Bogus.Faker(), maxCount, minCount);
+        public static List<ApiPositionInstanceV2> CreateInstanceStack(Bogus.Faker rangeFaker, int maxCount = 4, int minCount = 1)
+        {
+            var start = rangeFaker.Date.Past(2).Date;
+            var end = rangeFaker.Date.Future(2).Date;
+            var count = rangeFaker.Random.Int(minCount, maxCount);
+
+            var faker = new Bogus.Faker<ApiPositionInstanceV2>()
+                .RuleFor(i => i.Id, f => Guid.NewGuid())
+                .RuleFor(i => i.ExternalId, f => f.Random.AlphaNumeric(3))
+                .RuleFor(i => i.Calendar, f => "Normal")
+                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100));
+
+            var instances = faker.Generate(count);
+
+            // Space out instances
+            foreach (var instance in instances)
+            {
+                var newInstanceEnd = end;
+                if (newInstanceEnd <= start)
+                    newInstanceEnd = start.AddDays(60);
+
+                var instanceEnd = rangeFaker.Date.Between(start.AddDays(30), newInstanceEnd);
+                instance.AppliesFrom = start;
+                instance.AppliesTo = instanceEnd;
+
+                start = instanceEnd.Date.AddDays(1);
+            }
+
+            return instances;
+        }
+
+        public static Bogus.Faker<ApiPositionInstanceV2> CreateInstance()
+        {
+            return new Bogus.Faker<ApiPositionInstanceV2>()
+                .RuleFor(i => i.Id, f => Guid.NewGuid())
+                .RuleFor(i => i.ExternalId, f => f.Random.AlphaNumeric(3))
+                .RuleFor(i => i.Calendar, f => "Normal")
+                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100));
+        }
+
+
+
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/TestPositionBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/TestPositionBuilder.cs
@@ -1,0 +1,117 @@
+﻿using Fusion.ApiClients.Org;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public static class PositionBuilder
+    {
+
+        public static ApiPositionV2 NewPosition()
+        {
+            return CreateTestPosition()
+                .Generate();
+        }
+
+        public static Bogus.Faker<ApiPositionV2> CreateTestPosition()
+        {
+            return new Bogus.Faker<ApiPositionV2>()
+                .RuleFor(p => p.Id, f => Guid.NewGuid())
+                .RuleFor(p => p.Properties, f => new ApiPositionPropertiesV2())
+                .RuleFor(p => p.ExternalId, f => f.Random.AlphaNumeric(5))
+                .RuleFor(p => p.BasePosition, f => f.PickRandom(AllBasePositions.Except(new[] { DirectorBasePosition })))
+                .RuleFor(p => p.Instances, f => PositionInstanceBuilder.CreateInstanceStack(f, 4))
+                .FinishWith((f, p) =>
+                {
+                    p.Name = p.BasePosition.Name;
+                    p.Instances.ForEach(i => i.PositionId = p.Id);
+                });
+        }
+
+        
+        private static List<ApiBasePositionV2> basePositionCache = null;
+        public static List<ApiBasePositionV2> AllBasePositions
+        {
+            get
+            {
+                if (basePositionCache == null)
+                {
+                    var bps = GetBasePositionCSVImport();
+                    basePositionCache = bps.Select(bp => new ApiBasePositionV2
+                    {
+                        Id = bp.Id,
+                        Department = bp.Department,
+                        Discipline = bp.Discipline,
+                        Name = bp.Name,
+                        Inactive = bp.Inactive,
+                        ProjectType = bp.ProjectType
+                    }).ToList();
+                }
+
+                return basePositionCache;
+            }
+        }
+
+        public static ApiBasePositionV2 DirectorBasePosition => AllBasePositions.First(bp => bp.Id == new Guid("f942a973-9cac-4a96-8bc7-a9e41141f021"));
+
+        private static List<ApiBasePositionV2> GetBasePositionCSVImport()
+        {
+            var resourceData = AssemblyUtils.GetResourceFromCurrentAssembly($@"Fusion.Testing.Mocks.OrgService.Data.BasePositions.csv");
+            var data = resourceData.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            List<ApiBasePositionV2> positions = data.Skip(1)
+                .Where(l => !string.IsNullOrEmpty(l))   // Trim any empty lines
+                .Select(DeserializeCSVBasePosition)
+                .ToList();
+
+            return positions;
+        }
+
+        private static ApiBasePositionV2 DeserializeCSVBasePosition(string line)
+        {
+            string[] tokens = line.Split(';');  // GUID, Title, Discipline, Department
+
+            ApiBasePositionV2 p = new ApiBasePositionV2
+            {
+                Id = new Guid(tokens[0]),
+                Name = tokens[1].Trim(),
+                Discipline = (tokens[2] ?? "").Trim(),
+                Department = (tokens[3] ?? "").Trim(),
+                Inactive = bool.Parse(tokens[4])
+            };
+
+            return p;
+        }
+
+        static class AssemblyUtils
+        {
+            public static string GetResourceFromCurrentAssembly(string resourcePath)
+            {
+                return GetResource(Assembly.GetCallingAssembly(), resourcePath);
+            }
+
+            public static string GetResource(Assembly assembly, string resourcePath)
+            {
+                string[] manifestResourceNames = assembly.GetManifestResourceNames();
+                if (!manifestResourceNames.Contains(resourcePath))
+                {
+                    throw new ArgumentNullException("Could not locate resource in assembly. Located: " + string.Join(",", manifestResourceNames));
+                }
+                using (Stream stream = assembly.GetManifestResourceStream(resourcePath))
+                {
+                    using (StreamReader streamReader = new StreamReader(stream))
+                    {
+                        return streamReader.ReadToEnd();
+                    }
+                }
+            }
+        }
+    }
+
+    
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -55,5 +55,10 @@ namespace Fusion.Testing.Mocks.OrgService
         {
             companies.Add(new ApiCompanyV2 { Id = id, Name = name });
         }
+
+        //public static ApiPositionV2 ResolveContractPosition(Guid position)
+        //{
+
+        //}
     }
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -1,0 +1,59 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Testing.Mocks.OrgService.Api;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class OrgServiceMock
+    {
+        readonly WebApplicationFactory<Startup> factory;
+
+        internal static List<ApiClients.Org.ApiProjectV2> projects = new List<ApiClients.Org.ApiProjectV2>();
+        internal static List<ApiClients.Org.ApiPositionV2> positions = new List<ApiClients.Org.ApiPositionV2>();
+        internal static Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>> contracts = new Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>>();
+        internal static List<ApiClients.Org.ApiPositionV2> contractPositions = new List<ApiClients.Org.ApiPositionV2>();
+        internal static List<ApiCompanyV2> companies = new List<ApiCompanyV2>();
+
+        public OrgServiceMock()
+        {
+            factory = new WebApplicationFactory<Startup>();
+        }
+
+        public HttpClient CreateHttpClient()
+        {
+            var client = factory.CreateClient();
+            return client;
+        }
+
+
+        public static void AddProject(FusionTestProjectBuilder builder)
+        {
+            projects.Add(builder.Project);
+            positions.AddRange(builder.Positions);
+
+            foreach ((var contract, var positions) in builder.ContractsWithPositions)
+            {
+                if (!contracts.ContainsKey(builder.Project.ProjectId))
+                    contracts[builder.Project.ProjectId] = new List<ApiProjectContractV2>();
+
+                contracts[builder.Project.ProjectId].Add(contract);
+                contractPositions.AddRange(positions);
+
+                if (contract.Company != null && !companies.Any(c => c.Id == contract.Company.Id))
+                {
+                    companies.Add(contract.Company);
+                }
+            }
+        }
+        public static void AddCompany(Guid id, string name)
+        {
+            companies.Add(new ApiCompanyV2 { Id = id, Name = name });
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
@@ -1,0 +1,61 @@
+﻿using Bogus;
+using Fusion.ApiClients.Org;
+using System;
+using System.Linq;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class OrgTestData
+    {
+        public static Faker<ApiProjectV2> Project() => new Faker<ApiProjectV2>()
+            .CustomInstantiator(f =>
+            {
+                var director = Position()
+                    .RuleFor(p => p.BasePosition, f => PositionBuilder.DirectorBasePosition)
+                    .Generate();
+
+                var project = new ApiProjectV2()
+                {
+                    ProjectId = Guid.NewGuid(),
+                    Name = f.Commerce.ProductName(),
+                    ProjectType = "PRD",
+                    DomainId = f.Random.AlphaNumeric(5),
+                    Dates = new ApiProjectDatesV2() { EndDate = f.Date.Future(), StartDate = f.Date.Past(), Gates = new ApiProjectDecisionGatesV2() { } },
+                    Director = director,
+                    DirectorPositionId = director.Id
+                };
+
+                director.ProjectId = project.ProjectId;
+                director.Project = new ApiProjectReferenceV2()
+                {
+                    ProjectId = project.ProjectId,
+                    DomainId = project.DomainId,
+                    Name = project.Name,
+                    ProjectType = project.ProjectType
+                };
+
+                return project;
+            });
+
+        public static Faker<ApiPositionV2> Position() => PositionBuilder.CreateTestPosition();
+
+        public static Faker<ApiProjectContractV2> Contract() => new Faker<ApiProjectContractV2>()
+            .CustomInstantiator(f =>
+            {
+                return new ApiProjectContractV2()
+                {
+                    Id = Guid.NewGuid(),
+                    Company = Company().Generate(),
+                    ContractNumber = f.Finance.Account(10),
+                    Description = f.Lorem.Paragraphs(),
+                    StartDate = f.Date.Past(),
+                    EndDate = f.Date.Future(),
+                    Name = f.Hacker.Phrase()
+                };
+            });
+
+        public static Faker<ApiCompanyV2> Company() => new Faker<ApiCompanyV2>()
+            .RuleFor(c => c.Id, f => Guid.NewGuid())
+            .RuleFor(c => c.Name, f => f.Company.CompanyName());
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Properties/launchSettings.json
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:60197",
+      "sslPort": 44372
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Fusion.Testing.Mocks.OrgService": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Resolvers/OrgResolverMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Resolvers/OrgResolverMock.cs
@@ -1,0 +1,60 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Integration.Org;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fusion.Testing.Mocks.OrgService.Resolvers
+{
+    public class OrgResolverMock : Integration.Org.IProjectOrgResolver
+    {
+        public Task<IEnumerable<ApiBasePositionV2>> GetBasePositionsAsync()
+        {
+            return Task.FromResult(PositionBuilder.AllBasePositions.AsEnumerable());
+        }
+
+        public Task<ApiBasePositionV2> ResolveBasePositionAsync(Guid basePositionId)
+        {
+            var bp = PositionBuilder.AllBasePositions.FirstOrDefault(bp => bp.Id == basePositionId);
+            return Task.FromResult(bp);
+        }
+
+        public Task<ApiBasePositionV2> ResolveBasePositionAsync(string name, OrgProjectType projectType)
+        {
+            var bp = PositionBuilder.AllBasePositions.FirstOrDefault(bp => string.Equals(name, bp.Name, StringComparison.OrdinalIgnoreCase) && string.Equals(projectType.Name, bp.ProjectType));
+            return Task.FromResult(bp);
+        }
+
+        public Task<ApiProjectContractV2> ResolveContractAsync(Guid projectId, Guid contractId)
+        {
+            var contract = OrgServiceMock.contracts.ContainsKey(projectId) ? OrgServiceMock.contracts[projectId].FirstOrDefault(c => c.Id == contractId) : null;
+            return Task.FromResult(contract);
+        }
+
+        public Task<ApiPositionV2> ResolvePositionAsync(Guid positionId)
+        {
+            var pos = OrgServiceMock.positions.Union(OrgServiceMock.contractPositions).FirstOrDefault(p => p.Id == positionId);
+            return Task.FromResult(pos);
+        }
+
+        public Task<IEnumerable<ApiPositionV2>> ResolvePositionsAsync(IEnumerable<Guid> positionIds)
+        {
+            var allPositions = OrgServiceMock.positions.Union(OrgServiceMock.contractPositions).Where(p => positionIds.Contains(p.Id));
+            return Task.FromResult(allPositions.ToList().AsEnumerable());
+        }
+
+        public Task<ApiProjectV2> ResolveProjectAsync(OrgProjectId projectIdentifier)
+        {
+            var resolvedProject = projectIdentifier.Type switch
+            {
+                OrgProjectId.IdentifierType.DomainId => OrgServiceMock.projects.FirstOrDefault(p => string.Equals(p.DomainId, projectIdentifier.DomainId, StringComparison.OrdinalIgnoreCase)),
+                OrgProjectId.IdentifierType.Id => OrgServiceMock.projects.FirstOrDefault(p => p.ProjectId == projectIdentifier.ProjectId),
+                _ => throw new NotImplementedException($"Resolving by type {projectIdentifier.Type} is not implemented in mock")
+            };
+
+            return Task.FromResult(resolvedProject);
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/appsettings.json
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/CompaniesController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/CompaniesController.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using Fusion.AspNetCore.OData;
+
+namespace Fusion.Testing.Mocks.ProfileService.Api
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    public class CompaniesController : ControllerBase
+    {
+        [HttpGet("/companies")]
+        public List<ApiCompanyInfo> ListCompanies([FromQuery] ODataQueryParams @params)
+        {
+            var query = PeopleServiceMock.companies.AsQueryable();
+
+            // Support search
+            if (@params != null && !string.IsNullOrEmpty(@params.Search))
+            {
+                query = query.Where(c => c.Name.Contains(@params.Search));
+            }
+
+            var companies = query.OrderBy(c => c.Name).Select(c => new ApiCompanyInfo
+            {
+                Id = c.Id,
+                Name = c.Name
+            }).ToList();
+
+            return companies;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Models/ApiCompanyInfo.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Models/ApiCompanyInfo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Fusion.Testing.Mocks.ProfileService.Api
+{
+    public class ApiCompanyInfo
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Text;
+using Fusion.Integration.Profile.ApiClient;
+using System.Linq;
+using Fusion.AspNetCore.OData;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Fusion.Testing.Mocks.ProfileService.Api
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    public class PersonsController : ControllerBase
+    {
+        [MapToApiVersion("3.0")]
+        [HttpGet("/persons/{identifier}")]
+        public ActionResult<ApiPersonProfileV3> ResolveProfileV3(string identifier, ODataExpandParams expandParams)
+        {
+            var profile = default(ApiPersonProfileV3);
+
+            if (Guid.TryParse(identifier, out Guid uniqueId))
+                profile = PeopleServiceMock.profiles.FirstOrDefault(p => p.AzureUniqueId == uniqueId);
+            else
+                profile = PeopleServiceMock.profiles.FirstOrDefault(p => p.Mail != null && p.Mail.ToLower() == identifier.ToLower());
+
+            if (profile == null)
+                return NotFound();
+
+            // Must take a copy, as we don't want to change the "database"
+            var copy = JsonConvert.DeserializeObject<ApiPersonProfileV3>(JsonConvert.SerializeObject(profile));
+
+            copy.Roles = copy.Roles ?? new List<ApiPersonRoleV3>();
+            copy.Positions = copy.Positions ?? new List<ApiPersonPositionV3>();
+            copy.Contracts = copy.Contracts ?? new List<ApiPersonContractV3>();
+
+            if (!expandParams.ShouldExpand("roles"))
+                copy.Roles = null;
+                
+
+            if (!expandParams.ShouldExpand("positions"))
+                copy.Positions = null;
+
+            if (!expandParams.ShouldExpand("contracts"))
+                copy.Contracts = null;
+
+            return copy;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Program.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Fusion.Testing.Mocks.ProfileService.Api
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Startup.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/Startup.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Fusion.Testing.Mocks.ProfileService.Api
+{
+    internal class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers()
+                .AddNewtonsoftJson();
+
+            services.AddApiVersioning(s =>
+            {
+                s.ReportApiVersions = true;
+                s.AssumeDefaultVersionWhenUnspecified = true;
+                s.DefaultApiVersion = new ApiVersion(1, 0);
+                s.ApiVersionReader = ApiVersionReader.Combine(new HeaderApiVersionReader(new[] { "api-version" }), new QueryStringApiVersionReader()); // The default is api-version
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+            app.UseApiVersioning();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                //endpoints.MapGet("/", async context =>
+                //{
+                //    await context.Response.WriteAsync("Hello World!");
+                //});
+            });
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="30.0.4" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="3.5.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
+    <PackageReference Include="Fusion.AspNetCore" Version="3.1.7" />
+
+  </ItemGroup>
+  
+</Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/FusionTestProfiles.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/FusionTestProfiles.cs
@@ -1,0 +1,42 @@
+﻿using Bogus;
+using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.ApiClient;
+using System;
+
+namespace Fusion.Testing.Mocks.ProfileService
+{
+
+    public class FusionTestProfiles
+    {
+        public static ApiPersonProfileV3 CreateTestUser(FusionAccountType type, AccountClassification? classification = null)
+        {
+            return CreateTestUser()
+                .RuleFor(x => x.AccountType, type)
+                .RuleFor(x => x.AccountClassification, (f, p) =>
+                {
+                    if (classification != null)
+                        return classification;
+                    else
+                        return type == FusionAccountType.Employee ? AccountClassification.Internal : AccountClassification.External;
+                })
+                .Generate();
+        }
+
+        public static Bogus.Faker<ApiPersonProfileV3> CreateTestUser()
+        {
+            return new Bogus.Faker<ApiPersonProfileV3>()
+                .RuleFor(u => u.AzureUniqueId, f => Guid.NewGuid())
+                .RuleFor(u => u.Department, f => f.Commerce.Department())
+                .RuleFor(u => u.JobTitle, f => f.Name.JobTitle())
+                .RuleFor(u => u.MobilePhone, f => f.Phone.PhoneNumber())
+                .RuleFor(u => u.Mail, f => f.Person.Email)
+                .RuleFor(u => u.Name, f => f.Person.FullName)
+                .RuleFor(u => u.AccountType, f => f.PickRandom<FusionAccountType>())
+                .FinishWith((f, p) =>
+                {
+                    p.UPN = p.Mail;
+                });
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -1,0 +1,86 @@
+﻿using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Testing.Mocks.ProfileService.Api;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Fusion.Testing.Mocks.ProfileService
+{
+    public class PeopleServiceMock
+    {
+        readonly WebApplicationFactory<Startup> factory;
+
+        internal static List<ApiPersonProfileV3> profiles = new List<ApiPersonProfileV3>();
+        internal static List<ApiCompanyInfo> companies = new List<ApiCompanyInfo>();
+
+        public PeopleServiceMock()
+        {
+            factory = new WebApplicationFactory<Startup>();
+        }
+
+        public HttpClient CreateHttpClient()
+        {
+            var client = factory.CreateClient();
+            return client;
+        }
+
+        public static FusionTestUserBuilder AddTestProfile() => new FusionTestUserBuilder();
+        public static void AddCompany(Guid id, string name) => companies.Add(new ApiCompanyInfo { Id = id, Name = name });
+    }
+
+    public class FusionTestUserBuilder
+    {
+        private readonly ApiPersonProfileV3 profile;
+        public FusionTestUserBuilder()
+        {
+            profile = FusionTestProfiles.CreateTestUser();
+        }
+
+        public FusionTestUserBuilder(FusionAccountType type, AccountClassification? classification = null)
+        {
+            profile = FusionTestProfiles.CreateTestUser(type, classification);
+        }
+
+        public FusionTestUserBuilder WithRoles(string name)
+        {
+            if (profile.Roles == null) profile.Roles = new List<ApiPersonRoleV3>();
+
+            profile.Roles.Add(new ApiPersonRoleV3()
+            {
+                Name = name,
+                IsActive = true,
+                SourceSystem = "FusionTesting",
+                Type = ApiFusionRoleType.Global
+            });
+            return this;
+        }
+
+        public FusionTestUserBuilder WithRoles(string name, ApiFusionRoleScopeType scopeType, Guid scopeValue) => WithRoles(name, scopeType, $"{scopeValue}");
+        public FusionTestUserBuilder WithRoles(string name, ApiFusionRoleScopeType scopeType, string scopeValue)
+        {
+            if (profile.Roles == null) profile.Roles = new List<ApiPersonRoleV3>();
+
+            profile.Roles.Add(new ApiPersonRoleV3()
+            {
+                Name = name,
+                SourceSystem = "FusionTesting",
+                Type = ApiFusionRoleType.Scoped,
+                Scope = new ApiPersonRoleScopeV3()
+                {
+                    Type = scopeType,
+                    Value = scopeValue
+                }
+            });
+            return this;
+        }
+    
+        public ApiPersonProfileV3 SaveProfile()
+        {
+            PeopleServiceMock.profiles.Add(profile);
+            return profile;
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Properties/launchSettings.json
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:59457",
+      "sslPort": 44387
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Fusion.Testing.Mocks.ProfileService": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/appsettings.json
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
- [x] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Fixed contract list endpoint for project, which did not display contracts where the user is only delegated admin (without having a position).

Added new endpoints to facilitate deleting positions. This is done to prevent users having edit permissions directly in the org chart, which would give them the rights to add whomever they want without going through the requests.

Added options endpoint to check if the user have access to delete positions inside a contract.

Started adding a pilot for integration testing support for integration lib. These projects will be moved to packages when they support a majority of the feature and in a usefull syntax.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

USing postman, add a position in a contract and remove it using /projects/{orgProjectId}/contracts/{orgContractId}/mpp/positions/{orgPositionId}


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

