### PR TITLE
Task owner authorization on requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IAuthorizationHandler, RequestAccessAuthHandler>();
             services.AddScoped<IAuthorizationHandler, ContractorInContractHandler>();
             services.AddScoped<IAuthorizationHandler, ContractorInProjectHandler>();
+            services.AddScoped<IAuthorizationHandler, OrgPositionAccessHandler>();
 
             return services;
         }

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/OrgPositionAccessHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/OrgPositionAccessHandler.cs
@@ -1,0 +1,90 @@
+﻿using Fusion.Resources.Api.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Authorization.Handlers
+{
+    public class OrgPositionAccessHandler : AuthorizationHandler<Requirements.OrgPositionAccessRequirement>
+    {
+        private readonly IOrgApiClientFactory orgApiClientFactory;
+        private readonly IMemoryCache memCache;
+
+        public OrgPositionAccessHandler(IOrgApiClientFactory orgApiClientFactory, IMemoryCache memCache)
+        {
+            this.orgApiClientFactory = orgApiClientFactory;
+            this.memCache = memCache;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, OrgPositionAccessRequirement requirement)
+        {
+            if (context.User.GetAzureUniqueId() is null)
+            {
+                requirement.SetEvaluation("No unique object id located, cannot evaluate");
+                return;
+            }
+
+            var allowedMethods = await QueryAccessAsync(context, requirement);
+            
+            if (allowedMethods is null)
+                return;
+
+            switch (requirement.RequiredLevel)
+            {
+                case OrgPositionAccessRequirement.AccessLevel.Read:
+                    if (allowedMethods.Contains("get", StringComparer.OrdinalIgnoreCase))
+                        context.Succeed(requirement);
+                    break;
+
+                case OrgPositionAccessRequirement.AccessLevel.Write:
+                    if (allowedMethods.Contains("put", StringComparer.OrdinalIgnoreCase))
+                        context.Succeed(requirement);
+                    break;
+            }
+
+        }
+
+        private async Task<IEnumerable<string>?> QueryAccessAsync(AuthorizationHandlerContext context, OrgPositionAccessRequirement requirement)
+        {
+            string cacheKey = $"position-options-{requirement.OrgPositionId}-{context.User.GetAzureUniqueIdOrThrow()}";
+            
+            if (memCache.TryGetValue(cacheKey, out string[] cachedHeaders))
+            {
+                requirement.SetEvaluation("Using cached access info...");
+                return cachedHeaders;
+            }
+
+            var client = orgApiClientFactory.CreateClient(ApiClientMode.Delegate);
+
+            var request = new HttpRequestMessage(new HttpMethod("OPTIONS"), $"/projects/{requirement.OrgProjectId}/positions/{requirement.OrgPositionId}");
+            var response = await client.SendAsync(request);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                requirement.SetEvaluation("Org service reported no access");
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                requirement.SetEvaluation($"Could not query access from org chart. Service responded with {response.StatusCode}");
+                return null;
+            }
+
+            var allowedMethods = response.Content.Headers.Allow;
+
+            if (!allowedMethods.Any())
+            {
+                requirement.SetEvaluation("No allow header located...");
+                return null;
+            }
+
+            memCache.Set(cacheKey, allowedMethods.ToArray(), TimeSpan.FromMinutes(5));
+            return allowedMethods;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/OrgPositionAccessRequirement.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/OrgPositionAccessRequirement.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Authorization.Requirements
+{
+    public class OrgPositionAccessRequirement : Fusion.Authorization.FusionAuthorizationRequirement
+    {
+        public Guid OrgProjectId { get; }
+        public Guid OrgPositionId { get; }
+        public AccessLevel RequiredLevel { get; }
+
+        public override string Description => $"Must atleast have '{RequiredLevel}' access on the specific position in the org chart";
+
+        public override string Code => "OrgChartAccess";
+
+        public enum AccessLevel { Read, Write }
+
+        private OrgPositionAccessRequirement(AccessLevel requiredLevel, Guid orgProjectId, Guid orgPositionId)
+        {
+            RequiredLevel = requiredLevel;
+            OrgProjectId = orgProjectId;
+            OrgPositionId = orgPositionId;
+        }
+
+        public static OrgPositionAccessRequirement OrgPositionRead(Guid orgProjectId, Guid orgPositionId) => new OrgPositionAccessRequirement(AccessLevel.Read, orgProjectId, orgPositionId);
+        public static OrgPositionAccessRequirement OrgPositionWrite(Guid orgProjectId, Guid orgPositionId) => new OrgPositionAccessRequirement(AccessLevel.Write, orgProjectId, orgPositionId);
+
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -123,7 +123,7 @@ namespace Fusion.Resources.Api.Controllers
                     or.BeResourceOwner(user.fullDepartment);
                 });
             });
-
+            
             if (authResult.Unauthorized)
                 return authResult.CreateForbiddenResponse();
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using FluentValidation;
 using Fusion.AspNetCore.FluentAuthorization;
 using Fusion.AspNetCore.OData;
+using Fusion.Authorization;
+using Fusion.Integration.Org;
 using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Commands;
 using Fusion.Resources.Domain.Queries;
@@ -259,7 +261,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    // For now everyone with a position in the project can view requests
+                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(projectIdentifier.ProjectId));
                 });
             });
 
@@ -338,7 +341,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    // For now everyone with a position in the project can view requests
+                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(result.Project.OrgProjectId));                    
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -34,7 +34,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    or.OrgChartPositionWriteAccess(projectIdentifier.ProjectId, request.OrgPositionId);
                 });
             });
 
@@ -167,6 +167,11 @@ namespace Fusion.Resources.Api.Controllers
             Guid requestId, 
             [FromBody] PatchInternalRequestRequest request)
         {
+            var item = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+
+            if (item == null)
+                return ApiErrors.NotFound("Could not locate request", $"{requestId}");
+
             #region Authorization
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
@@ -174,7 +179,14 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    if (item.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
 
+                    if (item.AssignedDepartment is not null)
+                        or.BeResourceOwner(new DepartmentPath(item.AssignedDepartment).Parent(), includeDescendants: true);
+
+                    if (item.AssignedDepartment is null && item.OrgPosition is not null)
+                        or.BeResourceOwner(new DepartmentPath(item.OrgPosition.BasePosition.Department).GoToLevel(3), includeDescendants: true);
                 });
             });
 
@@ -185,12 +197,6 @@ namespace Fusion.Resources.Api.Controllers
 
             try
             {
-                var item = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
-
-                if (item == null)
-                    return ApiErrors.NotFound("Could not locate request", $"{requestId}");
-
-
                 var updateCommand = new UpdateInternalRequest(requestId);
 
                 if (request.AdditionalNote.HasValue) updateCommand.AdditionalNote = request.AdditionalNote.Value;
@@ -231,7 +237,10 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    or.BeTrustedApplication();
 
+                    // Can start with PRD, should maybe instead trim results when competence center starts.
+                    or.BeResourceOwner("TPD PRD", includeParents: true, includeDescendants: true);
                 });
             });
 
@@ -301,7 +310,9 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    // Start with allowing PRD resource owners access. 
+                    // We must eventually allow all resource owners, but trim the list based which is relevant for the business unit.
+                    or.BeResourceOwner("TPD PRD", includeParents: true, includeDescendants: true);
                 });
             });
 
@@ -342,7 +353,16 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     // For now everyone with a position in the project can view requests
-                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(result.Project.OrgProjectId));                    
+                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(result.Project.OrgProjectId));
+
+                    if (result.OrgPositionId.HasValue)
+                        or.OrgChartPositionReadAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
+
+                    if (result.AssignedDepartment is not null)
+                        or.BeResourceOwner(new DepartmentPath(result.AssignedDepartment).Parent(), includeDescendants: true);
+
+                    if (result.AssignedDepartment is null && result.OrgPosition is not null)
+                        or.BeResourceOwner(new DepartmentPath(result.OrgPosition.BasePosition.Department).GoToLevel(3), includeDescendants: true);
                 });
             });
 
@@ -375,7 +395,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    if (result.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });
             });
 
@@ -456,7 +477,11 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    if (result.Type == InternalRequestType.Allocation)
+                    {
+                        if (result.OrgPositionId.HasValue)
+                            or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
+                    }
                 });
 
             });
@@ -534,6 +559,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    if (result.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });
 
             });
@@ -719,11 +746,18 @@ namespace Fusion.Resources.Api.Controllers
         [HttpOptions("/projects/{projectIdentifier}/resources/requests/{requestId}/approve")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> CheckApprovalAccess([FromRoute] ProjectIdentifier projectIdentifier, Guid requestId)
         {
+            var result = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+
+            if (result == null)
+                return ApiErrors.NotFound("Could not locate request", $"{requestId}");
+
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    if (result.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });
 
             });
@@ -741,11 +775,18 @@ namespace Fusion.Resources.Api.Controllers
         [HttpOptions("/projects/{projectIdentifier}/resources/requests/{requestId}")]
         public async Task<ActionResult> CheckProjectAllocationRequestAccess([FromRoute] ProjectIdentifier projectIdentifier, Guid requestId)
         {
+            var result = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+
+            if (result == null)
+                return ApiErrors.NotFound("Could not locate request", $"{requestId}");
+
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    if (result.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });
 
             });

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ProjectRequestAccessTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ProjectRequestAccessTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fusion.ApiClients.Org;
+using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Testing;
+using Fusion.Testing.Authentication.User;
+using Fusion.Testing.Mocks;
+using Fusion.Testing.Mocks.OrgService;
+using Fusion.Testing.Mocks.ProfileService;
+using Xunit;
+using Xunit.Abstractions;
+#nullable enable 
+
+namespace Fusion.Resources.Api.Tests.IntegrationTests
+{
+    public class ProjectRequestAccessTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
+    {
+        private readonly ResourceApiFixture fixture;
+        private readonly TestLoggingScope loggingScope;
+
+        /// <summary>
+        ///     Will be generated new for each test
+        /// </summary>
+        private ApiPersonProfileV3 testUser;
+
+
+        // Created by the async lifetime
+        private TestApiInternalRequestModel normalRequest = null!;
+        private FusionTestProjectBuilder testProject = null!;
+
+        private Guid projectId => testProject.Project.ProjectId;
+
+        public ProjectRequestAccessTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+
+            // Generate random test user
+            testUser = fixture.AddProfile(FusionAccountType.External);
+        }
+
+        private HttpClient Client => fixture.ApiFactory.CreateClient();
+
+        public async Task InitializeAsync()
+        {
+            // Mock profile
+            testUser = PeopleServiceMock.AddTestProfile()
+                .SaveProfile();
+
+            // Mock project
+            testProject = new FusionTestProjectBuilder()
+                .WithPositions(200)
+                .AddToMockService();
+
+            // Prepare context resolver.
+            fixture.ContextResolver
+                .AddContext(testProject.Project);
+
+            // Prepare admin client
+            var adminClient = fixture.ApiFactory.CreateClient()
+                .WithTestUser(fixture.AdminUser)
+                .AddTestAuthToken();
+
+            // Create a default request we can work with
+            normalRequest = await adminClient.CreateDefaultRequestAsync(testProject, r => r.AsTypeNormal());
+        }
+
+        [Theory]
+        [InlineData("projectMember", true)]
+        [InlineData("normalEmployee", false)]
+        public async Task GetProjectRequests_When(string testCase, bool shouldHaveAccess)
+        {            
+            var projectMemberUser = fixture.AddProfile(FusionAccountType.Employee);
+            
+            if (testCase == "projectMember")
+                projectMemberUser.WithPosition(testProject.AddPosition().WithEnsuredFutureInstances().WithAssignedPerson(projectMemberUser));
+
+            using var projectMemberScope = fixture.UserScope(projectMemberUser);
+
+            var resp = await Client.TestClientGetAsync<object>($"/projects/{projectId}/resources/requests");
+            
+            if (shouldHaveAccess)
+                resp.Should().BeSuccessfull();
+            else
+                resp.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("projectMember", true)]
+        [InlineData("normalEmployee", false)]
+        public async Task GetRequestInProject_When(string testCase, bool shouldHaveAccess)
+        {
+            var projectMemberUser = fixture.AddProfile(FusionAccountType.Employee);
+
+            if (testCase == "projectMember")
+                projectMemberUser.WithPosition(testProject.AddPosition().WithEnsuredFutureInstances().WithAssignedPerson(projectMemberUser));
+
+            using var projectMemberScope = fixture.UserScope(projectMemberUser);
+
+            var resp = await Client.TestClientGetAsync<object>($"/projects/{projectId}/resources/requests/{normalRequest.Id}");
+
+            if (shouldHaveAccess)
+                resp.Should().BeSuccessfull();
+            else
+                resp.Should().BeUnauthorized();
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+
+    public static class ApiPersonProfileV3Extensions
+    {
+        public static ApiPersonProfileV3 WithPosition(this ApiPersonProfileV3 profile, ApiPositionV2 position)
+        {
+            var personPositions = position.Instances
+                .Where(i => i.AssignedPerson?.AzureUniqueId == profile.AzureUniqueId)
+                .Select(i => new ApiPersonPositionV3()
+                {
+                    AppliesFrom = i.AppliesFrom,
+                    AppliesTo = i.AppliesTo,
+                    Id = i.Id,
+                    BasePosition = new ApiPersonBasePositionV3()
+                    {
+                        Id = position.BasePosition.Id,
+                        Discipline = position.BasePosition.Discipline,
+                        Name = position.BasePosition.Name,
+                        SubDiscipline = position.BasePosition.SubDiscipline,
+                        Type = position.BasePosition.ProjectType
+                    },
+                    Name = position.Name,
+                    Obs = i.Obs,
+                    ParentPositionId = i.ParentPositionId,
+                    PositionExternalId = position.ExternalId,
+                    PositionId = position.Id,
+                    Project = new ApiPersonPositionProjectV3()
+                    {
+                        Id = position.ProjectId,
+                        DomainId = position.Project.DomainId,
+                        Name = position.Project.Name,
+                        Type = position.Project.ProjectType
+                    },
+                    Workload = i.Workload,
+                    TaskOwnerIds = i.TaskOwnerIds
+                }).ToList();
+
+            if (profile.Positions is null)
+                profile.Positions = new System.Collections.Generic.List<ApiPersonPositionV3>();
+
+            profile.Positions.AddRange(personPositions);
+
+            return profile;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgRequestInterceptor.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgRequestInterceptor.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class OrgRequestInterceptor : IDisposable
+    {
+        public HttpMethod Method { get; set; }
+        public string RequestPattern { get; set; }
+
+        public Func<string, HttpContext, Task> Processor { get; set; }
+
+
+        public OrgRequestInterceptor RespondWithHeaders(HttpStatusCode code, Action<IHeaderDictionary> headers)
+        {
+            Processor = (body, context) =>
+            {
+                context.Response.StatusCode = (int)code;
+                headers(context.Response.Headers);
+                return Task.CompletedTask;
+            };
+
+            return this;
+        }
+
+        public void Dispose()
+        {
+            OrgRequestMocker.RemoveInterceptor(this);
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgRequestMocker.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgRequestMocker.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+
+namespace Fusion.Testing.Mocks.OrgService
+{
+    public class OrgRequestMocker
+    {
+        public static OrgRequestMocker Current { get; } = new();
+
+        public List<OrgRequestInterceptor> Interceptors { get; } = new();
+
+
+        public OrgRequestInterceptor Intercept(HttpMethod method, string requestPattern)
+        {
+            var interceptor = new OrgRequestInterceptor()
+            {
+                Method = method,
+                RequestPattern = requestPattern
+            };
+
+            Interceptors.Add(interceptor);
+
+            return interceptor;
+        }
+
+        public static OrgRequestInterceptor InterceptOption(string requestPattern)
+        {
+            var interceptor = new OrgRequestInterceptor()
+            {
+                Method = HttpMethod.Options,
+                RequestPattern = requestPattern
+            };
+
+            lock (Current)
+            {
+                Current.Interceptors.Add(interceptor);
+            }
+
+            return interceptor;
+        }
+
+
+        public static void RemoveInterceptor(OrgRequestInterceptor interceptor)
+        {
+            lock (Current)
+            {
+                Current.Interceptors.Remove(interceptor);
+            }
+        }
+
+        internal OrgRequestInterceptor GetInterceptor(HttpRequest request)
+        {
+            foreach (var interceptor in Interceptors)
+            {
+                if (!string.Equals(interceptor.Method.Method, request.Method, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (Regex.IsMatch(request.Path.ToString(), interceptor.RequestPattern))
+                    return interceptor;
+            }
+
+            return null;
+        }
+    }
+
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
@@ -58,4 +58,5 @@ namespace Fusion.Testing.Mocks.OrgService
             .RuleFor(c => c.Id, f => Guid.NewGuid())
             .RuleFor(c => c.Name, f => f.Company.CompanyName());
     }
+
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added authorization rules for the task owners on internal requests.
Based access on project membership and if user has read/write permission on the relevant position. This is done by executing an option call to the org api for the relevant position.
The option response is cached in 5 minutes to cover a short session.


**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Will create integration tests.


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

