### PR TITLE
Endpoint to get relevant unassigned requests for a department

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/DepartmentRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/DepartmentRequestsController.cs
@@ -98,5 +98,30 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
             return apiModel;
         }
+
+        [HttpGet("departments/{departmentString}/resources/requests/unassigned")]
+        public async Task<ActionResult<ApiCollection<ApiResourceAllocationRequest>>> GetDepartmentUnassignedRequests(string departmentString) 
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal();
+                r.AnyOf(or =>
+                {
+                    // add requirements
+                });
+            });
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var requestCommand = new GetDepartmentUnassignedRequests(departmentString);
+            var result = await DispatchAsync(requestCommand);
+
+            var apiModel = result.Select(x => new ApiResourceAllocationRequest(x)).ToList();
+            return new ApiCollection<ApiResourceAllocationRequest>(apiModel);
+        }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
@@ -27,7 +27,7 @@ namespace Fusion.Resources.Domain.Queries
 
             public async Task<IEnumerable<QueryResourceAllocationRequest>> Handle(GetDepartmentUnassignedRequests request, CancellationToken cancellationToken)
             {
-                var unassignedRequests = await mediator.Send(new GetResourceAllocationRequests().WithUnassignedFilter(true));
+                var unassignedRequests = await mediator.Send(new GetResourceAllocationRequests().ExpandPositions().WithUnassignedFilter(true));
 
                 var relevantRequests = unassignedRequests
                     .Where(r => r.OrgPosition != null && IsRelevantBasePosition(request.DepartmentString, r.OrgPosition.BasePosition.Department))

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
@@ -1,0 +1,54 @@
+﻿using Fusion.Integration.Org;
+using MediatR;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Queries
+{
+    public class GetDepartmentUnassignedRequests : IRequest<IEnumerable<QueryResourceAllocationRequest>>
+    {
+        public GetDepartmentUnassignedRequests(string departmentString)
+        {
+            DepartmentString = departmentString;
+        }
+
+        public string DepartmentString { get; }
+
+        public class Handler : IRequestHandler<GetDepartmentUnassignedRequests, IEnumerable<QueryResourceAllocationRequest>>
+        {
+            private readonly IMediator mediator;
+
+            public Handler(IMediator mediator)
+            {
+                this.mediator = mediator;
+            }
+
+            public async Task<IEnumerable<QueryResourceAllocationRequest>> Handle(GetDepartmentUnassignedRequests request, CancellationToken cancellationToken)
+            {
+                var unassignedRequests = await mediator.Send(new GetResourceAllocationRequests().WithUnassignedFilter(true));
+
+                var relevantRequests = unassignedRequests
+                    .Where(r => r.OrgPosition != null && IsRelevantBasePosition(request.DepartmentString, r.OrgPosition.BasePosition.Department))
+                    .ToList();
+
+                return relevantRequests;
+            }
+
+            private static bool IsRelevantBasePosition(string sourceDepartment, string basePositionDepartment)
+            {
+                if (sourceDepartment is null || basePositionDepartment is null)
+                    return false;
+
+                if (sourceDepartment.StartsWith(basePositionDepartment, System.StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                if (basePositionDepartment.StartsWith(sourceDepartment, System.StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -33,6 +33,13 @@ namespace Fusion.Resources.Domain.Queries
             return this;
         }
 
+        public GetResourceAllocationRequests ExpandPositions(bool shouldExpand = true)
+        {
+            if (shouldExpand)
+                Expands |= ExpandFields.OrgPosition;
+            return this;
+        }
+
         public GetResourceAllocationRequests WithAssignedDepartment(string departmentString)
         {
             DepartmentString = departmentString;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -69,6 +69,24 @@ namespace Fusion.Resources.Api.Tests
             return newRequestResponse.Value;
         }
 
+        /// <summary>
+        /// Create new request and start it.
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<TestApiInternalRequestModel> CreateAndStartDefaultRequestOnPositionAsync(this HttpClient client, FusionTestProjectBuilder project, ApiPositionV2 position)
+        {
+            var requestModel = new ApiCreateInternalRequestModel()
+                .AsTypeNormal()
+                .WithPosition(position);
+
+            var newRequestResponse = await client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{project.Project.ProjectId}/requests", requestModel);
+            newRequestResponse.Should().BeSuccessfull();
+
+            var startedRequest = await client.StartProjectRequestAsync(project, newRequestResponse.Value.Id);
+
+            return startedRequest;
+        }
+
         public static async Task<TestApiInternalRequestModel> CreateDefaultResourceOwnerRequestAsync(this HttpClient client, string department, FusionTestProjectBuilder project,
             Action<ApiCreateInternalRequestModel> setup = null, Action<ApiPositionV2> positionSetup = null)
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
@@ -1,0 +1,126 @@
+﻿using FluentAssertions;
+using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Testing;
+using Fusion.Testing.Authentication.User;
+using Fusion.Testing.Mocks;
+using Fusion.Testing.Mocks.OrgService;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Fusion.Resources.Api.Tests.IntegrationTests.UnassignedRequests
+{
+    public class DepartmentUnassignedTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
+    {
+        private ResourceApiFixture fixture;
+        private FusionTestProjectBuilder testProject;
+        private readonly TestLoggingScope loggingScope;
+
+        public DepartmentUnassignedTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+        }
+
+        private HttpClient Client => fixture.ApiFactory.CreateClient();
+
+
+        [Fact]
+        public async Task ShouldReturnRequest_WhenBasePositionDepartmentStartsWith()
+        {
+            var department = "TPD PRD MY TEST DEP1";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = "TPD PRD MY TEST DEP");
+            var testPosition = testProject.AddPosition().WithBasePosition(bp);
+
+
+            using var adminScope = fixture.AdminScope();
+
+            var unassignedRequest = await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testPosition);
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview", new { value = new[] { new { id = Guid.Empty } } });
+            resp.Value.value.Should().Contain(r => r.id == unassignedRequest.Id);
+        }
+
+        [Fact]
+        public async Task ShouldReturnRequest_WhenBasePositionDepartmentTargetsSector()
+        {
+            var department = "TPD PRD MY TEST DEP1";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = "TPD PRD MY TEST");
+            var testPosition = testProject.AddPosition().WithBasePosition(bp);
+
+
+            using var adminScope = fixture.AdminScope();
+
+            var unassignedRequest = await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testPosition);
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview", new { value = new[] { new { id = Guid.Empty } } });
+            resp.Value.value.Should().Contain(r => r.id == unassignedRequest.Id);
+        }
+
+        [Fact]
+        public async Task ShouldReturnRequest_WhenDepartmentStartsWithBasePositionDepartment()
+        {
+            var department = "TPD PRD MY";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = "TPD PRD MY TEST");
+            var testPosition = testProject.AddPosition().WithBasePosition(bp);
+
+
+            using var adminScope = fixture.AdminScope();
+
+            var unassignedRequest = await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testPosition);
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview", new { value = new[] { new { id = Guid.Empty } } });
+            resp.Value.value.Should().Contain(r => r.id == unassignedRequest.Id);
+        }
+
+        [Fact]
+        public async Task ShouldNotReturnRequest_WhenBasePositionDepartmentNotInPath()
+        {
+            var department = "TPD PRD MY TEST DEP1";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = "TPD PRD OTHER TEST DEP");
+            var testPosition = testProject.AddPosition().WithBasePosition(bp);
+
+
+            using var adminScope = fixture.AdminScope();
+
+            var unassignedRequest = await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testPosition);
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview", new { value = new[] { new { id = Guid.Empty } } });
+            resp.Value.value.Should().NotContain(r => r.id == unassignedRequest.Id);
+        }
+
+
+
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task InitializeAsync()
+        {
+            // Mock project
+            testProject = new FusionTestProjectBuilder()
+                .WithPositions(200)
+                .AddToMockService();
+
+            // Prepare context resolver.
+            fixture.ContextResolver
+                .AddContext(testProject.Project);
+         
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -136,6 +136,20 @@ namespace Fusion.Testing.Mocks.OrgService
             return clone;
         }
 
+        public ApiBasePositionV2 AddBasePosition(string name, Action<ApiBasePositionV2> setup = null)
+        {
+            var bp = new ApiBasePositionV2()
+            {
+                Id = Guid.NewGuid(),
+                Name = name
+            };
+
+            setup?.Invoke(bp);
+
+
+            return bp;
+        }
+
         public ApiPositionV2 AddPosition()
         {
             var position = PositionBuilder.NewPosition();

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
@@ -22,6 +22,18 @@ namespace Fusion.Testing.Mocks.OrgService
             return position;
         }
 
+        public static ApiPositionV2 WithBasePosition(this ApiPositionV2 position, ApiBasePositionV2 basePosition)
+        {
+            position.BasePosition = basePosition;
+
+            bool hasBpName = position.Name == position.BasePosition.Name;
+
+            if (hasBpName)
+                position.Name = basePosition.Name;
+
+            return position;
+        }
+
         public static ApiPositionV2 WithRandomBasePosition(this ApiPositionV2 position, string except = null)
         {
             var faker = new Bogus.Faker();


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
New endpoint at `/departments/{departmentPath}/resources/requests/unassigned` that will locate all unassigned requests that should be relevant for the department to claim.

The requests will be filtered using the department info located on the base position for the position the request is created on. 
Requests are included if the baeposition department is contained in the full department path or if the department is contained in the department path of the base position.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [ ] Local tests are passing

TBD


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

