### PR TITLE
Updated to instance based task owner endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
@@ -45,28 +45,6 @@ namespace Fusion.Resources.Domain
         }
 
         /// <summary>
-        /// Resolve the task owner for the position.
-        /// 
-        /// The task owner could be empty, however this is unlikely. The default is that if no task owner can be located the project director is used.
-        /// </summary>
-        /// <param name="projectId">The project the position exists in</param>
-        /// <param name="positionId">The position id</param>
-        /// <param name="date">Optionally provide a date to use for calculating the report path. If left out today is used.</param>
-        /// <returns>Task owner or null if none could be located</returns>
-        public static async Task<RequestResponse<ApiPositionV2?>> GetTaskOwnerAsync(this IOrgApiClient client, Guid projectId, Guid positionId, DateTime? date = null)
-        {
-            if (positionId == Guid.Empty)
-                throw new ArgumentException("Position id cannot be empty when updating.");
-
-            var url = $"projects/{projectId}/positions/{positionId}/task-owner?api-version=2.0";
-
-            if (date != null)
-                url += $"&date={date:yyyy-MM-dd}";
-
-            return await GetAsync<ApiPositionV2?>(client, url);
-        }
-
-        /// <summary>
         /// Resolve the task owner for a specific instance on the position.
         /// This operation will return the task owner at the start of the instance (applies from date) if no other date is specified.
         /// 
@@ -76,15 +54,12 @@ namespace Fusion.Resources.Domain
         /// <param name="positionId">The position id</param>
         /// <param name="date">Optionally provide a date to use for calculating the report path. If left out today is used.</param>
         /// <returns>The return object is a bit different </returns>
-        public static async Task<RequestResponse<ApiTaskOwnerV2?>> GetInstanceTaskOwnerAsync(this IOrgApiClient client, Guid projectId, Guid positionId, Guid instanceId, DateTime? date = null)
+        public static async Task<RequestResponse<ApiTaskOwnerV2?>> GetInstanceTaskOwnerAsync(this IOrgApiClient client, Guid projectId, Guid positionId, Guid instanceId)
         {
             if (positionId == Guid.Empty)
                 throw new ArgumentException("Position id cannot be empty when updating.");
 
             var url = $"projects/{projectId}/positions/{positionId}/instances/{instanceId}/task-owner?api-version=2.0";
-
-            if (date != null)
-                url += $"&date={date:yyyy-MM-dd}";
 
             return await GetAsync<ApiTaskOwnerV2?>(client, url);
         }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.2.0" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.0" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.4" />
     <PackageReference Include="Fusion.AspNetCore" Version="5.0.0" />
   </ItemGroup>
   

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -33,7 +33,7 @@ namespace Fusion.Testing.Mocks.OrgService
         internal static List<ApiClients.Org.ApiPositionV2> contractPositions = new List<ApiClients.Org.ApiPositionV2>();
         internal static List<ApiCompanyV2> companies = new List<ApiCompanyV2>();
 
-        internal static Dictionary<Guid, Guid> taskOwnerMapping = new Dictionary<Guid, Guid>();
+        internal static ConcurrentDictionary<Guid, Guid> taskOwnerMapping = new ConcurrentDictionary<Guid, Guid>();
 
         internal static SemaphoreSlim semaphore = new SemaphoreSlim(1);
 
@@ -92,17 +92,17 @@ namespace Fusion.Testing.Mocks.OrgService
 
         public static void SetTaskOwner(Guid position, Guid taskOwnerPosition)
         {
-            semaphore.Wait();
-            try
-            {
-                taskOwnerMapping[position] = taskOwnerPosition;
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            taskOwnerMapping.TryAdd(position, taskOwnerPosition);
         }
 
+        public static ApiPositionV2 GetPosition(Guid id)
+        {
+            return positions.FirstOrDefault(p => p.Id == id);
+        }
+        public static ApiProjectV2 GetProject(Guid id)
+        {
+            return projects.FirstOrDefault(p => p.ProjectId == id);
+        }
         //public static ApiPositionV2 ResolveContractPosition(Guid position)
         //{
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
In some cases the task owner is incorrectly returned from resources. This might be based on manually calulating the relevant date. There is an endpoint that is specifically made to get the relevant taskowner for an exact instance, using either start/end or todays date.
Change expand task owner functionality in specific request query, to use the instance based endpoint.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Should be verified by testing on future position


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

