### PR TITLE
Add counting to relevant requests endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/DepartmentRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/DepartmentRequestsController.cs
@@ -116,12 +116,17 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 return authResult.CreateForbiddenResponse();
 
             #endregion
+            var countEnabled = Request.Query.ContainsKey("$count");
 
-            var requestCommand = new GetDepartmentUnassignedRequests(departmentString);
+            var requestCommand = new GetDepartmentUnassignedRequests(departmentString).WithOnlyCount(countEnabled);
+
             var result = await DispatchAsync(requestCommand);
 
             var apiModel = result.Select(x => new ApiResourceAllocationRequest(x)).ToList();
-            return new ApiCollection<ApiResourceAllocationRequest>(apiModel);
+            return new ApiCollection<ApiResourceAllocationRequest>(apiModel)
+            {
+                TotalCount = countEnabled ? result.TotalCount : null
+            };
         }
 
         [HttpGet("departments/{departmentString}/resources/requests/tbn")]

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -47,6 +47,12 @@ namespace Fusion.Resources.Domain.Queries
             return this;
         }
 
+        public GetResourceAllocationRequests WithExcludeDrafts(bool excludeDrafts = true)
+        {
+            ExcludeDrafts = excludeDrafts;
+            return this;
+        }
+
         public GetResourceAllocationRequests WithAssignedDepartment(string departmentString)
         {
             DepartmentString = departmentString;
@@ -185,9 +191,10 @@ namespace Fusion.Resources.Domain.Queries
                 if (!countOnly)
                 {
                     await AddWorkFlows(pagedQuery);
-                    await AddOrgPositions(pagedQuery, request.Expands);
                     await AddProposedPersons(pagedQuery);
                 }
+                
+                await AddOrgPositions(pagedQuery, request.Expands);
 
                 return pagedQuery;
             }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -192,9 +192,8 @@ namespace Fusion.Resources.Domain.Queries
                 {
                     await AddWorkFlows(pagedQuery);
                     await AddProposedPersons(pagedQuery);
+                    await AddOrgPositions(pagedQuery, request.Expands);
                 }
-                
-                await AddOrgPositions(pagedQuery, request.Expands);
 
                 return pagedQuery;
             }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
@@ -146,6 +146,24 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.UnassignedRequests
             resp.Value.value.Single().orgPosition.instances.Should().HaveCount(3);
         }
 
+        [Fact]
+        public async Task SupportsOnlyCount()
+        {
+            var department = "TPD PRD MY TEST DEP2";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = department);
+
+            using var adminScope = fixture.AdminScope();
+
+            await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testProject.AddPosition().WithBasePosition(bp));
+            await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, testProject.AddPosition().WithBasePosition(bp));
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview&$count=only",
+                new { totalCount = -1 });
+            resp.Value.totalCount.Should().Be(2);
+        }
+
         public Task DisposeAsync()
         {
             return Task.CompletedTask;


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Add `$count` parameter to unassigned requests for department endpoint

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

