### PR TITLE
Include assigned resource owner on requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -65,7 +65,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #region Validate input if timeline is expanded
 
-            var shouldExpandTimeline = query.ShoudExpand("timeline");
+            var shouldExpandTimeline = ODataParamsExtensions.ShouldExpand(query, "timeline");
             if (shouldExpandTimeline)
             {
                 if (timelineStart is null)
@@ -134,7 +134,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #region Validate input if timeline is expanded
 
-            var shouldExpandTimeline = query.ShoudExpand("timeline");
+            var shouldExpandTimeline = ODataParamsExtensions.ShouldExpand(query, "timeline");
             if (shouldExpandTimeline)
             {
                 if (timelineStart is null)

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -65,7 +65,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #region Validate input if timeline is expanded
 
-            var shouldExpandTimeline = ODataParamsExtensions.ShouldExpand(query, "timeline");
+            var shouldExpandTimeline = query.ShouldExpand("timeline");
             if (shouldExpandTimeline)
             {
                 if (timelineStart is null)
@@ -134,7 +134,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #region Validate input if timeline is expanded
 
-            var shouldExpandTimeline = ODataParamsExtensions.ShouldExpand(query, "timeline");
+            var shouldExpandTimeline = query.ShouldExpand("timeline");
             if (shouldExpandTimeline)
             {
                 if (timelineStart is null)

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -1,20 +1,24 @@
-﻿using System;
+﻿using Fusion.ApiClients.Org;
+using Fusion.Resources.Api.Controllers.Departments;
+using Fusion.Resources.Domain;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
-using Fusion.ApiClients.Org;
-using Fusion.Resources.Domain;
 
 namespace Fusion.Resources.Api.Controllers
 {
     public class ApiResourceAllocationRequest
     {
-        public ApiResourceAllocationRequest(QueryResourceAllocationRequest query)
+        public ApiResourceAllocationRequest(QueryResourceAllocationRequest query, QueryDepartment department)
         {
             Id = query.RequestId;
             Number = query.RequestNumber;
 
             AssignedDepartment = query.AssignedDepartment;
+            
+            if (department is not null)
+                AssignedDepartmentDetails = new ApiDepartment(department);
+
             Discipline = query.Discipline;
             State = query.State;
             Type = $"{query.Type}";
@@ -65,6 +69,7 @@ namespace Fusion.Resources.Api.Controllers
         public long Number { get; set; }
 
         public string? AssignedDepartment { get; set; }
+        public ApiDepartment? AssignedDepartmentDetails { get; }
         public string? Discipline { get; set; }
         public string? State { get; set; }
         /// <summary>Type of request

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -9,15 +9,14 @@ namespace Fusion.Resources.Api.Controllers
 {
     public class ApiResourceAllocationRequest
     {
-        public ApiResourceAllocationRequest(QueryResourceAllocationRequest query, QueryDepartment department)
+        public ApiResourceAllocationRequest(QueryResourceAllocationRequest query)
         {
             Id = query.RequestId;
             Number = query.RequestNumber;
 
             AssignedDepartment = query.AssignedDepartment;
-            
-            if (department is not null)
-                AssignedDepartmentDetails = new ApiDepartment(department);
+            if (query.AssignedDepartmentDetails is not null)
+                AssignedDepartmentDetails = new ApiDepartment(query.AssignedDepartmentDetails);
 
             Discipline = query.Discipline;
             State = query.State;

--- a/src/backend/api/Fusion.Resources.Application/LineOrg/LineOrgResolver.cs
+++ b/src/backend/api/Fusion.Resources.Application/LineOrg/LineOrgResolver.cs
@@ -83,17 +83,29 @@ namespace Fusion.Resources.Application.LineOrg
 
             var rebuiltCache = new DepartmentCache();
 
-            await UpdateCacheItemsUnsafe(rebuiltCache);
+            try
+            {
+                await UpdateCacheItemsUnsafe(rebuiltCache);
 
-            cache = rebuiltCache;
-            semaphoreSlim.Release();
+                cache = rebuiltCache;
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
         }
 
         private async Task UpdateCacheItems(string? filter = null)
         {
             await semaphoreSlim.WaitAsync();
-            await UpdateCacheItemsUnsafe(cache, filter);
-            semaphoreSlim.Release();
+            try
+            {
+                await UpdateCacheItemsUnsafe(cache, filter);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
         }
 
         private async Task UpdateCacheItemsUnsafe(DepartmentCache cache, string? filter = null)

--- a/src/backend/api/Fusion.Resources.Domain/Extensions/ODataParamsExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/ODataParamsExtensions.cs
@@ -6,7 +6,7 @@ namespace Fusion.Resources.Domain
 {
     public static class ODataParamsExtensions
     {
-        public static bool ShoudExpand(this ODataQueryParams query, string property)
+        public static bool ShouldExpand(this ODataQueryParams query, string property)
         {
             if (query.Expand != null && query.Expand.Contains(property, StringComparer.OrdinalIgnoreCase))
                 return true;

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -84,6 +84,7 @@ namespace Fusion.Resources.Domain
         public Guid? OrgPositionInstanceId { get; set; }
 
         public string? AssignedDepartment { get; set; }
+        public QueryDepartment? AssignedDepartmentDetails { get; set; }
         public string? Discipline { get; set; }
         public InternalRequestType Type { get; set; }
         public string? SubType { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
@@ -34,10 +34,10 @@ namespace Fusion.Resources.Domain
 
                 if (value != null)
                 {
-                    if (value.ShoudExpand("requests"))
+                    if (ODataParamsExtensions.ShouldExpand(value, "requests"))
                         Expands |= ExpandProperties.Requests;
 
-                    if (value.ShoudExpand("positions"))
+                    if (ODataParamsExtensions.ShouldExpand(value, "positions"))
                         Expands |= ExpandProperties.Positions;
                 }
             }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
@@ -34,10 +34,10 @@ namespace Fusion.Resources.Domain
 
                 if (value != null)
                 {
-                    if (ODataParamsExtensions.ShouldExpand(value, "requests"))
+                    if (value.ShouldExpand("requests"))
                         Expands |= ExpandProperties.Requests;
 
-                    if (ODataParamsExtensions.ShouldExpand(value, "positions"))
+                    if (value.ShouldExpand("positions"))
                         Expands |= ExpandProperties.Positions;
                 }
             }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequest.cs
@@ -25,7 +25,7 @@ namespace Fusion.Resources.Domain.Queries
 
         public GetContractPersonnelRequest WithQuery(ODataQueryParams query)
         {
-            if (query.ShoudExpand("comments"))
+            if (ODataParamsExtensions.ShouldExpand(query, "comments"))
             {
                 Expands |= ExpandProperties.RequestComments;
             }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequest.cs
@@ -25,7 +25,7 @@ namespace Fusion.Resources.Domain.Queries
 
         public GetContractPersonnelRequest WithQuery(ODataQueryParams query)
         {
-            if (ODataParamsExtensions.ShouldExpand(query, "comments"))
+            if (query.ShouldExpand("comments"))
             {
                 Expands |= ExpandProperties.RequestComments;
             }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
@@ -54,7 +54,7 @@ namespace Fusion.Resources.Domain.Queries
         {
             Query = query;
 
-            if (ODataParamsExtensions.ShouldExpand(query, "originalPosition"))
+            if (query.ShouldExpand("originalPosition"))
                 Expands |= ExpandFields.OriginalPosition;
 
             return this;

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
@@ -54,7 +54,7 @@ namespace Fusion.Resources.Domain.Queries
         {
             Query = query;
 
-            if (query.ShoudExpand("originalPosition"))
+            if (ODataParamsExtensions.ShouldExpand(query, "originalPosition"))
                 Expands |= ExpandFields.OriginalPosition;
 
             return this;

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
@@ -22,23 +22,23 @@ namespace Fusion.Resources.Domain
 
         private string? departmentFilter;
         private string? sector;
-        private string? departmentId;
+        private string[]? departmentIds = null;
 
         public IQueryable<QueryDepartment> Execute(IQueryable<DbDepartment> departments)
         {
-            if(!string.IsNullOrEmpty(sector))
+            if (!string.IsNullOrEmpty(sector))
             {
                 departments = departments.Where(dpt => dpt.SectorId == sector);
             }
 
-            if(!string.IsNullOrEmpty(departmentFilter))
+            if (!string.IsNullOrEmpty(departmentFilter))
             {
                 departments = departments.Where(dpt => dpt.DepartmentId.StartsWith(departmentFilter));
             }
 
-            if (!string.IsNullOrEmpty(departmentId))
+            if (departmentIds?.Any() == true)
             {
-                departments = departments.Where(dpt => dpt.DepartmentId == departmentId);
+                departments = departments.Where(dpt => departmentIds.Contains(dpt.DepartmentId));
             }
 
             return departments.Select(dpt => new QueryDepartment(dpt));
@@ -52,7 +52,12 @@ namespace Fusion.Resources.Domain
 
         public GetDepartments ById(string departmentId)
         {
-            this.departmentId = departmentId;
+            departmentIds = new []{ departmentId };
+            return this;
+        }
+        public GetDepartments ByIds(params string[] departmentIds)
+        {
+            this.departmentIds = departmentIds;
             return this;
         }
 
@@ -87,7 +92,7 @@ namespace Fusion.Resources.Domain
             private readonly IFusionProfileResolver profileResolver;
 
             public Handler(ResourcesDbContext db, ILineOrgResolver lineOrgResolver, IFusionProfileResolver profileResolver)
-            { 
+            {
                 this.db = db;
                 this.lineOrgResolver = lineOrgResolver;
                 this.profileResolver = profileResolver;
@@ -99,26 +104,26 @@ namespace Fusion.Resources.Domain
                 var departments = await request.Execute(db.Departments)
                     .ToDictionaryAsync(dpt => dpt.DepartmentId, cancellationToken);
 
-                if(request.shouldExpandResourceOwners)
+                if (request.shouldExpandResourceOwners)
                 {
                     var searchedDepartments = departments.Keys!.ToHashSet();
 
-                    //TODO: maybe solve this in a smarter way
-                    if(request.resourceOwnerSearch is null && request.departmentId is not null)
+                    // Optimize search when searching for a specific department
+                    if (request.resourceOwnerSearch is null && request.departmentIds?.Length == 1)
                     {
-                        request.resourceOwnerSearch = request.departmentId;
+                        request.resourceOwnerSearch = request.departmentIds.Single();
                     }
 
                     var resourceOwners = await lineOrgResolver
                         .GetResourceOwners(request.resourceOwnerSearch, cancellationToken);
 
-                    foreach(var resourceOwner in resourceOwners)
+                    foreach (var resourceOwner in resourceOwners)
                     {
                         if (!searchedDepartments.Contains(resourceOwner.DepartmentId)) continue;
 
                         var department = departments[resourceOwner.DepartmentId];
                         department.LineOrgResponsible = resourceOwner.Responsible;
-                        
+
                         result.Add(department!);
                     }
                 }
@@ -127,7 +132,7 @@ namespace Fusion.Resources.Domain
                     result = departments.Values.ToList();
                 }
 
-                if(request.shouldExpandDelegatedResourceOwners)
+                if (request.shouldExpandDelegatedResourceOwners)
                 {
                     foreach (var department in result)
                     {
@@ -146,7 +151,7 @@ namespace Fusion.Resources.Domain
                                 .ToList();
                         }
                     }
-                    
+
                 }
 
                 return result;

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -20,19 +20,19 @@ namespace Fusion.Resources.Domain.Queries
 
         public GetResourceAllocationRequestItem WithQuery(ODataQueryParams query)
         {
-            if (ODataParamsExtensions.ShouldExpand(query, "comments"))
+            if (query.ShouldExpand("comments"))
             {
                 Expands |= ExpandProperties.RequestComments;
             }
-            if (ODataParamsExtensions.ShouldExpand(query, "taskOwner"))
+            if (query.ShouldExpand("taskOwner"))
             {
                 Expands |= ExpandProperties.TaskOwner;
             }
-            if (ODataParamsExtensions.ShouldExpand(query, "proposedPerson.resourceOwner"))
+            if (query.ShouldExpand("proposedPerson.resourceOwner"))
             {
                 Expands |= ExpandProperties.ResourceOwner;
             }
-            if (ODataParamsExtensions.ShouldExpand(query, "departmentDetails"))
+            if (query.ShouldExpand("departmentDetails"))
             {
                 Expands |= ExpandProperties.DepartmentDetails;
             }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/MockHttpClientBuilder.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/MockHttpClientBuilder.cs
@@ -21,6 +21,9 @@ namespace Fusion.Resources.Api.Tests.Fixture
         private const string baseaddress = "http://mock-api.local";
         private readonly MockApi stubs = new MockApi();
 
+        private string defaultResponseContent = null;
+        private HttpStatusCode defaultResponseCode = HttpStatusCode.NotFound;
+
         public void WithResponse(StubResponse response)
         {
             if(stubs.Contains(response.Url))
@@ -34,6 +37,14 @@ namespace Fusion.Resources.Api.Tests.Fixture
             => WithResponse(new StubResponse(url, content, statusCode));
         public void WithResponse<T>(string url, T data, HttpStatusCode statusCode = HttpStatusCode.OK)
             => WithResponse(url, JsonSerializer.Serialize(data), statusCode);
+
+        public void WithDefaultResponse(string data, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            defaultResponseContent = data;
+            defaultResponseCode = statusCode;
+        }
+        public void WithDefaultResponse<T>(T data, HttpStatusCode statusCode = HttpStatusCode.OK)
+            => WithDefaultResponse(JsonSerializer.Serialize(data), statusCode);
 
         public HttpClient Build()
         {
@@ -49,7 +60,10 @@ namespace Fusion.Resources.Api.Tests.Fixture
                     {
                         return new HttpResponseMessage
                         {
-                            StatusCode = HttpStatusCode.NotFound
+                            StatusCode = defaultResponseCode,
+                            Content = defaultResponseContent is not null
+                                ? new StringContent(defaultResponseContent)
+                                : null
                         };
                     }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -9,6 +9,7 @@ using Fusion.Testing;
 using System.Threading.Tasks;
 using Fusion.Resources.Api.Tests.FusionMocks;
 using System.Data;
+using System.Collections.Generic;
 
 namespace Fusion.Resources.Api.Tests.Fixture
 {
@@ -68,7 +69,6 @@ namespace Fusion.Resources.Api.Tests.Fixture
 
             return account;
         }
-
         internal void EnsureDepartment(string departmentId, string sectorId = null, ApiPersonProfileV3 defactoResponsible = null)
         {
             using var scope = ApiFactory.Services.CreateScope();


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Add the possibility to expand details about the assigned department on requests. This will I.E. allow seeing the resource owner of the assigned department.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

