### PR TITLE
Resources - Not able to re-certify outdated delegate

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Commands/Roles/RecertifyContractReadRoleAssignment.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Roles/RecertifyContractReadRoleAssignment.cs
@@ -53,7 +53,7 @@ namespace Fusion.Resources.Domain.Commands
                     telemetryClient.TrackTrace("Role was not found when trying to update. It must have expired - creating new...");
 
                     // If the role was not updated, it might have expired or not been created - ensure new exists.
-                    await mediator.Publish(new CreateContractReadRoleAssignment(notification.DelegatedRoleId));
+                    await mediator.Send(new CreateContractReadRoleAssignment(notification.DelegatedRoleId));
                 }                
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Internally in backend services code was using mediator.Publish instead of mediator.Send for a command.
Publish is used for Notifications
Send is used for Requests

CreateContractReadRoleAssignment is a Request, and since it was "Published" the handler expected was missing.
Using Send should utilize the request handler.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

