### PR TITLE
Resources - Notifications - RunOnStartup = false

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notification.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notification.cs
@@ -26,7 +26,7 @@ namespace Fusion.Resources.Functions
 
         [Singleton]
         [FunctionName("sent-notifications-cleanup")]
-        public async Task CleanupSentNotifications([TimerTrigger("0 0 0 * * *", RunOnStartup = true)] TimerInfo timer, ILogger log)
+        public async Task CleanupSentNotifications([TimerTrigger("0 0 0 * * *", RunOnStartup = false)] TimerInfo timer, ILogger log)
         {
             var dateCutoff = DateTime.Today.AddDays(-1);
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Damn, forgot the old runOnStartup.


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

