### PR TITLE
Person notes

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonNote.cs
@@ -1,0 +1,27 @@
+﻿using Fusion.Resources.Domain;
+using System;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiPersonNote
+    {
+        public ApiPersonNote(QueryPersonNote note)
+        {
+            Id = note.Id;
+            Content = note.Content;
+            Title = note.Title;
+            IsShared = note.IsShared;
+            Updated = note.Updated;
+            UpdatedBy = new ApiPerson(note.UpdatedBy);
+        }
+
+        public Guid Id { get; set; }
+        public string? Content { get; set; }
+        public string? Title { get; set; }
+        public bool IsShared { get; set; }
+        public DateTimeOffset Updated { get; set; }
+        public ApiPerson UpdatedBy { get; set; } = null!;
+    }
+
+
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
@@ -1,0 +1,47 @@
+﻿using Fusion.Resources.Domain.Queries;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiResourceOwnerProfile
+    {
+        public ApiResourceOwnerProfile(QueryResourceOwnerProfile resourceOwnerProfile)
+        {
+            FullDepartment = resourceOwnerProfile.FullDepartment!;
+            Sector = resourceOwnerProfile.Sector;
+            IsResourceOwner = resourceOwnerProfile.IsDepartmentManager;
+            ResponsibilityInDepartments = resourceOwnerProfile.DepartmentsWithResponsibility;
+            RelevantSectors = resourceOwnerProfile.RelevantSectors;
+
+            ChildDepartments = resourceOwnerProfile.ChildDepartments;
+            SiblingDepartments = resourceOwnerProfile.SiblingDepartments;
+
+            // Compile the relevant department list
+            RelevantDepartments = ResponsibilityInDepartments
+                .Union(resourceOwnerProfile.ChildDepartments ?? new ())
+                .Union(resourceOwnerProfile.SiblingDepartments ?? new ())                
+                .Distinct()
+                .ToList();
+
+            if (Sector is not null && !RelevantDepartments.Contains(Sector))
+                RelevantDepartments.Add(Sector);
+        }
+
+        public string FullDepartment { get; set; }
+        public string? Sector { get; set; }
+
+
+        public bool IsResourceOwner { get; set; }
+
+        public List<string> ResponsibilityInDepartments { get; set; } = new();
+
+        public List<string> RelevantDepartments { get; set; } = new();
+        public List<string> RelevantSectors { get; set; } = new();
+
+        public List<string>? ChildDepartments { get; set; } 
+        public List<string>? SiblingDepartments { get; set; }
+    }
+
+
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -1,6 +1,5 @@
 ﻿using Fusion.AspNetCore.FluentAuthorization;
 using Fusion.Integration;
-using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -65,45 +64,150 @@ namespace Fusion.Resources.Api.Controllers
             var respObject = new ApiResourceOwnerProfile(resourceOwnerProfile);
             return respObject;
         }
-    }
 
-    public class ApiResourceOwnerProfile
-    {
-        public ApiResourceOwnerProfile(QueryResourceOwnerProfile resourceOwnerProfile)
+        [HttpGet("/persons/{personId}/resources/notes")]
+        public async Task<ActionResult<List<ApiPersonNote>>> GetPersonNotes(string personId)
         {
-            FullDepartment = resourceOwnerProfile.FullDepartment!;
-            Sector = resourceOwnerProfile.Sector;
-            IsResourceOwner = resourceOwnerProfile.IsDepartmentManager;
-            ResponsibilityInDepartments = resourceOwnerProfile.DepartmentsWithResponsibility;
-            RelevantSectors = resourceOwnerProfile.RelevantSectors;
 
-            ChildDepartments = resourceOwnerProfile.ChildDepartments;
-            SiblingDepartments = resourceOwnerProfile.SiblingDepartments;
+            #region Authorization
 
-            // Compile the relevant department list
-            RelevantDepartments = ResponsibilityInDepartments
-                .Union(resourceOwnerProfile.ChildDepartments ?? new ())
-                .Union(resourceOwnerProfile.SiblingDepartments ?? new ())                
-                .Distinct()
-                .ToList();
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
 
-            if (Sector is not null && !RelevantDepartments.Contains(Sector))
-                RelevantDepartments.Add(Sector);
+                r.AnyOf(or =>
+                {
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var user = await EnsureUserAsync(personId);
+            if (user.error is not null)
+                return user.error;
+
+            var notes = await DispatchAsync(new GetPersonNotes(user.azureId));
+
+            return notes.Select(n => new ApiPersonNote(n)).ToList();
         }
 
-        public string FullDepartment { get; set; }
-        public string? Sector { get; set; }
+        [HttpPut("/persons/{personId}/resources/notes/{noteId}")]
+        public async Task<ActionResult<ApiPersonNote>> UpdatePersonalNote(string personId, Guid noteId, [FromBody] PersonNotesRequest request)
+        {
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
+
+                r.AnyOf(or =>
+                {
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var user = await EnsureUserAsync(personId);
+            if (user.error is not null)
+                return user.error;
+
+            var notes = await DispatchAsync(new GetPersonNotes(user.azureId));
+            if (!notes.Any(n => n.Id == noteId))
+                return ApiErrors.NotFound("Could not locate note for user");
+
+            var updatedNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.Update(noteId, request.Content, request.IsShared)
+                .OnUser(user.azureId)
+                .WithTitle(request.Title));
+
+            return new ApiPersonNote(updatedNote);
+        }
+
+        [HttpPost("/persons/{personId}/resources/notes")]
+        public async Task<ActionResult<ApiPersonNote>> CreateNewPersonalNote(string personId, [FromBody] PersonNotesRequest request)
+        {
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
+
+                r.AnyOf(or =>
+                {
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var user = await EnsureUserAsync(personId);
+            if (user.error is not null)
+                return user.error;
 
 
-        public bool IsResourceOwner { get; set; }
+            var newNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.CreateNew(request.Content, request.IsShared)
+                .OnUser(user.azureId)
+                .WithTitle(request.Title));
 
-        public List<string> ResponsibilityInDepartments { get; set; } = new();
+            return new ApiPersonNote(newNote);
+        }
 
-        public List<string> RelevantDepartments { get; set; } = new();
-        public List<string> RelevantSectors { get; set; } = new();
+        [HttpDelete("/persons/{personId}/resources/notes/{noteId}")]
+        public async Task<ActionResult> DeletePersonalNote(string personId, Guid noteId)
+        {
 
-        public List<string>? ChildDepartments { get; set; } 
-        public List<string>? SiblingDepartments { get; set; }
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
+
+                r.AnyOf(or =>
+                {
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var user = await EnsureUserAsync(personId);
+            if (user.error is not null)
+                return user.error!;
+
+            var notes = await DispatchAsync(new GetPersonNotes(user.azureId));
+            if (!notes.Any(n => n.Id == noteId))
+                return ApiErrors.NotFound("Could not locate note for user");
+
+            await DispatchAsync(new Domain.Commands.DeletePersonNote(noteId, user.azureId));
+
+            return NoContent();
+        }
+
+        private async Task<(Guid azureId, ActionResult? error)> EnsureUserAsync(string personId)
+        {
+            var user = await profileResolver.ResolvePersonBasicProfileAsync(personId);
+            if (user is null)
+                return (Guid.Empty, ApiErrors.NotFound("Could not locate user"));
+            if (user.AzureUniqueId is null)
+                return (Guid.Empty, ApiErrors.InvalidInput("Could not locate any unique id for the user. User must exist in ad."));
+
+            return (user.AzureUniqueId.Value, null);
+        }
     }
 
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -124,9 +124,9 @@ namespace Fusion.Resources.Api.Controllers
             if (!notes.Any(n => n.Id == noteId))
                 return ApiErrors.NotFound("Could not locate note for user");
 
-            var updatedNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.Update(noteId, request.Content, request.IsShared)
-                .OnUser(user.azureId)
-                .WithTitle(request.Title));
+            var updatedNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.Update(noteId, request.Content, user.azureId)
+                .WithTitle(request.Title)
+                .SetIsShared(request.IsShared));
 
             return new ApiPersonNote(updatedNote);
         }
@@ -157,9 +157,9 @@ namespace Fusion.Resources.Api.Controllers
                 return user.error;
 
 
-            var newNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.CreateNew(request.Content, request.IsShared)
-                .OnUser(user.azureId)
-                .WithTitle(request.Title));
+            var newNote = await DispatchAsync(Domain.Commands.CreateOrUpdatePersonNote.CreateNew(request.Content, user.azureId)
+                .WithTitle(request.Title)
+                .SetIsShared(request.IsShared));
 
             return new ApiPersonNote(newNote);
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/PersonNotesRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/PersonNotesRequest.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class PersonNotesRequest
+    {
+        public string? Title { get; set; }
+        public string? Content { get; set; }
+        public bool IsShared { get; set; }
+
+        public class Validator : AbstractValidator<PersonNotesRequest>
+        {
+            public Validator()
+            {
+                RuleFor(x => x.Title).NotContainScriptTag()
+                    .MaximumLength(250);
+                RuleFor(x => x.Content).NotContainScriptTag()
+                    .MaximumLength(2500);
+            }
+        }
+    }
+
+
+}

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/ProfileSyncHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/ProfileSyncHandler.cs
@@ -1,0 +1,39 @@
+﻿using Fusion.Integration.Profile;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.FusionEvents
+{
+    public class ProfileSyncHandler : IProfileSyncHandler
+    {
+        private readonly IMediator mediator;
+        private readonly ResourcesDbContext dbContext;
+
+        public ProfileSyncHandler(IMediator mediator, ResourcesDbContext dbContext)
+        {
+            this.mediator = mediator;
+            this.dbContext = dbContext;
+        }
+
+        public async Task ProcessProfileAsync(IProfileSyncHandler.ProfileUpdatedEventContext context)
+        {
+            // Check if we are tracking this profile.
+            var isTracked = await dbContext.Persons.AnyAsync(p => p.AzureUniqueId == context.Person.AzureUniquePersonId || (p.Mail != null && p.Mail == context.Person.Mail));
+            if (isTracked)
+            {
+                var updatedProfile = await context.ResolveProfile.Value;
+                if  (updatedProfile is not null) await mediator.Publish(new Domain.Notifications.ProfileUpdated(updatedProfile));
+            }
+
+            if (context.WasRemoved)
+            {
+                await mediator.Publish(new Domain.Notifications.ProfileRemovedFromCompany(context.Person.AzureUniquePersonId));
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -56,6 +56,8 @@ namespace Fusion.Resources.Api
             // Configure fusion integration
             services.AddFusionIntegration(options =>
             {
+                options.AddProfileSync<FusionEvents.ProfileSyncHandler>();
+
                 options.AddFusionAuthorization();
                 options.AddOrgIntegration();
                 options.AddFusionRoles();

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -56,7 +56,8 @@ namespace Fusion.Resources.Api
             // Configure fusion integration
             services.AddFusionIntegration(options =>
             {
-                options.AddProfileSync<FusionEvents.ProfileSyncHandler>();
+                try { options.AddProfileSync<FusionEvents.ProfileSyncHandler>(); } 
+                catch { /* Shitfix untill fixed in integration lib. Throws when added multitple times, which is done in the integration tests. (static bool flag) */ }
 
                 options.AddFusionAuthorization();
                 options.AddOrgIntegration();

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Fusion.Resources.Database.Entities
 {
 
-
     public class DbPersonAbsence
     {
         public Guid Id { get; set; }

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbPersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbPersonNote.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Fusion.Resources.Database.Entities
+{
+    /// <summary>
+    /// The note follows the targeted person through department changes. 
+    /// Considered making the note a combination of resource owner department & resource id, but this would not support changes in org structure.
+    /// 
+    /// With introduction of other resource pools, context properties might have to be introduced.
+    /// </summary>
+    public class DbPersonNote
+    {
+        public Guid Id { get; set; }
+        public Guid AzureUniqueId { get; set; }
+        [MaxLength(250)]
+        public string? Title { get; set; }
+        [MaxLength(2500)]
+        public string? Content { get; set; }
+        
+        /// <summary>
+        /// This flag should indicate that the note should be shared amongst other relevant resource owners.
+        /// </summary>
+        public bool IsShared { get; set; }
+        public DateTimeOffset Updated { get; set; }
+
+        public Guid UpdatedById { get; set; }
+        public DbPerson UpdatedBy { get; set; } = null!;
+
+        internal static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DbPersonNote>(entity =>
+            {
+                entity.HasOne(e => e.UpdatedBy).WithMany().OnDelete(DeleteBehavior.Restrict);
+
+                // Create index on unique id, which will primarily be used to fetch items.
+                entity.HasIndex(e => e.AzureUniqueId).IsClustered(false).IncludeProperties(e => new
+                {
+                    e.Id,
+                    e.Title,
+                    e.Content,
+                    e.IsShared,
+                    e.Updated,
+                    e.UpdatedById
+                });
+            });
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210417150335_Added person note.Designer.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210417150335_Added person note.Designer.cs
@@ -4,14 +4,16 @@ using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Fusion.Resources.Database.Migrations
 {
     [DbContext(typeof(ResourcesDbContext))]
-    partial class ResourcesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210417150335_Added person note")]
+    partial class Addedpersonnote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210417150335_Added person note.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210417150335_Added person note.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fusion.Resources.Database.Migrations
+{
+    public partial class Addedpersonnote : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PersonNotes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AzureUniqueId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
+                    Content = table.Column<string>(type: "nvarchar(2500)", maxLength: 2500, nullable: true),
+                    IsShared = table.Column<bool>(type: "bit", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonNotes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PersonNotes_Persons_UpdatedById",
+                        column: x => x.UpdatedById,
+                        principalTable: "Persons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonNotes_AzureUniqueId",
+                table: "PersonNotes",
+                column: "AzureUniqueId")
+                .Annotation("SqlServer:Clustered", false)
+                .Annotation("SqlServer:Include", new[] { "Id", "Title", "Content", "IsShared", "Updated", "UpdatedById" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonNotes_UpdatedById",
+                table: "PersonNotes",
+                column: "UpdatedById");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PersonNotes");
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Database/ResourcesDbContext.cs
+++ b/src/backend/api/Fusion.Resources.Database/ResourcesDbContext.cs
@@ -39,7 +39,8 @@ namespace Fusion.Resources.Database
 
         public DbSet<DbResponsibilityMatrix> ResponsibilityMatrices { get; set; }
         public DbSet<DbPersonAbsence> PersonAbsences { get; set; }
-        
+        public DbSet<DbPersonNote> PersonNotes { get; set; }
+
         public DbSet<DbDepartment> Departments { get; set; }
         public DbSet<DbDepartmentResponsible> DepartmentResponsibles { get; set; }
 
@@ -54,6 +55,7 @@ namespace Fusion.Resources.Database
             DbPerson.OnModelCreating(modelBuilder);
             DbDelegatedRole.OnModelCreating(modelBuilder);
             DbPersonAbsence.OnModelCreating(modelBuilder);
+            DbPersonNote.OnModelCreating(modelBuilder);
             DbResponsibilityMatrix.OnModelCreating(modelBuilder);
             DbResourceAllocationRequest.OnModelCreating(modelBuilder);
             DbDepartment.OnModelCreating(modelBuilder);

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateContractPersonnel.cs
@@ -1,4 +1,5 @@
-﻿using Fusion.Integration.Org;
+﻿using FluentValidation;
+using Fusion.Integration.Org;
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using MediatR;
@@ -13,7 +14,6 @@ using System.Threading.Tasks;
 
 namespace Fusion.Resources.Domain.Commands
 {
-
     public class CreateContractPersonnel : TrackableRequest<QueryContractPersonnel>
     {
         public CreateContractPersonnel(Guid projectId, Guid contractIdentifier, string mail)

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateOrUpdatePersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateOrUpdatePersonNote.cs
@@ -1,0 +1,104 @@
+﻿using FluentValidation;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable 
+
+namespace Fusion.Resources.Domain.Commands
+{
+    public class CreateOrUpdatePersonNote : TrackableRequest<QueryPersonNote> 
+    {
+        private CreateOrUpdatePersonNote(Guid? id, string? content, bool isShared)
+        {
+            NoteId = id;
+            Content = content;
+            IsShared = isShared;
+        }
+
+        public Guid? NoteId { get; }
+        public string? Content { get; }
+        public bool IsShared { get; }
+
+        public string? Title { get; set; }
+        public Guid AzureUniqueId { get; set; }
+
+        public CreateOrUpdatePersonNote OnUser(Guid azureUniqueId)
+        {
+            AzureUniqueId = azureUniqueId;
+            return this;
+        }
+        public CreateOrUpdatePersonNote WithTitle(string? title)
+        {
+            Title = title;
+            return this;
+        }
+
+        public static CreateOrUpdatePersonNote CreateNew(string? content, bool isShared) => new CreateOrUpdatePersonNote(null, content, isShared);
+        public static CreateOrUpdatePersonNote Update(Guid id, string? content, bool isShared) => new CreateOrUpdatePersonNote(id, content, isShared);
+
+        #region Validation
+        public class Validator : AbstractValidator<CreateOrUpdatePersonNote>
+        {
+            public Validator(ResourcesDbContext dbContext)
+            {
+                RuleFor(x => x.AzureUniqueId).NotEmpty();
+
+                // Check if note already exist when creating new.
+                RuleFor(x => x)
+                    .MustAsync(async (x, cancel) =>
+                    {
+                        var exists = await dbContext.PersonNotes.AnyAsync(n => n.Title == x.Title && n.AzureUniqueId == x.AzureUniqueId && n.Content == x.Content);
+                        return !exists;
+                    })
+                    .When(x => x.NoteId == null)
+                    .WithMessage("Note already exist");
+            }
+        }
+
+        #endregion
+
+        #region Handler
+        public class Handler : IRequestHandler<CreateOrUpdatePersonNote, QueryPersonNote>
+        {
+            private readonly ResourcesDbContext dbContext;
+
+            public Handler(ResourcesDbContext dbContext)
+            {
+                this.dbContext = dbContext;
+            }
+
+            public async Task<QueryPersonNote> Handle(CreateOrUpdatePersonNote request, CancellationToken cancellationToken)
+            {
+                
+                DbPersonNote note;
+                if (request.NoteId != null)
+                {
+                    note = await dbContext.PersonNotes.FirstOrDefaultAsync(p => p.Id == request.NoteId && p.AzureUniqueId == request.AzureUniqueId);
+                    if (note is null)
+                        throw new ArgumentException("Note id does not exist");
+                }
+                else
+                {
+                    note = dbContext.PersonNotes.Add(new DbPersonNote() { AzureUniqueId = request.AzureUniqueId }).Entity;
+                }
+
+                note.Content = request.Content;
+                note.IsShared = request.IsShared;
+                note.Title = request.Title;
+                note.Updated = DateTimeOffset.UtcNow;
+                note.UpdatedBy = request.Editor.Person;
+
+                await dbContext.SaveChangesAsync(cancellationToken);
+
+                return new QueryPersonNote(note);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateOrUpdatePersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateOrUpdatePersonNote.cs
@@ -13,33 +13,35 @@ namespace Fusion.Resources.Domain.Commands
 {
     public class CreateOrUpdatePersonNote : TrackableRequest<QueryPersonNote> 
     {
-        private CreateOrUpdatePersonNote(Guid? id, string? content, bool isShared)
+        private CreateOrUpdatePersonNote(Guid? id, string? content, Guid azureUniqueId)
         {
             NoteId = id;
             Content = content;
-            IsShared = isShared;
+            AzureUniqueId = azureUniqueId;
         }
 
         public Guid? NoteId { get; }
         public string? Content { get; }
-        public bool IsShared { get; }
+        public Guid AzureUniqueId { get; }
+
+        public bool IsShared { get; set;  }
 
         public string? Title { get; set; }
-        public Guid AzureUniqueId { get; set; }
 
-        public CreateOrUpdatePersonNote OnUser(Guid azureUniqueId)
-        {
-            AzureUniqueId = azureUniqueId;
-            return this;
-        }
         public CreateOrUpdatePersonNote WithTitle(string? title)
         {
             Title = title;
             return this;
         }
+        public CreateOrUpdatePersonNote SetIsShared(bool isShared = false)
+        {
+            IsShared = isShared;
+            return this;
+        }
 
-        public static CreateOrUpdatePersonNote CreateNew(string? content, bool isShared) => new CreateOrUpdatePersonNote(null, content, isShared);
-        public static CreateOrUpdatePersonNote Update(Guid id, string? content, bool isShared) => new CreateOrUpdatePersonNote(id, content, isShared);
+
+        public static CreateOrUpdatePersonNote CreateNew(string? content, Guid azureUniqueId) => new CreateOrUpdatePersonNote(null, content, azureUniqueId);
+        public static CreateOrUpdatePersonNote Update(Guid id, string? content, Guid azureUniqueId) => new CreateOrUpdatePersonNote(id, content, azureUniqueId);
 
         #region Validation
         public class Validator : AbstractValidator<CreateOrUpdatePersonNote>

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeletePersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/DeletePersonNote.cs
@@ -1,0 +1,43 @@
+﻿using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable 
+
+namespace Fusion.Resources.Domain.Commands
+{
+    public class DeletePersonNote : TrackableRequest
+    {
+        public DeletePersonNote(Guid noteId, Guid personAzureUniqueId)
+        {
+            NoteId = noteId;
+            PersonAzureUniqueId = personAzureUniqueId;
+        }
+
+        public Guid NoteId { get; }
+        public Guid PersonAzureUniqueId { get; }
+
+        public class Handler : AsyncRequestHandler<DeletePersonNote>
+        {
+            private readonly ResourcesDbContext dbContext;
+
+            public Handler(ResourcesDbContext dbContext)
+            {
+                this.dbContext = dbContext;
+            }
+
+            protected override async Task Handle(DeletePersonNote request, CancellationToken cancellationToken)
+            {
+                var note = await dbContext.PersonNotes.FirstOrDefaultAsync(n => n.Id == request.NoteId && n.AzureUniqueId == request.PersonAzureUniqueId);
+                if (note is null)
+                    throw new ArgumentException("Could not locate note to delete");
+
+                dbContext.Remove(note);
+                await dbContext.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
@@ -54,6 +54,11 @@ namespace Fusion.Resources.Domain
             return new PersonId(personId.OriginalIdentifier);
         }
 
+        public static implicit operator Fusion.Integration.Profile.PersonIdentifier(PersonId personId)
+        {
+            return Fusion.Integration.Profile.PersonIdentifier.Parse(personId.OriginalIdentifier);
+        }
+
         public static implicit operator PersonId?(ApiPersonV2? assignedPerson)
         {
             if (assignedPerson is null)

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonNote.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonNote.cs
@@ -1,0 +1,30 @@
+﻿using Fusion.Resources.Database.Entities;
+using System;
+
+namespace Fusion.Resources.Domain
+{
+    public class QueryPersonNote
+    {
+        public QueryPersonNote(DbPersonNote note)
+        {
+            if (note.UpdatedBy is null)
+                throw new ArgumentNullException("Updated by person must be included");
+
+            Id = note.Id;
+            PersonAzureUniqueId = note.AzureUniqueId;
+            Content = note.Content;
+            Title = note.Title;
+            Updated = note.Updated;
+            UpdatedBy = new QueryPerson(note.UpdatedBy);
+            IsShared = note.IsShared;
+        }
+
+        public Guid Id { get; set; }
+        public Guid PersonAzureUniqueId { get; set; }
+        public string? Content { get; set; }
+        public string? Title { get; set; }
+        public bool IsShared { get; set; }
+        public DateTimeOffset Updated { get; set; }
+        public QueryPerson UpdatedBy { get; set; } 
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ClearPersonNotesHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ClearPersonNotesHandler.cs
@@ -1,0 +1,35 @@
+﻿using Fusion.Integration.Diagnostics;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Notifications.Handlers
+{
+    public class ClearPersonNotesHandler : INotificationHandler<ProfileRemovedFromCompany>
+    {
+        private ResourcesDbContext dbContext;
+        private IFusionLogger<ProfileUpdatedHandler> logger;
+
+        public ClearPersonNotesHandler(ResourcesDbContext dbContext, IFusionLogger<ProfileUpdatedHandler> logger)
+        {
+            this.dbContext = dbContext;
+            this.logger = logger;
+        }
+
+        public async Task Handle(ProfileRemovedFromCompany notification, CancellationToken cancellationToken)
+        {
+            var notes = await dbContext.PersonNotes.Where(n => n.AzureUniqueId == notification.AzureUniqueId)
+                .ToListAsync();
+            dbContext.RemoveRange(notes);
+
+            if (notes.Any())
+                logger.LogInformation("Removing {NoteCount} notes for user {UniqueId}", notes.Count, notification.AzureUniqueId);
+
+            await dbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ProfileUpdatedHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ProfileUpdatedHandler.cs
@@ -1,0 +1,65 @@
+﻿using Fusion.Integration.Diagnostics;
+using Fusion.Integration.Profile;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Notifications.Handlers
+{
+    public class ProfileUpdatedHandler : INotificationHandler<ProfileUpdated>
+    {
+        private readonly ResourcesDbContext dbContext;
+        private readonly IFusionLogger<ProfileUpdatedHandler> logger;
+
+        public ProfileUpdatedHandler(ResourcesDbContext dbContext, IFusionLogger<ProfileUpdatedHandler> logger)
+        {
+            this.dbContext = dbContext;
+            this.logger = logger;
+        }
+
+        public async Task Handle(ProfileUpdated notification, CancellationToken cancellationToken)
+        {
+            var profile = await ResolveDbPersonAsync(notification.Profile);
+
+            if (profile is null)
+            {
+                return;
+            }
+
+            var hasChanged = profile.JobTitle != profile.JobTitle
+                || profile.Mail != profile.Mail
+                || profile.Name != profile.Name
+                || profile.Phone != profile.Phone
+                || profile.AccountType != $"{profile.AccountType}";
+
+            profile.JobTitle = profile.JobTitle;
+            profile.Mail = profile.Mail;
+            profile.Name = profile.Name;
+            profile.Phone = profile.Phone;
+            profile.AccountType = $"{profile.AccountType}";
+
+            if (hasChanged)
+            {
+                await dbContext.SaveChangesAsync();
+                logger.LogInformation("Updated profile for {UPN} ({UniqueId})", notification.Profile.UPN, notification.Profile.AzureUniqueId);
+            }
+        }
+
+        private async Task<DbPerson?> ResolveDbPersonAsync(FusionPersonProfile profile)
+        {
+            if (profile.AzureUniqueId.HasValue)
+                return await dbContext.Persons.FirstOrDefaultAsync(p => p.AzureUniqueId == profile.AzureUniqueId.Value);
+
+            // Must avoid null == null compares..
+            if (!string.IsNullOrEmpty(profile.Mail))
+                return await dbContext.Persons.FirstOrDefaultAsync(p => p.Mail == profile.Mail);
+
+            // No profile matches...
+            return null;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/ProfileRemovedFromCompany.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/ProfileRemovedFromCompany.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using System;
+
+namespace Fusion.Resources.Domain.Notifications
+{
+    public class ProfileRemovedFromCompany : INotification
+    {
+        public ProfileRemovedFromCompany(Guid azureUniqueId)
+        {
+            AzureUniqueId = azureUniqueId;
+        }
+
+        public Guid AzureUniqueId { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/ProfileUpdated.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/ProfileUpdated.cs
@@ -1,0 +1,15 @@
+﻿using Fusion.Integration.Profile;
+using MediatR;
+
+namespace Fusion.Resources.Domain.Notifications
+{
+    public class ProfileUpdated : INotification
+    {
+        public ProfileUpdated(FusionPersonProfile profile)
+        {
+            Profile = profile;
+        }
+
+        public FusionPersonProfile Profile { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonNotes.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonNotes.cs
@@ -1,0 +1,45 @@
+﻿using Fusion.Integration;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Queries
+{
+
+    public class GetPersonNotes : IRequest<IEnumerable<QueryPersonNote>>
+    {
+        public GetPersonNotes(Guid azureUniqueId)
+        {
+            AzureUniqueId = azureUniqueId;
+        }
+
+        public Guid AzureUniqueId { get; }
+
+        public class Handler : IRequestHandler<GetPersonNotes, IEnumerable<QueryPersonNote>>
+        {
+            private readonly ResourcesDbContext dbContext;
+            private readonly IFusionProfileResolver profileResolver;
+
+            public Handler(ResourcesDbContext dbContext, IFusionProfileResolver profileResolver)
+            {
+                this.dbContext = dbContext;
+                this.profileResolver = profileResolver;
+            }
+
+            public async Task<IEnumerable<QueryPersonNote>> Handle(GetPersonNotes request, CancellationToken cancellationToken)
+            {
+                var notes = await dbContext.PersonNotes
+                    .Include(p => p.UpdatedBy)
+                    .Where(p => p.AzureUniqueId == request.AzureUniqueId)
+                    .ToListAsync(cancellationToken);
+
+                return notes.Select(n => new QueryPersonNote(n));
+            }
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -15,6 +15,98 @@ using Xunit.Abstractions;
 #nullable enable
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    public class PersonNotesTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
+    {
+        private readonly ResourceApiFixture fixture;
+        private readonly TestLoggingScope loggingScope;
+        /// <summary>
+        /// Will be generated new for each test
+        /// </summary>
+        private readonly ApiPersonProfileV3 testUser;
+
+        private Guid testNoteId;
+
+        private HttpClient client => fixture.ApiFactory.CreateClient();
+
+        public PersonNotesTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+
+            // Generate random test user
+            testUser = fixture.AddProfile(FusionAccountType.Employee);
+        }
+
+        [Fact]
+        public async Task Create_ShouldBeSuccessful_WhenUserExists()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.TestClientPostAsync($"persons/{testUser.AzureUniqueId}/resources/notes?api-version=1.0-preview", new
+            {
+                title = $"Test {Guid.NewGuid()}",
+                content = "My test note"
+            }, new { id = Guid.Empty, title = string.Empty, content = string.Empty, isShared = false });
+            resp.Should().BeSuccessfull();
+
+            resp.Value.id.Should().NotBeEmpty();
+            resp.Value.title.Should().NotBeNullOrEmpty();
+            resp.Value.content.Should().NotBeNullOrEmpty();
+            resp.Value.isShared.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Delete_ShouldBeSuccessfull()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.TestClientDeleteAsync($"persons/{testUser.AzureUniqueId}/resources/notes/{testNoteId}?api-version=1.0-preview");
+            resp.Should().BeSuccessfull();
+        }
+
+        [Fact]
+        public async Task Update_ShouldBeSuccessfull()
+        {
+            var newTitle = $"Updated title {Guid.NewGuid()}";
+            var newContent = $"My new content {Guid.NewGuid()}";
+
+            using var adminScope = fixture.AdminScope();
+            var resp = await client.TestClientPutAsync($"persons/{testUser.AzureUniqueId}/resources/notes/{testNoteId}?api-version=1.0-preview", new
+            {
+                title = newTitle,
+                content = newContent,
+                isShared = true
+            }, new { id = Guid.Empty, title = string.Empty, content = string.Empty, isShared = false });
+
+            resp.Should().BeSuccessfull();
+
+            resp.Value.title.Should().Be(newTitle);
+            resp.Value.content.Should().Be(newContent);
+            resp.Value.isShared.Should().Be(true);
+        }
+
+        public async Task InitializeAsync()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.TestClientPostAsync($"persons/{testUser.AzureUniqueId}/resources/notes?api-version=1.0-preview", new
+            {
+                title = $"Test {Guid.NewGuid()}",
+                content = "My test note"
+            }, new { id = Guid.Empty });
+            resp.Should().BeSuccessfull();
+
+            testNoteId = resp.Value.id;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
     public class PersonAbsenceTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added endpoints to support adding notes to a resources. Instead of just one note the solution is based on a collection of notes, which can be labeled and support for marking specific items as shared. 
The idea is that some notes could be of a private nature, while others could be shared with other resource owners in the area (ex. what the person wants to work with etc). The public info could then be used in a search engine when locating candidates.

Endpoints are:
- GET|POST `/persons/{uniqueId|mail}/resources/notes`
- PUT|DELETE `/persons/{uniqueId|mail}/resources/notes/{noteId}`

Supported api version: `1.0-preview`


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Should be verified by frontend, to ensure initial usage is covered.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

