### PR TITLE
Avoid replacing absence to date with from date when null

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
@@ -139,14 +139,14 @@ namespace Fusion.Resources.Api.Controllers
             {
                 Id = absence.Id;
                 AppliesFrom = absence.AppliesFrom.UtcDateTime;
-                AppliesTo = absence.AppliesTo is null ? absence.AppliesFrom.UtcDateTime : absence.AppliesTo!.Value.UtcDateTime;
+                AppliesTo = absence.AppliesTo?.UtcDateTime;
                 Type = $"{absence.Type}";
                 AbsencePercentage = absence.AbsencePercentage;
             }
 
             public Guid Id { get; set; }
             public DateTime AppliesFrom { get; set; }
-            public DateTime AppliesTo { get; set; }
+            public DateTime? AppliesTo { get; set; }
             public double? AbsencePercentage { get; set; }
             public string Type { get; set; } = null!;
         }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When applies to and applies from is the same date, the frontend cannot determine wether the end date is actually set. To prevent this, we can just send back the null value as is



**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

