### PR TITLE
Fix issue where expandin resource owners without resource owner search would only return CEO

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
@@ -103,6 +103,12 @@ namespace Fusion.Resources.Domain
                 {
                     var searchedDepartments = departments.Keys!.ToHashSet();
 
+                    //TODO: maybe solve this in a smarter way
+                    if(request.resourceOwnerSearch is null && request.departmentId is not null)
+                    {
+                        request.resourceOwnerSearch = request.departmentId;
+                    }
+
                     var resourceOwners = await lineOrgResolver
                         .GetResourceOwners(request.resourceOwnerSearch, cancellationToken);
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

