### PR TITLE
do not count draft requests as unassigned

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -254,7 +254,7 @@ namespace Fusion.Resources.Api.Controllers
             #endregion
 
 
-            var requestCommand = new GetResourceAllocationRequests(query);
+            var requestCommand = new GetResourceAllocationRequests(query).ForAll();
             var result = await DispatchAsync(requestCommand);
 
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartmentUnassignedRequests.cs
@@ -39,7 +39,7 @@ namespace Fusion.Resources.Domain.Queries
                     .ExpandPositions()
                     .ExpandPositionInstances()
                     .WithUnassignedFilter(true)
-                    .WithExcludeDrafts(true)
+                    .ForResourceOwners()
                     .WithExcludeCompleted(true), cancellationToken) ;
 
                 var sourceDepartmentLevel = request.DepartmentString.Split(" ").Length;

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -16,7 +16,6 @@ namespace Fusion.Resources.Domain.Queries
 {
     public class GetResourceAllocationRequests : IRequest<QueryRangedList<QueryResourceAllocationRequest>>
     {
-
         public GetResourceAllocationRequests(ODataQueryParams? query = null)
         {
             this.Query = query ?? new ODataQueryParams();
@@ -49,12 +48,6 @@ namespace Fusion.Resources.Domain.Queries
             return this;
         }
 
-        public GetResourceAllocationRequests WithExcludeDrafts(bool excludeDrafts = true)
-        {
-            ExcludeDrafts = excludeDrafts;
-            return this;
-        }
-
         public GetResourceAllocationRequests WithAssignedDepartment(string departmentString)
         {
             DepartmentString = departmentString;
@@ -75,12 +68,6 @@ namespace Fusion.Resources.Domain.Queries
             OnlyCount = onlyReturnCount;
             return this;
         }
-
-        //public GetResourceAllocationRequests WithExcludeDrafts(bool excludeDrafts = true)
-        //{
-        //    ExcludeDrafts = excludeDrafts;
-        //    return this;
-        //}
 
         public GetResourceAllocationRequests WithExcludeCompleted(bool exclude = false)
         {
@@ -103,7 +90,6 @@ namespace Fusion.Resources.Domain.Queries
         public string? DepartmentString { get; private set; }
         public bool Unassigned { get; private set; }
         public bool OnlyCount { get; private set; }
-        public bool? ExcludeDrafts { get; private set; }
         public bool? ExcludeCompleted { get; private set; }
 
         private DbInternalRequestOwner? Owner { get; set; }
@@ -152,8 +138,6 @@ namespace Fusion.Resources.Domain.Queries
                 if (request.Owner is not null)
                     query = query.Where(r => r.IsDraft == false || r.RequestOwner == request.Owner);
 
-                //if (request.ExcludeDrafts.HasValue && request.ExcludeDrafts.Value)
-                //    query = query.Where(c => c.IsDraft == false);
                 if (request.ExcludeCompleted.GetValueOrDefault(false))
                     query = query.Where(c => c.State.IsCompleted == false);
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/UnassignedRequests/DepartmentUnassignedTests.cs
@@ -129,6 +129,25 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.UnassignedRequests
         }
 
         [Fact]
+        public async Task ShouldExcludeDraftRequests()
+        {
+            var department = "TPD PRD MY TEST DEP1";
+            fixture.EnsureDepartment(department);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = department);
+
+            using var adminScope = fixture.AdminScope();
+
+            var unassignedRequest = await Client.CreateDefaultRequestAsync(testProject, 
+                _=> { }, 
+                pos => pos.WithBasePosition(bp)
+            );
+
+            var resp = await Client.TestClientGetAsync($"/departments/{department}/resources/requests/unassigned?api-version=1.0-preview", new { value = new[] { new { id = Guid.Empty } } });
+            resp.Value.value.Should().NotContain(r => r.id == unassignedRequest.Id);
+        }
+
+        [Fact]
         public async Task ShouldExpandPositionInstances()
         {
             var department = "TPD PRD MY TEST DEP1";


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
- Remove obsolete code for draft requests
- Update relevant departments endpoint to exclude drafts by using `ForRequestOwners` on request object.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

