### PR TITLE
Updated department personnel query and allocation metadata

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
@@ -20,6 +20,7 @@ namespace Fusion.Resources.Api.Controllers
             OfficeLocation = p.OfficeLocation;
             Department = p.Department!;
             FullDepartment = p.FullDepartment!;
+            IsResourceOwner = p.IsResourceOwner;
 
             if (p.Timeline != null) Timeline = p.Timeline.Select(ti => new TimelineRange(ti)).ToList();
 
@@ -42,6 +43,7 @@ namespace Fusion.Resources.Api.Controllers
         public string? OfficeLocation { get; set; }
         public string Department { get; set; }
         public string FullDepartment { get; set; }
+        public bool IsResourceOwner { get; set; }
 
         /// <summary>
         /// Enum, <see cref="FusionAccountType"/>.
@@ -109,6 +111,9 @@ namespace Fusion.Resources.Api.Controllers
                 Name = pos.Name;
                 Location = pos.Location;
                 Workload = pos.Workload;
+                AllocationState = pos.AllocationState;
+                AllocationUpdated = pos.AllocationUpdated;
+
                 Project = new ApiProjectReference(pos.Project);
                 BasePosition = new ApiBasePosition(pos.BasePosition);
             }
@@ -121,6 +126,8 @@ namespace Fusion.Resources.Api.Controllers
             public ApiBasePosition BasePosition { get; set; } = null!;
             public string Name { get; set; } = null!;
             public string? Location { get; set; }
+            public string? AllocationState { get; set; }
+            public DateTime? AllocationUpdated { get; set; }
 
             public bool IsActive => AppliesFrom >= DateTime.UtcNow.Date && AppliesTo >= DateTime.UtcNow.Date;
             public double Workload { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryInternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryInternalPersonnelPerson.cs
@@ -39,6 +39,6 @@ namespace Fusion.Resources.Domain
         public List<QueryTimelineRange<QueryPersonnelTimelineItem>>? Timeline { get; set; }
         public List<QueryPersonnelPosition> PositionInstances { get; set; }
         public List<QueryPersonAbsenceBasic> Absence { get; set; }
-
+        public bool IsResourceOwner { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelPosition.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelPosition.cs
@@ -16,5 +16,12 @@ namespace Fusion.Resources.Domain
         public bool IsActive => AppliesFrom >= DateTime.UtcNow.Date && AppliesTo >= DateTime.UtcNow.Date;
         public double Workload { get; set; }
         public QueryProjectRef Project { get; set; } = null!;
+
+        /// <summary>
+        /// Indicates that the allocation has been changed outside approved channels.
+        /// Null or "ChangedByTaskOwner". 
+        /// </summary>
+        public string? AllocationState { get; set; }
+        public DateTime? AllocationUpdated { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -22,14 +22,16 @@ namespace Fusion.Resources.Domain
 
     public class QueryProjectRef 
     {
-        public QueryProjectRef(Guid orgId, string name, string domainId)
+        public QueryProjectRef(Guid orgId, string name, string domainId, string type)
         {
             OrgProjectId = orgId;
             Name = name;
             DomainId = domainId;
+            Type = type;
         }
         public string Name { get; set; }
         public string DomainId { get; set; }
         public Guid OrgProjectId { get; set; }
+        public string Type { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
@@ -87,7 +87,7 @@ namespace Fusion.Resources.Domain
                 OfficeLocation = i.document.officeLocation,
                 Department = i.document.department,
                 IsResourceOwner = i.document.isResourceOwner,
-                FullDepartment = departments.Where(d => d.EndsWith(i.document.department)).FirstOrDefault(),
+                FullDepartment = i.document.fullDepartment,
                 PositionInstances = i.document.positions.Select(p => new QueryPersonnelPosition
                 {
                     PositionId = p.id,

--- a/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
@@ -16,7 +16,7 @@ namespace Fusion.Resources.Domain
         {
             var response = await peopleClient.PostAsJsonAsync("/search/persons/query", new
             {
-                filter = string.Join(" or ", departments.Select(dep => $"fullDepartment eq '{dep}'")),
+                filter = string.Join(" or ", departments.Select(dep => $"manager/fullDepartment eq '{dep}'")),
                 top = 500
             });
 
@@ -42,6 +42,7 @@ namespace Fusion.Resources.Domain
                             upn = string.Empty,
                             accountType = string.Empty,
                             isExpired = false,
+                            isResourceOwner = false,
 
                             positions = new [] {
                                 new {
@@ -54,11 +55,14 @@ namespace Fusion.Resources.Domain
                                     obs = string.Empty,
                                     locationName = string.Empty,
                                     workload = 0.0,
+                                    allocationState = string.Empty,
+                                    allicationUpdated = (DateTime?)null,
                                     project = new
                                     {
                                         name = string.Empty,
                                         id = Guid.Empty,
-                                        domainId = string.Empty
+                                        domainId = string.Empty,
+                                        type = string.Empty
                                     },
 
                                     basePosition = new
@@ -66,7 +70,7 @@ namespace Fusion.Resources.Domain
                                         id = Guid.Empty,
                                         name = string.Empty,
                                         discipline = string.Empty,
-                                        projectType = string.Empty
+                                        type = string.Empty
                                     }
                                 }
 
@@ -82,6 +86,7 @@ namespace Fusion.Resources.Domain
                 JobTitle = i.document.jobTitle,
                 OfficeLocation = i.document.officeLocation,
                 Department = i.document.department,
+                IsResourceOwner = i.document.isResourceOwner,
                 FullDepartment = departments.Where(d => d.EndsWith(i.document.department)).FirstOrDefault(),
                 PositionInstances = i.document.positions.Select(p => new QueryPersonnelPosition
                 {
@@ -91,9 +96,11 @@ namespace Fusion.Resources.Domain
                     AppliesTo = p.appliesTo!.Value,
                     Name = p.name,
                     Location = p.locationName,
-                    BasePosition = new QueryBasePosition(p.basePosition.id, p.basePosition.name, p.basePosition.discipline, p.basePosition.projectType),
-                    Project = new QueryProjectRef(p.project.id, p.project.name, p.project.domainId),
-                    Workload = p.workload
+                    BasePosition = new QueryBasePosition(p.basePosition.id, p.basePosition.name, p.basePosition.discipline, p.basePosition.type),
+                    Project = new QueryProjectRef(p.project.id, p.project.name, p.project.domainId, p.project.type),
+                    Workload = p.workload,
+                    AllocationState = p.allocationState,
+                    AllocationUpdated = p.allicationUpdated
                 }).OrderBy(p => p.AppliesFrom).ToList()
             }).ToList();
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
As the search index now has the manager property we can query on this property to get the personnel reporting to a department. This will give us a better view as the child department managers have their own department on the profile.
Added display of the new allocation state properties, which should indicate to the resource owner that the "task" has been updated after their person was allocated.


**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Should verify in the resource owner app that the department is correct


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

