### PR TITLE
Resources - Internal Requests - GetRequests doesn't expand orgPosition data when expected

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -104,12 +104,13 @@ namespace Fusion.Resources.Domain.Queries
 
                 foreach (var queryResourceAllocationRequest in requestItems)
                 {
-                    if (queryResourceAllocationRequest.OrgPosition == null) continue;
+                    if (queryResourceAllocationRequest.OrgPositionId == null) continue;
 
-                    var originalPosition = resolvedOrgChartPositions.FirstOrDefault(p =>
-                        p.Id == queryResourceAllocationRequest.OrgPosition.Id);
-                    if (originalPosition != null)
-                        queryResourceAllocationRequest.WithResolvedOriginalPosition(queryResourceAllocationRequest.OrgPosition, queryResourceAllocationRequest.OrgPositionInstanceId);
+                    var position = resolvedOrgChartPositions.FirstOrDefault(p =>
+                        p.Id == queryResourceAllocationRequest.OrgPositionId);
+
+                    if (position != null)
+                        queryResourceAllocationRequest.WithResolvedOriginalPosition(position, queryResourceAllocationRequest.OrgPositionInstanceId);
                 }
 
                 return requestItems;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -150,6 +150,34 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task GetProjectRequestsExpanded_AdminRole_ShouldBe_Authorized()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var r = await Client.TestClientPostAsync($"/projects/{testRequest.Project.ProjectId}/requests", testRequest.Request, new { Id = Guid.Empty });
+                r.Should().BeSuccessfull();
+            }
+
+            var plainList = await Client.TestClientGetAsync<PagedCollection<ResourceAllocationRequestTestModel>>($"/projects/{testRequest.Project.ProjectId}/requests");
+            plainList.Should().BeSuccessfull();
+            foreach (var m in plainList.Value.Value)
+            {
+                m.OrgPosition.Should().BeNull();
+            }
+
+            var expandedList = await Client.TestClientGetAsync<PagedCollection<ResourceAllocationRequestTestModel>>($"/projects/{testRequest.Project.ProjectId}/requests?$expand=orgPosition");
+
+            expandedList.Should().BeSuccessfull();
+            foreach (var m in expandedList.Value.Value)
+            {
+                m.OrgPosition.Should().NotBeNull();
+            }
+
+        }
+
+        [Fact]
         public async Task GetRequest_AdminRole_ShouldBe_Authorized()
         {
             using var adminScope = fixture.AdminScope();
@@ -263,8 +291,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             public string Discipline { get; set; }
             public ObjectWithId Project { get; set; }
             public string Type { get; set; }
-            public ObjectWithId OrgPosition { get; set; }
-            public ObjectWithId OrgPositionInstance { get; set; }
+            public ObjectWithId? OrgPosition { get; set; }
+            public ObjectWithId? OrgPositionInstance { get; set; }
             public string AdditionalNote { get; set; }
             public bool? IsDraft { get; set; }
             public Dictionary<string, object> ProposedChanges { get; set; }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Expanding orgPosition used the wrong property, and didn't expand.
Switched to id



**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Updated tests to check if expansion work


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

