### PR TITLE
Resources - Change route for internal requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -124,7 +124,7 @@ namespace Fusion.Resources.Api.Controllers
             }
         }
 
-        [HttpPut("/resources/internal-requests/requests/{requestId}")]
+        [HttpPut("/resources/requests/internal/{requestId}")]
         [HttpPut("/projects/{projectIdentifier}/requests/{requestId}")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> UpdateProjectAllocationRequest(
             [FromRoute] ProjectIdentifier? projectIdentifier, Guid requestId,
@@ -224,7 +224,7 @@ namespace Fusion.Resources.Api.Controllers
         }
 
 
-        [HttpGet("/resources/internal-requests/requests")]
+        [HttpGet("/resources/requests/internal")]
         [HttpGet("/projects/{projectIdentifier}/requests")]
         public async Task<ActionResult<ApiCollection<ApiResourceAllocationRequest>>> GetResourceAllocationRequestsForProject(
             [FromRoute] ProjectIdentifier? projectIdentifier, [FromQuery] ODataQueryParams query)
@@ -256,7 +256,7 @@ namespace Fusion.Resources.Api.Controllers
             return new ApiCollection<ApiResourceAllocationRequest>(apiModel);
         }
 
-        [HttpGet("/resources/internal-requests/requests/{requestId}")]
+        [HttpGet("/resources/requests/internal/{requestId}")]
         [HttpGet("/projects/{projectIdentifier}/requests/{requestId}")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> GetResourceAllocationRequest(Guid requestId)
         {
@@ -284,7 +284,7 @@ namespace Fusion.Resources.Api.Controllers
             return new ApiResourceAllocationRequest(result);
         }
 
-        [HttpDelete("/resources/internal-requests/requests/{requestId}")]
+        [HttpDelete("/resources/requests/internal/{requestId}")]
         [HttpDelete("/projects/{projectIdentifier}/requests/{requestId}")]
         public async Task<ActionResult> DeleteProjectAllocationRequest(Guid requestId)
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -185,7 +185,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task Get_InternalRequest_ShouldBeAuthorized()
         {
             using var adminScope = fixture.AdminScope();
-            var response = await Client.TestClientGetAsync<ResourceAllocationRequestTestModel>($"/resources/internal-requests/requests/{normalRequest.Request.Id}");
+            var response = await Client.TestClientGetAsync<ResourceAllocationRequestTestModel>($"/resources/requests/internal/{normalRequest.Request.Id}");
             response.Should().BeSuccessfull();
 
             AssertPropsAreEqual(response.Value, normalRequest.Request, adminScope);
@@ -194,7 +194,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task Get_InternalRequests_ShouldBeAuthorized()
         {
             using var adminScope = fixture.AdminScope();
-            var response = await Client.TestClientGetAsync<PagedCollection<ResourceAllocationRequestTestModel>>($"/resources/internal-requests/requests");
+            var response = await Client.TestClientGetAsync<PagedCollection<ResourceAllocationRequestTestModel>>($"/resources/requests/internal");
             response.Should().BeSuccessfull();
 
             response.Value.Value.Count().Should().BeGreaterThan(0);
@@ -255,7 +255,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 ProposedPersonAzureUniqueId = normalRequest.Request.ProposedPersonAzureUniqueId
             };
 
-            var response = await Client.TestClientPutAsync<ResourceAllocationRequestTestModel>($"/resources/internal-requests/requests/{normalRequest.Request.Id}", updateRequest);
+            var response = await Client.TestClientPutAsync<ResourceAllocationRequestTestModel>($"/resources/requests/internal/{normalRequest.Request.Id}", updateRequest);
             response.Should().BeSuccessfull();
 
             AssertPropsAreEqual(response.Value, updateRequest, adminScope);
@@ -266,7 +266,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             using var adminScope = fixture.AdminScope();
             var updateRequest = new UpdateResourceAllocationRequest();
-            var response = await Client.TestClientPutAsync<ResourceAllocationRequestTestModel>($"/resources/internal-requests/requests/{normalRequest.Request.Id}", updateRequest);
+            var response = await Client.TestClientPutAsync<ResourceAllocationRequestTestModel>($"/resources/requests/internal/{normalRequest.Request.Id}", updateRequest);
             response.Value.Updated.Should().BeNull();
         }
         #endregion


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Revisited routes. Mismatching occured.
Base is now: /resources/requests/internal


**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

changed routes in tests


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

