### PR TITLE
Add access control logic for request creators

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IAuthorizationHandler, ContractorInContractHandler>();
             services.AddScoped<IAuthorizationHandler, ContractorInProjectHandler>();
             services.AddScoped<IAuthorizationHandler, OrgPositionAccessHandler>();
+            services.AddScoped<IAuthorizationHandler, RequestCreatorHandler>();
 
             return services;
         }

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -123,6 +123,12 @@ namespace Fusion.Resources.Api.Controllers
             return builder;
         }
 
+        public static IAuthorizationRequirementRule BeRequestCreator(this IAuthorizationRequirementRule builder, Guid requestId)
+        {
+            builder.AddRule(new RequestCreatorRequirement(requestId));
+            return builder;
+        }
+
         #region Domain rules
 
         public static IAuthorizationRequirementRule CanDelegateInternalRole(this IAuthorizationRequirementRule builder, ProjectIdentifier project, Guid contractOrgId)

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/RequestCreatorHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/RequestCreatorHandler.cs
@@ -1,0 +1,31 @@
+﻿using Fusion.Resources.Api.Authorization.Requirements;
+using Fusion.Resources.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Authorization.Handlers
+{
+    public class RequestCreatorHandler : AuthorizationHandler<RequestCreatorRequirement>
+    {
+        private readonly ResourcesDbContext db;
+
+        public RequestCreatorHandler(ResourcesDbContext db)
+        {
+            this.db = db;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, RequestCreatorRequirement requirement)
+        {
+            var userId = context.User.GetAzureUniqueIdOrThrow();
+            var request = await db.ResourceAllocationRequests
+                    .Include(req => req.CreatedBy)
+                    .SingleAsync(req => req.Id == requirement.RequestId);
+
+            if(request.CreatedBy.AzureUniqueId == userId)
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/RequestCreatorRequirement.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/RequestCreatorRequirement.cs
@@ -1,0 +1,18 @@
+﻿using Fusion.Authorization;
+using System;
+
+namespace Fusion.Resources.Api.Authorization.Requirements
+{
+    public class RequestCreatorRequirement : FusionAuthorizationRequirement
+    {
+        public RequestCreatorRequirement(Guid requestId)
+        {
+            this.RequestId = requestId;
+        }
+
+        public override string Description => "The user must be the creator of the request.";
+        public override string Code => "AllocationReqCreator";
+
+        public Guid RequestId { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -140,7 +140,7 @@ namespace Fusion.Resources.Api.Controllers
                 OrgPositionId = request.OrgPositionId,
                 OrgProjectId = position.ProjectId,
                 OrgPositionInstanceId = request.OrgPositionInstanceId,
-                AssignedDepartment = departmentPath                
+                AssignedDepartment = departmentPath
             };
 
             try
@@ -180,9 +180,9 @@ namespace Fusion.Resources.Api.Controllers
         [HttpPatch("/projects/{projectIdentifier}/resources/requests/{requestId}")]
         [HttpPatch("/departments/{departmentString}/resources/requests/{requestId}")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> PatchInternalRequest(
-            [FromRoute] ProjectIdentifier? projectIdentifier, 
-            string? departmentString, 
-            Guid requestId, 
+            [FromRoute] ProjectIdentifier? projectIdentifier,
+            string? departmentString,
+            Guid requestId,
             [FromBody] PatchInternalRequestRequest request)
         {
             var item = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
@@ -208,13 +208,11 @@ namespace Fusion.Resources.Api.Controllers
 
                     if (!request.AssignedDepartment.HasValue && !request.ProposedPersonAzureUniqueId.HasValue)
                         or.BeRequestCreator(requestId);
-
                 });
             });
 
             if (authResult.Unauthorized)
                 return authResult.CreateForbiddenResponse();
-
             #endregion
 
             try
@@ -367,7 +365,7 @@ namespace Fusion.Resources.Api.Controllers
         [HttpGet("/resources/requests/internal/{requestId}")]
         [HttpGet("/projects/{projectIdentifier}/requests/{requestId}")]
         [HttpGet("/projects/{projectIdentifier}/resources/requests/{requestId}")]
-        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}")]        
+        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> GetResourceAllocationRequest(Guid requestId, [FromQuery] ODataQueryParams query)
         {
             var result = await DispatchAsync(new GetResourceAllocationRequestItem(requestId).WithQuery(query));
@@ -405,7 +403,7 @@ namespace Fusion.Resources.Api.Controllers
             return new ApiResourceAllocationRequest(result);
         }
 
-   
+
         [HttpPost("/projects/{projectIdentifier}/requests/{requestId}/start")]
         [HttpPost("/projects/{projectIdentifier}/resources/requests/{requestId}/start")]
         public async Task<ActionResult<ApiResourceAllocationRequest>> StartProjectRequestWorkflow([FromRoute] ProjectIdentifier projectIdentifier, Guid requestId)
@@ -609,14 +607,14 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion
 
-            
+
             await using var scope = await BeginTransactionAsync();
 
             await DispatchAsync(new Logic.Commands.ResourceAllocationRequest.Approve(requestId));
 
             await scope.CommitAsync();
 
-            
+
             result = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             return new ApiResourceAllocationRequest(result!);
         }
@@ -679,7 +677,7 @@ namespace Fusion.Resources.Api.Controllers
                 return authResult.CreateForbiddenResponse();
 
             #endregion
-            
+
             var comment = await DispatchAsync(new AddComment(User.GetRequestOrigin(), requestId, create.Content));
 
             return Created($"/resources/requests/internal/{requestId}/comments/{comment.Id}", new ApiRequestComment(comment));
@@ -811,7 +809,7 @@ namespace Fusion.Resources.Api.Controllers
 
             return NoContent();
         }
-        
+
         [HttpOptions("/projects/{projectIdentifier}/requests/{requestId}")]
         [HttpOptions("/projects/{projectIdentifier}/resources/requests/{requestId}")]
         public async Task<ActionResult> CheckProjectAllocationRequestAccess([FromRoute] ProjectIdentifier projectIdentifier, Guid requestId)

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -206,8 +206,7 @@ namespace Fusion.Resources.Api.Controllers
                     if (item.AssignedDepartment is null && item.OrgPosition is not null)
                         or.BeResourceOwner(new DepartmentPath(item.OrgPosition.BasePosition.Department).GoToLevel(3), includeDescendants: true);
 
-                    if (!request.AssignedDepartment.HasValue && !request.ProposedPersonAzureUniqueId.HasValue)
-                        or.BeRequestCreator(requestId);
+                    or.BeRequestCreator(requestId);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -63,7 +63,6 @@ namespace Fusion.Resources.Api.Controllers
 
             try
             {
-
                 using var transaction = await BeginTransactionAsync();
 
                 var newRequest = await DispatchAsync(command);
@@ -187,6 +186,10 @@ namespace Fusion.Resources.Api.Controllers
 
                     if (item.AssignedDepartment is null && item.OrgPosition is not null)
                         or.BeResourceOwner(new DepartmentPath(item.OrgPosition.BasePosition.Department).GoToLevel(3), includeDescendants: true);
+
+                    if (!request.AssignedDepartment.HasValue && !request.ProposedPersonAzureUniqueId.HasValue)
+                        or.BeRequestCreator(requestId);
+
                 });
             });
 
@@ -360,6 +363,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.AnyOf(or =>
                 {
+                    or.BeRequestCreator(requestId);
                     // For now everyone with a position in the project can view requests
                     or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(result.Project.OrgProjectId));
 
@@ -405,6 +409,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
+                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -487,6 +492,8 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     if (result.Type == InternalRequestType.Allocation)
                     {
+                        or.BeRequestCreator(requestId);
+
                         if (result.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                     }
@@ -768,6 +775,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    or.BeRequestCreator(requestId);
+
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });
@@ -797,6 +806,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    or.BeRequestCreator(requestId);
+
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                 });

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -580,6 +580,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
+                    or.BeRequestCreator(requestId);
                 });
 
             });

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -119,19 +119,14 @@ namespace Fusion.Resources.Api.Controllers
 
             // Resolve position
             var position = await ResolvePositionAsync(request.OrgPositionId);
-            if (position is null)
-                return ApiErrors.InvalidInput($"Could not resolve org chart position with id '{request.OrgPositionId}'");
-
             var positionInstance = position.Instances.FirstOrDefault(i => i.Id == request.OrgPositionInstanceId);
-            if (position is null)
-                return ApiErrors.InvalidInput($"Could not resolve org chart position instance with id '{request.OrgPositionInstanceId}'");
 
             if (positionInstance?.AssignedPerson is null)
                 return ApiErrors.InvalidInput($"Cannot create change request for position instance without assigned person.");
 
             var assignedPerson = await profileResolver.ResolvePersonBasicProfileAsync(positionInstance.AssignedPerson!.AzureUniqueId!);
             if (!assignedPerson?.FullDepartment?.Equals(departmentPath, StringComparison.OrdinalIgnoreCase) == true)
-                return Forbid();
+                return ApiErrors.InvalidInput($"The assigned resource does not belong to the department '{departmentPath}'");
 
             var command = new CreateInternalRequest(InternalRequestOwner.ResourceOwner, request.ResolveType())
             {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -581,7 +581,6 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
-                    or.BeRequestCreator(requestId);
                 });
 
             });

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -448,7 +448,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    or.BeResourceOwner(new DepartmentPath(departmentPath).Parent(), includeDescendants: true);
+                    or.BeRequestCreator(requestId);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -99,7 +99,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-
+                    or.BeResourceOwner(departmentPath, includeParents: false, includeDescendants: true);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
@@ -18,7 +18,6 @@ namespace Fusion.Resources.Api.Controllers
         public PatchProperty<ApiPropertiesCollection?> ProposedChanges { get; set; } = new();
 
         public PatchProperty<ProposalParametersRequest> ProposalParameters { get; set; } = new();
-
         #region Validator
 
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -40,9 +40,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
             loggingScope = new TestLoggingScope(output);
-        }
-        public async Task InitializeAsync()
-        {
+
             var creator = fixture.AddProfile(FusionAccountType.Employee);
             var resourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             resourceOwner.IsResourceOwner = true;
@@ -60,8 +58,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = TestDepartment);
             testPosition = testProject.AddPosition().WithBasePosition(bp);
 
-
-
             Users = new Dictionary<string, ApiPersonProfileV3>()
             {
                 ["creator"] = creator,
@@ -69,6 +65,8 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 ["resourceOwnerCreator"] = resourceOwnerCreator
             };
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
 
         [Theory]
         //TODO: [InlineData("resourceOwner", TestDepartment, true)]

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -51,6 +51,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             testProject = new FusionTestProjectBuilder()
                 .WithPositions(200)
+                .WithProperty("pimsWriteSyncEnabled", true)
                 .AddToMockService();
 
             fixture.ContextResolver

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -168,7 +168,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
         //TODO: [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", false)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
 
         public async Task CanReassignOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
         {
@@ -215,7 +215,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
         //TODO: [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", false)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanProposeNormalRequest(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -239,7 +239,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, false)]
         //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
         //TODO: [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
+        //TODO: [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanAcceptNormalRequest(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -1,0 +1,245 @@
+﻿using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Testing;
+using Fusion.Testing.Authentication.User;
+using Fusion.Testing.Mocks;
+using Fusion.Testing.Mocks.OrgService;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Fusion.Resources.Api.Tests.AuthorizationTests
+{
+    public class SecurityMatrixTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
+    {
+        const string TestDepartment = "TPD PRD TST ASD";
+        const string SiblingDepartment = "TPD PRD TST FGH";
+        const string ParentDepartment = "TPD PRD TS";
+
+        const string SameL2Department = "TPD PRD FE MMS STR1";
+
+        private ResourceApiFixture fixture;
+        private TestLoggingScope loggingScope;
+        private FusionTestProjectBuilder testProject;
+        private ApiClients.Org.ApiPositionV2 testPosition;
+        private OrgRequestInterceptor creatorInterceptor;
+
+        public Dictionary<string, ApiPersonProfileV3> Users { get; private set; }
+
+        public SecurityMatrixTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+            fixture.DisableMemoryCache();
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+        }
+        public async Task InitializeAsync()
+        {
+            var creator = fixture.AddProfile(FusionAccountType.Employee);
+            var resourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            resourceOwner.IsResourceOwner = true;
+
+            testProject = new FusionTestProjectBuilder()
+                .WithPositions(200)
+                .AddToMockService();
+
+            fixture.ContextResolver
+               .AddContext(testProject.Project);
+
+            var bp = testProject.AddBasePosition($"{Guid.NewGuid()}", s => s.Department = TestDepartment);
+            testPosition = testProject.AddPosition().WithBasePosition(bp);
+
+
+
+            Users = new Dictionary<string, ApiPersonProfileV3>()
+            {
+                ["creator"] = creator,
+                ["resourceOwner"] = resourceOwner
+            };
+        }
+
+        [Theory]
+        //TODO: [InlineData("resourceOwner", TestDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SiblingDepartment, true)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
+        public async Task CanDeleteRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
+        {
+            var request = await CreateAndStartRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientDeleteAsync<dynamic>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("resourceOwner", TestDepartment, true)]
+        [InlineData("resourceOwner", SiblingDepartment, true)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
+
+        public async Task CanReadRequestsAssignedToDepartment(string role, string department, bool shouldBeAllowed)
+        {
+            var request = await CreateAndStartRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientGetAsync<TestApiInternalRequestModel>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("resourceOwner", TestDepartment, true)]
+        [InlineData("resourceOwner", SiblingDepartment, true)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
+
+        public async Task CanEditGeneralOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
+        {
+            var request = await CreateAndStartRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                new
+                {
+                    proposedChanges = new
+                    {
+                        location = new { id = Guid.NewGuid(), name = "Test location" }
+                    }
+                }
+            );
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("resourceOwner", TestDepartment, true)]
+        [InlineData("resourceOwner", SiblingDepartment, true)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
+
+        public async Task CanEditAdditionalCommentOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
+        {
+            var request = await CreateAndStartRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                new
+                {
+                    additionalComment = "updated comment"
+                }
+            );
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("resourceOwner", TestDepartment, true)]
+        [InlineData("resourceOwner", SiblingDepartment, true)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", false)]
+
+        public async Task CanReassignOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
+        {
+            const string changedDepartment = "TPD UPD ASD";
+            fixture.EnsureDepartment(changedDepartment);
+
+            var request = await CreateAndStartRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                new { assignedDepartment = changedDepartment }
+            );
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("resourceOwner", TestDepartment, false)]
+        [InlineData("resourceOwner", SiblingDepartment, false)]
+        //TODO: [InlineData("resourceOwner", ParentDepartment, true)]
+        //TODO: [InlineData("resourceOwner", SameL2Department, true)]
+        [InlineData("creator", "TPD RND WQE FQE", true)]
+        public async Task CanStartRequest(string role, string department, bool shouldBeAllowed)
+        {
+            var request = await CreateRequest();
+            Users[role].FullDepartment = department;
+            using var userScope = fixture.UserScope(Users[role]);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var result = await client.TestClientPostAsync<dynamic>(
+                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}/start", null
+            );
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        private async Task<TestApiInternalRequestModel> CreateAndStartRequest()
+        {
+            var creatorClient = fixture.ApiFactory.CreateClient()
+                            .WithTestUser(Users["creator"])
+                            .AddTestAuthToken();
+
+            using var i = creatorInterceptor = OrgRequestMocker
+                 .InterceptOption($"/{testPosition.Id}")
+                 .RespondWithHeaders(HttpStatusCode.NoContent, h => h.Add("Allow", "PUT"));
+
+            return await creatorClient.CreateAndStartDefaultRequestOnPositionAsync(testProject, testPosition);
+        }
+
+        private async Task<TestApiInternalRequestModel> CreateRequest()
+        {
+            var creatorClient = fixture.ApiFactory.CreateClient()
+                            .WithTestUser(Users["creator"])
+                            .AddTestAuthToken();
+
+            using var i = creatorInterceptor = OrgRequestMocker
+                 .InterceptOption($"/{testPosition.Id}")
+                 .RespondWithHeaders(HttpStatusCode.NoContent, h => h.Add("Allow", "PUT"));
+
+            return await creatorClient.CreateRequestAsync(testProject.Project.ProjectId,
+                req => req.AsTypeNormal().WithPosition(testPosition)
+            );
+        }
+
+        public Task DisposeAsync()
+        {
+            creatorInterceptor.Dispose();
+            loggingScope.Dispose();
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -41,6 +41,8 @@ namespace Fusion.Resources.Api.Tests.Fixture
             return delegatedAdmin;
         }
 
+        internal void DisableMemoryCache() => ApiFactory.isMemorycacheDisabled = true;
+
         public ResourceApiFixture()
         {
             ApiFactory = new ResourcesApiWebAppFactory();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
@@ -26,6 +26,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Fusion.Resources.Application.LineOrg;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Fusion.Resources.Api.Tests.Fixture
 {
@@ -82,6 +83,8 @@ namespace Fusion.Resources.Api.Tests.Fixture
         }
 
         private static object locker = new object();
+        public bool isMemorycacheDisabled = false;
+
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.ConfigureAppConfiguration(cfgBuilder =>
@@ -102,9 +105,15 @@ namespace Fusion.Resources.Api.Tests.Fixture
                 services.TryRemoveImplementationService("ContextEventReceiver");
                 services.TryRemoveImplementationService<ICompanyResolver>();
                 services.TryRemoveImplementationService<LineOrgCacheRefresher>();
+                
+                if(isMemorycacheDisabled)
+                {
+                    services.TryRemoveImplementationService<IMemoryCache>();
+                    services.AddScoped<IMemoryCache, AlwaysEmptyCache>();
+                }
 
-                    //make it transient in the tests, to make sure that test contracts are added to in-memory collection
-                    services.AddTransient<ICompanyResolver, PeopleCompanyResolver>();
+                //make it transient in the tests, to make sure that test contracts are added to in-memory collection
+                services.AddTransient<ICompanyResolver, PeopleCompanyResolver>();
                 services.AddSingleton<IProjectOrgResolver>(sp => new OrgResolverMock());
                 services.AddSingleton<IFusionContextResolver>(sp => contextResolverMock);
                 services.AddSingleton<IFusionRolesClient>(Span => roleClientMock);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/AlwaysEmptyCache.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/AlwaysEmptyCache.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+
+namespace Fusion.Resources.Api.Tests.FusionMocks
+{
+    class AlwaysEmptyCache : IMemoryCache
+    {
+        class ExpiredEntry : ICacheEntry
+        {
+            public ExpiredEntry(object key)
+            {
+                Key = key;
+            }
+            public DateTimeOffset? AbsoluteExpiration { get; set; } = DateTimeOffset.MinValue;
+            public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; } = DateTimeOffset.Now - DateTimeOffset.MinValue;
+
+            public IList<IChangeToken> ExpirationTokens => new List<IChangeToken>();
+
+            public object Key { get; }
+
+            public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks => new List<PostEvictionCallbackRegistration>();
+
+            public CacheItemPriority Priority { get; set; }
+            public long? Size { get; set; }
+            public TimeSpan? SlidingExpiration { get; set; }
+            public object Value { get; set; }
+
+            public void Dispose()
+            {
+            }
+        }
+        public ICacheEntry CreateEntry(object key) => new ExpiredEntry(key);
+
+        public void Dispose(){}
+
+        public void Remove(object key){}
+
+        public bool TryGetValue(object key, out object value)
+        {
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -50,7 +50,7 @@ namespace Fusion.Resources.Api.Tests
         }
 
 
-        public static async Task<TestApiInternalRequestModel> CreateDefaultRequestAsync(this HttpClient client, FusionTestProjectBuilder project, 
+        public static async Task<TestApiInternalRequestModel> CreateDefaultRequestAsync(this HttpClient client, FusionTestProjectBuilder project,
             Action<ApiCreateInternalRequestModel> setup = null, Action<ApiPositionV2> positionSetup = null)
         {
             var position = project.AddPosition();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -90,7 +90,9 @@ namespace Fusion.Resources.Api.Tests
         public static async Task<TestApiInternalRequestModel> CreateDefaultResourceOwnerRequestAsync(this HttpClient client, string department, FusionTestProjectBuilder project,
             Action<ApiCreateInternalRequestModel> setup = null, Action<ApiPositionV2> positionSetup = null)
         {
-            var position = project.AddPosition().WithInstances(1).WithEnsuredFutureInstances();
+            var position = project.AddPosition()
+                .WithInstances(1)
+                .WithEnsuredFutureInstances();
 
             positionSetup?.Invoke(position);
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -82,7 +82,11 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             // Create a default request we can work with
 
             // Create adjustment request on a position instance currently active
-            adjustmentRequest = await adminClient.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, r => r.AsTypeResourceOwner(SUBTYPE_ADJUST));
+            adjustmentRequest = await adminClient.CreateDefaultResourceOwnerRequestAsync(
+                testDepartment, testProject, 
+                r => r.AsTypeResourceOwner(SUBTYPE_ADJUST), 
+                p => p.WithAssignedPerson(fixture.AddProfile(FusionAccountType.Employee))
+            );
         }
 
         public Task DisposeAsync()
@@ -130,6 +134,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
 
             var position = testProject.AddPosition();
+            position.WithAssignedPerson(fixture.AddProfile(FusionAccountType.Employee));
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests", new
             {
                 type = "resourceOwnerChange",
@@ -219,7 +224,11 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, r => r.AsTypeResourceOwner(subType));
+            var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject,
+                r => r.AsTypeResourceOwner(subType),
+                p => p.WithAssignedPerson(fixture.AddProfile(FusionAccountType.Employee))
+            );
+
 
             await Client.ProposeChangesAsync(request.Id, new { workload = 50 });
             await Client.ProposePersonAsync(request.Id, testUser);
@@ -278,20 +287,44 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests/{request.Id}/start", null);
             response.Should().BeSuccessfull();
         }
+        
         [Fact]
-        public async Task RemoveResourceRequest_Start_ShouldBeBadRequest_WhenNoCurrentlyAssignedPersons()
+        public async Task CreatRequestForUnassignedPositionInstance_ShouldGiveBadRequest()
         {
             using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, r => r.AsTypeResourceOwner(SUBTYPE_REMOVE), p => p.WithNoAssignedPerson());
+            var position = testProject.AddPosition()
+                .WithInstances(1)
+                .WithEnsuredFutureInstances()
+                .WithNoAssignedPerson();
 
-            await Client.SetChangeParamsAsync(request.Id, DateTime.Today.AddDays(1));
+            var requestModel = new ApiCreateInternalRequestModel()
+                .AsTypeResourceOwner()
+                .WithPosition(position)
+                .AsTypeResourceOwner(SUBTYPE_REMOVE);
 
-            var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests/{request.Id}/start", null);
-            response.Should().BeBadRequest();
-
-            response.Should().ContainErrorOnProperty("OrgPositionInstance.AssignedToUniqueId");
+            var newRequestResponse = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests", requestModel);
+            newRequestResponse.Should().BeBadRequest();
         }
+        
+        // Is this still relevant? i.e could a position instance become unassigned between change 
+        // request is created and when it is started?
+        //[Fact]
+        //public async Task RemoveResourceRequest_Start_ShouldBeBadRequest_WhenNoCurrentlyAssignedPersons()
+        //{
+        //    using var adminScope = fixture.AdminScope();
+
+        //    var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, 
+        //        r => r.AsTypeResourceOwner(SUBTYPE_REMOVE), p => p.WithAssignedPerson(fixture.AddProfile(FusionAccountType.Employee))
+        //    );
+
+        //    await Client.SetChangeParamsAsync(request.Id, DateTime.Today.AddDays(1));
+
+        //    var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests/{request.Id}/start", null);
+        //    response.Should().BeBadRequest();
+
+        //    response.Should().ContainErrorOnProperty("OrgPositionInstance.AssignedToUniqueId");
+        //}
     }
 
 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -330,7 +330,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task CreateChangeRequest_Should_ReturnBadRequest_WhenPimsWriteSyncNotEnabled()
         {
-
             // Mock project
             var disabledTestProject = new FusionTestProjectBuilder()
                 .WithPositions(200)
@@ -344,7 +343,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             using var adminScope = fixture.AdminScope();
 
-            var position = disabledTestProject.AddPosition();
+            var position = disabledTestProject.AddPosition()
+                .WithAssignedPerson(fixture.AddProfile(FusionAccountType.Employee))
+                .WithEnsuredFutureInstances();
+
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests", new
             {
                 type = "resourceOwnerChange",
@@ -357,7 +359,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             var error = JsonConvert.DeserializeAnonymousType(response.Content, new { error = new { code = string.Empty, message = string.Empty } });
             error!.error.code.Should().Be("ChangeRequestsDisabled");
-            
         }
 
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgTestData.cs
@@ -22,7 +22,8 @@ namespace Fusion.Testing.Mocks.OrgService
                     DomainId = f.Random.AlphaNumeric(5),
                     Dates = new ApiProjectDatesV2() { EndDate = f.Date.Future(), StartDate = f.Date.Past(), Gates = new ApiProjectDecisionGatesV2() { } },
                     Director = director,
-                    DirectorPositionId = director.Id
+                    DirectorPositionId = director.Id,
+                    Properties = new ApiPropertiesCollectionV2()
                 };
 
                 director.ProjectId = project.ProjectId;


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
- Add new auth requirement for request creator
- Implement security matrix for request creator

[Security Matrix](https://teams.microsoft.com/l/file/447EDF2B-9A6F-4163-A77E-E896A98E0617?tenantId=3aa4a235-b6e2-48d5-9195-7fcf05b459b0&fileType=xlsx&objectUrl=https%3A%2F%2Fstatoilsrm.sharepoint.com%2Fsites%2FProView190%2FShared%20Documents%2FFeatures%20-%20Resources%2FResource%20allocation%2FFusion-Resource-Allocation-API.xlsx&baseUrl=https%3A%2F%2Fstatoilsrm.sharepoint.com%2Fsites%2FProView190&serviceName=teams&threadId=19:1382bf30a0614a6b86a0a15c55a9833b@thread.skype&groupId=33a6ebec-c93b-47ae-94b9-fbc6fa6c4a4b)



**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

