### PR TITLE
Api versioning and swagger improvements

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -37,8 +37,18 @@ namespace Fusion.Resources.Api
                 });
 
 
+            services.AddApiVersioning(s =>
+            {
+                s.ReportApiVersions = true;
+                s.AssumeDefaultVersionWhenUnspecified = true;
+                s.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
+                s.ApiVersionReader = new Fusion.AspNetCore.Mvc.Versioning.HeaderOrQueryVersionReader("api-version");
+            });
+
             services.AddHttpContextAccessor();
             services.AddSwagger(Configuration);
+
+            
 
 
             // Configure fusion integration

--- a/src/backend/api/Fusion.Resources.Api/Swagger/AddApiVersionParameter.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/AddApiVersionParameter.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class AddApiVersionParameter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var version = context.ApiDescription.GetApiVersion() ?? new AspNetCore.Mvc.ApiVersion(1, 0);
+
+            var apiVersionParam = new OpenApiParameter()
+            {
+                Name = "api-version",
+                Required = true,
+                In = ParameterLocation.Query
+            };
+            apiVersionParam.Example = new OpenApiString(version.ToString());
+
+            operation.Parameters.Add(apiVersionParam);
+                
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/FusionSwaggerConfig.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/FusionSwaggerConfig.cs
@@ -1,0 +1,48 @@
+﻿using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class FusionSwaggerConfig
+    {
+        internal static bool UseFusionSwaggerSetup = false;
+
+        internal Action<SwaggerGenOptions>? SetupAction { get; private set; }
+        internal List<int> EnabledVersions { get; } = new List<int>();
+        internal bool AddPreviewEndpoints { get; private set; }
+
+        internal FusionSwaggerConfig()
+        {
+            UseFusionSwaggerSetup = true;
+        }
+
+
+        public FusionSwaggerConfig AddApiVersion(int majorVersion)
+        {
+            EnabledVersions.Add(majorVersion);
+            return this;
+        }
+
+        public FusionSwaggerConfig AddApiPreview()
+        {
+            AddPreviewEndpoints = true;
+            return this;
+        }
+
+        public FusionSwaggerConfig ConfigureSwaggerGen(Action<SwaggerGenOptions> swaggerSetup)
+        {
+            SetupAction = swaggerSetup;
+            return this;
+        }
+
+        public FusionSwaggerConfig ForceStringConverter<TModel>()
+        {
+            TypeConverterAttribute typeConverterAttribute = new TypeConverterAttribute(typeof(ToStringTypeConverter));
+            TypeDescriptor.AddAttributes(typeof(TModel), typeConverterAttribute);
+
+            return this;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/ODataQueryParamSwaggerFilter.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/ODataQueryParamSwaggerFilter.cs
@@ -1,0 +1,51 @@
+﻿using Fusion.AspNetCore.OData;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Replace any params of the type ODataQueryParam, with the $-query params.
+    /// </summary>
+    public class ODataQueryParamSwaggerFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            foreach (var path in swaggerDoc.Paths)
+            {
+                foreach (var op in path.Value.Operations)
+                {
+                    var @params = op.Value.Parameters.ToList();
+
+                    var pathParams = @params.Where(p => p.In == ParameterLocation.Query).ToList();
+
+                    var odataQueryParam = pathParams.Where(p => p.Schema != null && p.Schema.Reference != null)
+                        .FirstOrDefault(p => p.Schema.Reference.Id == nameof(ODataQueryParams));
+
+                    if (odataQueryParam != null)
+                    {
+                        op.Value.Parameters.Remove(odataQueryParam);
+
+                        op.Value.Parameters.Add(new OpenApiParameter
+                        {
+                            Name = "$expand",
+                            In = ParameterLocation.Query,
+                            Description = "Comma seperated list of properties to include",
+                            AllowEmptyValue = true
+                        });
+
+                        op.Value.Parameters.Add(new OpenApiParameter
+                        {
+                            Name = "$filter",
+                            In = ParameterLocation.Query,
+                            Description = "OData query filter",
+                            AllowEmptyValue = true,
+                            AllowReserved = true
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/OptionalRouteParamFilter.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/OptionalRouteParamFilter.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Linq;
+
+namespace Fusion.Resources.Api.Swagger
+{
+    /// <summary>
+    /// Swagger document filter to post-process all the routes, and remove required path params found in controller action, but not in the route. 
+    /// This supports the scenario where one action support multiple routes, where some params can be null.
+    /// </summary>
+    public class OptionalRouteParamFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            foreach (var path in swaggerDoc.Paths)
+            {
+                var route = Microsoft.AspNetCore.Routing.Template.TemplateParser.Parse(path.Key);
+                var parameters = route.Parameters.Where(p => p.IsParameter).Select(p => p.Name);
+
+                foreach (var operation in path.Value.Operations.Values)
+                {
+                    var routeParamsToRemove = operation.Parameters
+                        .Where(p => p.In == ParameterLocation.Path)
+                        .Where(p => !parameters.Any(routeParam => string.Equals(routeParam, p.Name, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+
+                    routeParamsToRemove.ForEach(r => operation.Parameters.Remove(r));
+                }
+            }
+
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/StartupExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/StartupExtensions.cs
@@ -1,13 +1,11 @@
 ﻿using Fusion.Resources.Api.Controllers;
+using Fusion.Resources.Api.Swagger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -15,94 +13,32 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddSwagger(this IServiceCollection services, IConfiguration config)
         {
-            var tenantId = config.GetValue<string>("Swagger:TenantId");
 
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("resources-api-v1", new OpenApiInfo { Title = "Fusion Resources API", Version = "1.0" });
-                c.OperationFilter<SecurityRequirementsOperationFilter>();
-                c.DocumentFilter<SwaggerComplexRouteShitfix>();
-                c.MapType<ProjectIdentifier>(() => new OpenApiSchema { Type = typeof(string).Name  });
-                c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme()
+            services.AddSwagger(config, "Fusion Resources API", swagger => swagger
+                .AddApiVersion(1)
+
+                // When promoting endpoints, add new version to update the version dropdown 
+                //.AddApiVersion(2)
+
+                .AddApiPreview()
+                .ForceStringConverter<ProjectIdentifier>()
+                .ConfigureSwaggerGen(s =>
                 {
-                    In = ParameterLocation.Header,
-                    Name = "Authorization",
-                    Description = "Azure Active Directory",
-                    Flows = new OpenApiOAuthFlows()
-                    {
-                        Implicit = new OpenApiOAuthFlow
-                        {
-                            AuthorizationUrl = new Uri($"https://login.microsoftonline.com/{tenantId}/oauth2/authorize"),
-                            TokenUrl = new Uri($"https://login.microsoftonline.com/{tenantId}/oauth2/token"),
-                        }
-                    },
-                    Type = SecuritySchemeType.OAuth2
-                });
+                    s.MapType<ProjectIdentifier>(() => new OpenApiSchema { Type = "string", Description = "Org project id or context id" });
 
-                var securityRequirement = new OpenApiSecurityRequirement();
-                securityRequirement.Add(new OpenApiSecurityScheme
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Id = "oauth2",
-                        Type = ReferenceType.SecurityScheme
-                    }
-                }, new List<string>());
-
-                c.AddSecurityRequirement(securityRequirement);
-            });
+                    s.DocumentFilter<OptionalRouteParamFilter>();
+                }));
 
             return services;
         }
 
         public static IApplicationBuilder UseResourcesApiSwagger(this IApplicationBuilder app, IConfiguration configuration)
         {
-            app.UseSwagger();
-
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/resources-api-v1/swagger.json", "Fusion Resources API 1.0");
-
-                c.OAuthAppName(configuration.GetValue<string>("Swagger:OAuthAppName"));
-                c.OAuthClientId(configuration.GetValue<string>("Swagger:ClientId"));
-                c.OAuthRealm(configuration.GetValue<string>("Swagger:TenantId"));
-                c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>() { { "resource", configuration.GetValue<string>("Swagger:Resource") } });
-            });
+            app.UseFusionSwagger();
 
             return app;
         }
 
     }
 
-
-
-    public class SwaggerComplexRouteShitfix : IDocumentFilter
-    {
-        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
-        {
-            var projectIdentifier = typeof(ProjectIdentifier);
-            var props = projectIdentifier.GetProperties().Select(p => p.Name);
-
-            foreach (var path in swaggerDoc.Paths)
-            {
-                foreach (var op in path.Value.Operations)
-                {
-                    var @params = op.Value.Parameters.ToList();
-
-                    var pathParams = @params.Where(p => p.In == ParameterLocation.Path).ToList();
-                    
-
-                    if (props.All(p => pathParams.Any(pp => pp.Name == p)))
-                    {
-                        var paramsToRemove = pathParams.Where(pp => props.Contains(pp.Name)).ToList();
-
-                        foreach (var toRemove in paramsToRemove)
-                        {
-                            op.Value.Parameters.Remove(toRemove);
-                        }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerApiConfig.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerApiConfig.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class SwaggerApiConfig
+    {
+        public string Title { get; set; } = null!;
+        public List<int> EnabledVersions { get; } = new List<int>();
+        public bool EnablePreview { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerSetup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerSetup.cs
@@ -1,0 +1,149 @@
+﻿using Fusion.AspNetCore.OData;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Filters;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+
+    public static class SwaggerSetup
+    {
+        public static IServiceCollection AddSwagger(this IServiceCollection services, IConfiguration configuration, string title, Action<FusionSwaggerConfig> fusionSwaggerSetup)
+        {
+            var tenantId = configuration.GetValue<string>("Swagger:TenantId");
+
+            var setupBuilder = new FusionSwaggerConfig();
+            fusionSwaggerSetup(setupBuilder);
+
+            services.Configure<SwaggerApiConfig>(c =>
+            {
+                c.Title = title;
+                c.EnabledVersions.AddRange(setupBuilder.EnabledVersions);
+                c.EnablePreview = setupBuilder.AddPreviewEndpoints;
+            });
+
+
+            services.AddSwaggerGen(c =>
+            {
+
+                foreach (var version in setupBuilder.EnabledVersions)
+                    c.SwaggerDoc($"api-v{version}", new OpenApiInfo { Title = title, Version = $"{version}.0" });
+
+                if (setupBuilder.AddPreviewEndpoints)
+                    c.SwaggerDoc($"api-beta", new OpenApiInfo { Title = title, Version = $"Previews" });
+
+                setupBuilder.SetupAction?.Invoke(c);
+
+                // Only add endpoints that belongs to the version spec
+                c.DocInclusionPredicate((version, desc) =>
+                {
+                    var v = desc.GetApiVersion() ?? new ApiVersion(1, 0);
+
+                    if (int.TryParse(version.Split("-")[1].Substring(1), out int major))
+                    {
+                        return v.MajorVersion == major && v.Status == null;
+                    }
+
+                    if (version == "api-beta")
+                    {
+                        return v.Status != null;
+                    }
+
+                    return true;
+                });
+                c.OperationFilter<SecurityRequirementsOperationFilter>();
+                c.OperationFilter<AddApiVersionParameter>();
+
+                c.DocumentFilter<ODataQueryParamSwaggerFilter>();
+
+                c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme()
+                {
+                    In = ParameterLocation.Header,
+                    Name = "Authorization",
+                    Description = "Azure Active Directory",
+                    Flows = new OpenApiOAuthFlows()
+                    {
+                        Implicit = new OpenApiOAuthFlow
+                        {
+                            AuthorizationUrl = new Uri($"https://login.microsoftonline.com/{tenantId}/oauth2/authorize"),
+                            TokenUrl = new Uri($"https://login.microsoftonline.com/{tenantId}/oauth2/token"),
+                        }
+                    },
+                    Type = SecuritySchemeType.OAuth2
+                });
+
+                var securityRequirement = new OpenApiSecurityRequirement();
+                securityRequirement.Add(new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Id = "oauth2",
+                        Type = ReferenceType.SecurityScheme
+                    }
+                }, new List<string>());
+
+                c.AddSecurityRequirement(securityRequirement);
+            });
+
+            TypeConverterAttribute typeConverterAttribute = new TypeConverterAttribute(typeof(ToStringTypeConverter));
+            TypeDescriptor.AddAttributes(typeof(ODataQueryParams), typeConverterAttribute);
+
+            return services;
+        }
+
+        public static IApplicationBuilder UseFusionSwagger(this IApplicationBuilder app)
+        {
+            if (FusionSwaggerConfig.UseFusionSwaggerSetup == false)
+                return app;
+
+            var instanceConfig = app.ApplicationServices.GetService<IOptions<SwaggerApiConfig>>();
+            var configuration = app.ApplicationServices.GetRequiredService<IConfiguration>();
+
+            app.UseSwagger();
+
+            app.UseSwaggerUI(c =>
+            {
+                if (instanceConfig != null)
+                {
+                    foreach (var version in instanceConfig.Value.EnabledVersions)
+                        c.SwaggerEndpoint($"/swagger/api-v{version}/swagger.json", $"v{version}.0");
+
+                    if (instanceConfig.Value.EnablePreview)
+                        c.SwaggerEndpoint($"/swagger/api-beta/swagger.json", $"Previews");
+                }
+
+                c.OAuthAppName(configuration.GetValue<string>("Swagger:OAuthAppName"));
+                c.OAuthClientId(configuration.GetValue<string>("Swagger:ClientId"));
+                c.OAuthRealm(configuration.GetValue<string>("Swagger:TenantId"));
+                c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>() { { "resource", configuration.GetValue<string>("Swagger:Resource") } });
+            });
+
+            return app;
+        }
+
+        public static ApiVersion? GetApiVersion(this ApiDescription apiDescription)
+        {
+            var thisVersionProp = apiDescription.ActionDescriptor.Properties.FirstOrDefault(prop => (Type)prop.Key == typeof(ApiVersionModel));
+            var thisVersionValue = thisVersionProp.Value as ApiVersionModel;
+            var thisDeclaredVersion = thisVersionValue?.DeclaredApiVersions.OrderByDescending(p => p).FirstOrDefault();
+
+            if (thisDeclaredVersion != null)
+                return thisDeclaredVersion;
+
+            return thisVersionValue?.ImplementedApiVersions.OrderByDescending(p => p).FirstOrDefault();
+        }
+
+
+
+
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Swagger/ToStringTypeConverter.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/ToStringTypeConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Type converter to make asp.net core convert the complext type to a string. 
+    /// This is usefull when the framework explodes complext types in either query or route, when it is in reality a string that is bound by logic.
+    /// 
+    /// Ref:
+    /// https://blog.magnusmontin.net/2020/04/03/custom-data-types-in-asp-net-core-web-apis/
+    /// https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/456
+    /// </summary>
+    public class ToStringTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+
+    }
+}


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added api versioning support with default 1.0. This should let all existing endpoints work as execpted without having to provide a `?api-version=` param.

As uasability of swagger degrades when version is added, as the query param is not defined anywhere, we must add support for this by manipulating the output through swagger filters.
This filter adds a api-version query param to all endpoints and sets default value for a specific document. This means different versions must be added to different documents.

By making pages for different versions the usability of swagger ui improves, however using swagger to generate clients etc could see a 'hit'.

Also added swagger filters to make the complex models used in odata filtering usable, like removing the properties and replacing with a single `$filter` query string.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~

Open swagger for pr api.


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

