### PR TITLE
Internal Requests - Incorrect default state when initializing workflow

### DIFF
--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/InitializedHandler.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/InitializedHandler.cs
@@ -53,7 +53,7 @@ namespace Fusion.Resources.Logic.Commands
                     dbContext.Workflows.Add(workflow.CreateDatabaseEntity(notification.RequestId, DbRequestType.InternalRequest));
 
                     request.LastActivity = DateTime.UtcNow;
-                    request.State.State = AllocationDirectWorkflowV1.CREATED;
+                    request.State.State = workflow.GetCurrent().Id;
 
                     // Try to resolve the default assigned department
                     if (request.AssignedDepartment is null)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/JointVentureRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/JointVentureRequestTests.cs
@@ -107,7 +107,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         [Theory]
         [InlineData("isDraft", false)]
-        [InlineData("state", "created")]
+        [InlineData("state", "approval")]
         public async Task JVRequest_Start_ShouldSet(string property, object value)
         {
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -201,7 +201,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         [Theory]
         [InlineData("isDraft", false)]
-        [InlineData("state", "created")]
+        [InlineData("state", "proposal")]
         public async Task NormalRequest_Start_ShouldSet(string property, object value)
         {
             using var adminScope = fixture.AdminScope();


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When initializing workflow previously the state returned was 'created'.
Should return state id based on current workflow step


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Changed tests to reflect new state.
Can be verified when initializing workflow using client, checking state returned.


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

