### PR TITLE
Internal requests - Endpoint returning count of unassigned requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -225,6 +225,27 @@ namespace Fusion.Resources.Api.Controllers
             }
         }
 
+        [HttpGet("/resources/requests/internal/unassigned")]
+        public async Task<ActionResult<int>> GetResourceAllocationRequestsUnassignedCount([FromQuery] bool? isDraft)
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal();
+                r.AnyOf(or =>
+                {
+
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            return await DispatchAsync(new GetResourceAllocationRequestsUnassignedCount(isDraft));
+        }
 
         [HttpGet("/resources/requests/internal")]
         [HttpGet("/projects/{projectIdentifier}/requests")]
@@ -457,7 +478,7 @@ namespace Fusion.Resources.Api.Controllers
                 return authResult.CreateForbiddenResponse();
 
             #endregion
-            
+
             var comment = await DispatchAsync(new AddComment(User.GetRequestOrigin(), requestId, create.Content));
 
             return Created($"/resources/requests/internal/{requestId}/comments/{comment.Id}", new ApiRequestComment(comment));

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestsUnassignedCount.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestsUnassignedCount.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using Fusion.Resources.Database;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fusion.Resources.Domain.Queries
+{
+    public class GetResourceAllocationRequestsUnassignedCount : IRequest<int>
+    {
+        public GetResourceAllocationRequestsUnassignedCount(bool? isDraft)
+        {
+            IsDraft = isDraft;
+        }
+
+        public bool? IsDraft { get; }
+
+
+        public class Handler : IRequestHandler<GetResourceAllocationRequestsUnassignedCount, int>
+        {
+            private readonly ResourcesDbContext db;
+
+            public Handler(ResourcesDbContext db)
+            {
+                this.db = db;
+            }
+
+            public async Task<int> Handle(GetResourceAllocationRequestsUnassignedCount request, CancellationToken cancellationToken)
+            {
+                var query = db.ResourceAllocationRequests
+                    .Where(x => string.IsNullOrEmpty(x.AssignedDepartment))
+                    .AsQueryable();
+
+                if (request.IsDraft.HasValue)
+                    query = query.Where(x => x.IsDraft == request.IsDraft.Value);
+
+                return await query.CountAsync();
+            }
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -218,12 +218,20 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         }
         [Fact]
+        public async Task Get_UnassignedInternalRequest_ShouldBeAuthorized()
+        {
+            using var adminScope = fixture.AdminScope();
+            var response = await Client.TestClientGetAsync<int>($"/resources/requests/internal/unassigned");
+            response.Should().BeSuccessfull();
+
+        }
+        [Fact]
         public async Task Get_InternalRequest_ShouldBeAuthorized()
         {
             using var adminScope = fixture.AdminScope();
             var response = await Client.TestClientGetAsync<ResourceAllocationRequestTestModel>($"/resources/requests/internal/{normalRequest.Request.Id}?$expand=comments");
             response.Should().BeSuccessfull();
-            
+
             // Test comment expansion
             response.Value.Comments!.Count().Should().BeGreaterOrEqualTo(1);
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Returns a count of unassigned requests.
Requests without assigned departments.

Can pass optional queryString argument isDraft to distinct between requests in draft or not.
Default counts all unassigned requests

/resources/requests/internal/unassigned?isdraft=false
/resources/requests/internal/unassigned?isdraft=true
/resources/requests/internal/unassigned


**Testing:**
- [ ] ~~Can be tested~~
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [ ] Checklist finalized / ready for review

