### PR TITLE
Removed completed requests from the unassigned request list

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -175,6 +175,7 @@ namespace Fusion.Resources.Api.Controllers
             var requestCommand = new GetResourceAllocationRequests(query)
                 .ForResourceOwners()
                 .WithUnassignedFilter(true)
+                .WithExcludeCompleted(true)
                 .WithOnlyCount(countEnabled);
 
             var result = await DispatchAsync(requestCommand);

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -60,6 +60,12 @@ namespace Fusion.Resources.Domain.Queries
         //    return this;
         //}
 
+        public GetResourceAllocationRequests WithExcludeCompleted(bool exclude = false)
+        {
+            ExcludeCompleted = exclude;
+            return this;
+        }
+
         public GetResourceAllocationRequests ForResourceOwners()
         {
             Owner = DbInternalRequestOwner.ResourceOwner;
@@ -76,6 +82,7 @@ namespace Fusion.Resources.Domain.Queries
         public bool Unassigned { get; private set; }
         public bool OnlyCount { get; private set; }
         public bool? ExcludeDrafts { get; private set; }
+        public bool? ExcludeCompleted { get; private set; }
 
         private DbInternalRequestOwner? Owner { get; set; }
 
@@ -124,6 +131,8 @@ namespace Fusion.Resources.Domain.Queries
 
                 //if (request.ExcludeDrafts.HasValue && request.ExcludeDrafts.Value)
                 //    query = query.Where(c => c.IsDraft == false);
+                if (request.ExcludeCompleted.GetValueOrDefault(false))
+                    query = query.Where(c => c.State.IsCompleted == false);
 
                 if (request.Query.HasFilter)
                 {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -109,5 +109,27 @@ namespace Fusion.Resources.Api.Tests
 
             return resp.Value;
         }
+
+        public static async Task ProvisionRequestAsync(this HttpClient client, Guid requestId)
+        {
+            var resp = await client.TestClientPostAsync<object>($"/resources/requests/internal/{requestId}/provision", null);
+            resp.Should().BeSuccessfull();
+        }
+
+        public static async Task<TestApiInternalRequestModel> TaskOwnerApproveAsync(this HttpClient client, FusionTestProjectBuilder project, Guid requestId)
+        {
+            var resp = await client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{project.Project.ProjectId}/resources/requests/{requestId}/approve", null);
+            resp.Should().BeSuccessfull();
+
+            return resp.Value;
+        }
+
+        public static async Task<TestApiInternalRequestModel> ResourceOwnerApproveAsync(this HttpClient client, string department, Guid requestId)
+        {
+            var resp = await client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{department}/resources/requests/{requestId}/approve", null);
+            resp.Should().BeSuccessfull();
+
+            return resp.Value;
+        }
     }
 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -65,6 +65,28 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         }
 
+        [Fact]
+        public async Task GetUnassigned_ShouldNotBeIncluded_WhenCompleted()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var testPerson = fixture.AddProfile(FusionAccountType.Employee);
+
+            var testRequest = await Client.CreateDefaultRequestAsync(testProject);
+            await Client.StartProjectRequestAsync(testProject, testRequest.Id);
+            await Client.ProposePersonAsync(testRequest.Id, testPerson);
+            await Client.ResourceOwnerApproveAsync(InternalRequestData.RandomDepartment, testRequest.Id);
+            await Client.TaskOwnerApproveAsync(testProject, testRequest.Id);
+            await Client.ProvisionRequestAsync(testRequest.Id);
+
+            var list = await Client.TestClientGetAsync($"/resources/requests/internal/unassigned", new
+            {
+                value = new[] { new { id = Guid.Empty } }
+            });
+
+            list.Value.value.Should().NotContain(r => r.id == testRequest.Id);
+        }
+
         #region GetDeparmentRequests
 
         [Fact]


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added forced filter, which removed completed requests from the unassigned list. These might be unassigned but is not really relevant to list here.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Can verify in api, as there should be some completed unallocated requests


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

