### PR TITLE
Handle serialized null value in proposedChanges

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -99,14 +99,18 @@ namespace Fusion.Resources.Domain
                 if (ProposedChangesJson is null)
                     return new Dictionary<string, object>();
 
+                Dictionary<string, object>? value = null;
+
                 try
                 {
-                    return JsonSerializer.Deserialize<Dictionary<string, object>>(ProposedChangesJson)!;
+                    value = JsonSerializer.Deserialize<Dictionary<string, object>>(ProposedChangesJson);
                 }
-                catch
+                catch (JsonException)
                 {
-                    return new Dictionary<string, object>();
+                    // Invalid JSON?
                 }
+
+                return value ?? new Dictionary<string, object>();
             }
         }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -556,6 +556,22 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeBadRequest();
         }
 
+        [Fact]
+        public async Task CreateRequest_ShouldBeCreated_WhenProposedChangesIsNull()
+        {
+            using var adminScope = fixture.AdminScope();
+            var position = testProject.AddPosition();
+
+            var response = await Client.TestClientPostAsync($"/projects/{projectId}/requests", new
+            {
+                type = "Normal",
+                orgPositionId = position.Id,
+                orgPositionInstanceId = position.Instances.First().Id,
+                proposedPersonAzureUniqueId = this.testUser.AzureUniqueId!.Value
+            }, new { Id = Guid.Empty });
+
+            response.Should().BeSuccessfull();
+        }
         #endregion
     }
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Correctly set proposedChanges to empty dictionary when value from db is a serialized null value ("null"). Solving it here will also handle values that are already in the database.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

