### PR TITLE
Reset allocation state endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -158,7 +158,41 @@ namespace Fusion.Resources.Api.Controllers
             var returnModel = department.Select(p => new ApiInternalPersonnelPerson(p)).ToList();
             return new ApiCollection<ApiInternalPersonnelPerson>(returnModel);
         }
-    
+
+        [HttpGet("departments/{fullDepartmentString}/resources/personnel/{personIdentifier}")]
+        public async Task<ActionResult<ApiInternalPersonnelPerson>> GetPersonnelAllocation(string fullDepartmentString, string personIdentifier)
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AnyOf(or =>
+                {
+                    or.BeTrustedApplication();
+                    or.FullControl();
+
+                    or.FullControlInternal();
+
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var personnelItem = await DispatchAsync(new GetPersonnelAllocation(personIdentifier));
+
+            if (personnelItem is null)
+                throw new InvalidOperationException("Could locate profile for person");
+
+            if (personnelItem.FullDepartment != fullDepartmentString)
+                return ApiErrors.NotFound($"Person does not belong to department ({personnelItem.FullDepartment})");
+
+
+            return Ok(new ApiInternalPersonnelPerson(personnelItem));
+        }
+
         [HttpPost("departments/{fullDepartmentString}/resources/personnel/{personIdentifier}/allocations/{instanceId}/allocation-state/reset")]
         public async Task<ActionResult> ResetAllocationState(string fullDepartmentString, string personIdentifier, Guid instanceId)
         {

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ResetAllocationState.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ResetAllocationState.cs
@@ -1,0 +1,57 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable 
+
+namespace Fusion.Resources.Domain.Commands
+{
+    public class ResetAllocationState : TrackableRequest
+    {
+        public ResetAllocationState(Guid orgProjectId, Guid orgPositionId, Guid orgInstanceId)
+        {
+            OrgProjectId = orgProjectId;
+            OrgPositionId = orgPositionId;
+            OrgInstanceId = orgInstanceId;
+        }
+
+        public Guid OrgProjectId { get; }
+        public Guid OrgPositionId { get; }
+        public Guid OrgInstanceId { get; }
+
+        public class Handler : AsyncRequestHandler<ResetAllocationState>
+        {
+            private readonly ILogger<Handler> logger;
+            private readonly ResourcesDbContext dbContext;
+            private readonly IOrgApiClientFactory orgApiClientFactory;
+
+            public Handler(ILogger<Handler> logger, ResourcesDbContext dbContext, IOrgApiClientFactory orgApiClientFactory)
+            {
+                this.logger = logger;
+                this.dbContext = dbContext;
+                this.orgApiClientFactory = orgApiClientFactory;
+            }
+
+            protected override async Task Handle(ResetAllocationState request, CancellationToken cancellationToken)
+            {
+                var client = orgApiClientFactory.CreateClient(ApiClientMode.Application);
+
+                var resetStateUrl = $"/projects/{request.OrgProjectId}/positions/{request.OrgPositionId}/instances/{request.OrgInstanceId}/allocation-state/reset";
+                var resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, resetStateUrl));
+
+                if (!resp.IsSuccessStatusCode)
+                {
+                    var content = await resp.Content.ReadAsStringAsync();
+                    logger.LogError("Received error from org api {StatusCode}: " + content, resp.StatusCode);
+
+                    throw new IntegrationError("Org api failed when trying to reset allocation state", new OrgApiError(resp, content));
+                }
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
@@ -49,6 +49,11 @@ namespace Fusion.Resources.Domain
             return new PersonId(uniqueId);
         }
 
+        public static implicit operator PersonId(PersonnelId personId)
+        {
+            return new PersonId(personId.OriginalIdentifier);
+        }
+
         public static implicit operator PersonId?(ApiPersonV2? assignedPerson)
         {
             if (assignedPerson is null)

--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonnelId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonnelId.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Fusion.Integration.Profile;
+using System;
 
 namespace Fusion.Resources.Domain
 {
@@ -45,6 +46,11 @@ namespace Fusion.Resources.Domain
         public static implicit operator PersonnelId(Guid uniqueId)
         {
             return new PersonnelId(uniqueId);
+        }
+
+        public static implicit operator PersonIdentifier(PersonnelId personId)
+        {
+            return PersonIdentifier.Parse(personId.OriginalIdentifier);
         }
     }
 

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
@@ -41,6 +41,15 @@ namespace Fusion.Resources.Domain
             Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
         }
+        public QueryPersonAbsenceBasic(QueryPersonAbsence absence)
+        {
+            Id = absence.Id;
+            Comment = absence.Comment;
+            AppliesFrom = absence.AppliesFrom;
+            AppliesTo = absence.AppliesTo;
+            Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
+            AbsencePercentage = absence.AbsencePercentage;
+        }
 
         public Guid Id { get; set; }
         public string? Comment { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentPersonnel.cs
@@ -2,19 +2,18 @@
 using Fusion.AspNetCore.OData;
 using Fusion.Integration.Http;
 using Fusion.Resources.Database;
-using Itenso.TimePeriod;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fusion.Resources.Domain
 {
+
     public class GetDepartmentPersonnel : IRequest<IEnumerable<QueryInternalPersonnelPerson>>
     {
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonnelAllocation.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonnelAllocation.cs
@@ -1,0 +1,63 @@
+﻿using Fusion.Integration;
+using Fusion.Integration.Http;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain
+{
+    public class GetPersonnelAllocation : IRequest<QueryInternalPersonnelPerson?>
+    {
+        public GetPersonnelAllocation(PersonnelId personId)
+        {
+            PersonId = personId;
+        }
+
+        public PersonnelId PersonId { get; }
+
+        public class Handler : IRequestHandler<GetPersonnelAllocation, QueryInternalPersonnelPerson?>
+        {
+            private readonly ILogger<Handler> logger;
+            private readonly ResourcesDbContext db;
+            private readonly IHttpClientFactory httpClientFactory;
+            private readonly IMediator mediator;
+            private readonly IFusionProfileResolver profileResolver;
+
+            public Handler(ILogger<Handler> logger, ResourcesDbContext db, IHttpClientFactory httpClientFactory, IMediator mediator, IFusionProfileResolver profileResolver)
+            {
+                this.logger = logger;
+                this.db = db;
+                this.httpClientFactory = httpClientFactory;
+                this.mediator = mediator;
+                this.profileResolver = profileResolver;
+            }
+
+            public async Task<QueryInternalPersonnelPerson?> Handle(GetPersonnelAllocation request, CancellationToken cancellationToken)
+            {
+                var peopleClient = httpClientFactory.CreateClient(HttpClientNames.ApplicationPeople);
+
+                var user = await profileResolver.ResolvePersonBasicProfileAsync(request.PersonId);
+                if (user is null)
+                    return null;
+
+                if (user.AzureUniqueId is null)
+                    throw new InvalidOperationException("Profile must have a azure unique id");
+
+                var personWithAllocations = await PeopleSearchUtils.GetPersonFromSearchIndexAsync(peopleClient, user.AzureUniqueId.Value);
+
+                if (personWithAllocations is null)
+                    return null;
+
+                var absence = await mediator.Send(new GetPersonAbsence(request.PersonId));
+
+                personWithAllocations.Absence = absence.Select(a => new QueryPersonAbsenceBasic(a)).ToList();
+                return personWithAllocations;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added endpoint to reset allocation state on a persons allocation. This should be used by the resource owner to "accept" changes done by the task owner.
The operation will fetch the allocations for the user by using the profile search. From here the project and position id is resolved. Only the person id and instance id must be provided by the client.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [ ] Local tests are passing

Should be verified by changing an position so the allocation state is updated in the search index. As this is mainly integration logic automated tests as skipped.

*Verified by updating allocation for person in org chart, then resetting using the endpoint. State set to null while allocation updated remains same date.*

**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

