### PR TITLE
Resources - PeopleCompanyResolver cache duration

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Services/PeopleCompanyResolver.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/PeopleCompanyResolver.cs
@@ -22,7 +22,7 @@ namespace Fusion.Resources.Domain.Services
         {
             this.client = httpClientFactory.CreateClient("FusionClient.People.Application");
             
-            cacheRestTimer = new Timer((state) => companies = null, null, TimeSpan.FromHours(12), TimeSpan.FromHours(12));
+            cacheRestTimer = new Timer((state) => companies = null, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
         }
 
         public void Dispose()


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Existing resolver caches data for 12 hours. 
If a new company is added we may have to wait 12 hours until it is available.

Reduce cache time from 12 hours to 5 minutes


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

