### PR TITLE
Hide resource owner notes when request is completed

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -664,8 +664,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success)
             {
-                if (!request.IsCompleted) allowedMethods.Add("GET");
-                allowedMethods.Add("POST");
+                allowedMethods.Add("GET", "POST");
             }
 
             Response.Headers["Allow"] = string.Join(',', allowedMethods);
@@ -694,7 +693,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    if (!request.IsCompleted)
+                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
             #endregion
@@ -703,8 +703,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success)
             {
-                if (!request.IsCompleted) allowedMethods.Add("GET");
-                allowedMethods.Add("PUT", "DELETE");
+                allowedMethods.Add("GET", "PUT", "DELETE");
             }
 
             Response.Headers["Allow"] = string.Join(',', allowedMethods);
@@ -731,7 +730,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    if (!request.IsCompleted)
+                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -752,6 +752,9 @@ namespace Fusion.Resources.Api.Controllers
             if (request == null)
                 return FusionApiError.NotFound(requestId, "Request not found");
 
+            if (request.IsCompleted)
+                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
+
             #region Authorization
             var requiredDepartment = request.AssignedDepartment ?? request.OrgPosition?.BasePosition?.Department;
 
@@ -763,8 +766,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (!request.IsCompleted)
-                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 
@@ -789,6 +791,9 @@ namespace Fusion.Resources.Api.Controllers
             if (comment is null)
                 return FusionApiError.NotFound(commentId, "Comment not found");
 
+            if (request.IsCompleted)
+                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
+
             #region Authorization
 
             var requiredDepartment = request.AssignedDepartment ?? request.OrgPosition?.BasePosition?.Department;
@@ -801,8 +806,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (!request.IsCompleted)
-                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 
@@ -825,6 +829,9 @@ namespace Fusion.Resources.Api.Controllers
 
             if (comment is null)
                 return FusionApiError.NotFound(commentId, "Comment not found");
+
+            if(request.IsCompleted)
+                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
 
             #region Authorization
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -654,8 +654,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (!request.IsCompleted)
-                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
             #endregion
@@ -664,7 +663,8 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success)
             {
-                allowedMethods.Add("GET", "POST");
+                if (!request.IsCompleted) allowedMethods.Add("POST");
+                allowedMethods.Add("GET");
             }
 
             Response.Headers["Allow"] = string.Join(',', allowedMethods);
@@ -693,15 +693,14 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (!request.IsCompleted)
-                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
             #endregion
 
             var allowedMethods = new List<string> { "OPTIONS" };
 
-            if (authResult.Success)
+            if (!request.IsCompleted && authResult.Success)
             {
                 allowedMethods.Add("GET", "PUT", "DELETE");
             }
@@ -717,7 +716,8 @@ namespace Fusion.Resources.Api.Controllers
 
             if (request == null)
                 return FusionApiError.NotFound(requestId, "Request not found");
-
+            if (request.IsCompleted)
+                return FusionApiError.InvalidOperation("comment-closed-request", "Cannot add comment on closed request");
             #region Authorization
 
             var requiredDepartment = request.AssignedDepartment ?? request.OrgPosition?.BasePosition?.Department;
@@ -730,8 +730,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (!request.IsCompleted)
-                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -717,7 +717,7 @@ namespace Fusion.Resources.Api.Controllers
             if (request == null)
                 return FusionApiError.NotFound(requestId, "Request not found");
             if (request.IsCompleted)
-                return FusionApiError.InvalidOperation("comment-closed-request", "Cannot add comment on closed request");
+                return FusionApiError.InvalidOperation("CommentsDisabled", "Cannot add comment on closed request");
             #region Authorization
 
             var requiredDepartment = request.AssignedDepartment ?? request.OrgPosition?.BasePosition?.Department;
@@ -753,7 +753,7 @@ namespace Fusion.Resources.Api.Controllers
                 return FusionApiError.NotFound(requestId, "Request not found");
 
             if (request.IsCompleted)
-                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
+                return FusionApiError.InvalidOperation("CommentsDisabled", "Comments are closed on completed requests.");
 
             #region Authorization
             var requiredDepartment = request.AssignedDepartment ?? request.OrgPosition?.BasePosition?.Department;
@@ -792,7 +792,7 @@ namespace Fusion.Resources.Api.Controllers
                 return FusionApiError.NotFound(commentId, "Comment not found");
 
             if (request.IsCompleted)
-                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
+                return FusionApiError.InvalidOperation("CommentsDisabled", "Comments are closed on completed requests.");
 
             #region Authorization
 
@@ -831,7 +831,7 @@ namespace Fusion.Resources.Api.Controllers
                 return FusionApiError.NotFound(commentId, "Comment not found");
 
             if(request.IsCompleted)
-                return FusionApiError.InvalidOperation("comment-closed-request", "Comments are closed on completed requests.");
+                return FusionApiError.InvalidOperation("CommentsDisabled", "Comments are closed on completed requests.");
 
             #region Authorization
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -654,16 +654,18 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    if (!request.IsCompleted)
+                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
             #endregion
-            
+
             var allowedMethods = new List<string> { "OPTIONS" };
 
             if (authResult.Success)
             {
-                allowedMethods.Add("GET", "POST");
+                if (!request.IsCompleted) allowedMethods.Add("GET");
+                allowedMethods.Add("POST");
             }
 
             Response.Headers["Allow"] = string.Join(',', allowedMethods);
@@ -701,7 +703,8 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success)
             {
-                allowedMethods.Add("GET", "PUT", "DELETE");
+                if (!request.IsCompleted) allowedMethods.Add("GET");
+                allowedMethods.Add("PUT", "DELETE");
             }
 
             Response.Headers["Allow"] = string.Join(',', allowedMethods);
@@ -761,7 +764,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    if (!request.IsCompleted)
+                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 
@@ -782,7 +786,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (request == null)
                 return FusionApiError.NotFound(requestId, "Request not found");
-            
+
             if (comment is null)
                 return FusionApiError.NotFound(commentId, "Comment not found");
 
@@ -798,7 +802,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
+                    if (!request.IsCompleted)
+                        or.BeResourceOwner(new DepartmentPath(requiredDepartment).Parent(), includeParents: true, includeDescendants: true);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Logic/DeleteNotesHandler.cs
+++ b/src/backend/api/Fusion.Resources.Logic/DeleteNotesHandler.cs
@@ -8,10 +8,7 @@ using System.Threading.Tasks;
 
 namespace Fusion.Resources.Logic
 {
-    class DeleteNotesHandler : 
-        INotificationHandler<RequestProvisioned>,
-        INotificationHandler<RequestProvisioningFailed>
-
+    public class DeleteNotesHandler : INotificationHandler<RequestProvisioned>
     {
         private readonly ResourcesDbContext resourcesDb;
 
@@ -20,11 +17,6 @@ namespace Fusion.Resources.Logic
             this.resourcesDb = resourcesDb;
         }
         public async Task Handle(RequestProvisioned notification, CancellationToken cancellationToken)
-        {
-            await DeleteNotes(notification.RequestId, cancellationToken);
-        }
-
-        public async Task Handle(RequestProvisioningFailed notification, CancellationToken cancellationToken)
         {
             await DeleteNotes(notification.RequestId, cancellationToken);
         }

--- a/src/backend/api/Fusion.Resources.Logic/DeleteNotesHandler.cs
+++ b/src/backend/api/Fusion.Resources.Logic/DeleteNotesHandler.cs
@@ -1,0 +1,40 @@
+﻿using Fusion.Resources.Database;
+using Fusion.Resources.Logic.Events;
+using MediatR;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Logic
+{
+    class DeleteNotesHandler : 
+        INotificationHandler<RequestProvisioned>,
+        INotificationHandler<RequestProvisioningFailed>
+
+    {
+        private readonly ResourcesDbContext resourcesDb;
+
+        public DeleteNotesHandler(ResourcesDbContext resourcesDb)
+        {
+            this.resourcesDb = resourcesDb;
+        }
+        public async Task Handle(RequestProvisioned notification, CancellationToken cancellationToken)
+        {
+            await DeleteNotes(notification.RequestId, cancellationToken);
+        }
+
+        public async Task Handle(RequestProvisioningFailed notification, CancellationToken cancellationToken)
+        {
+            await DeleteNotes(notification.RequestId, cancellationToken);
+        }
+
+        private Task DeleteNotes(Guid requestId, CancellationToken cancellationToken)
+        {
+            resourcesDb.RequestComments.RemoveRange(
+                resourcesDb.RequestComments.Where(c => c.RequestId == requestId)
+            );
+            return resourcesDb.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Events/RequestProvisioned.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Events/RequestProvisioned.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using System;
+
+namespace Fusion.Resources.Logic.Events
+{
+    public class RequestProvisioned : INotification
+    {
+        public RequestProvisioned(Guid requestId)
+        {
+            RequestId = requestId;
+        }
+
+        public Guid RequestId { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Events/RequestProvisioningFailed.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Events/RequestProvisioningFailed.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using System;
+
+namespace Fusion.Resources.Logic.Events
+{
+    public class RequestProvisioningFailed : INotification
+    {
+        public RequestProvisioningFailed(Guid requestId)
+        {
+            RequestId = requestId;
+        }
+
+        public Guid RequestId { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Fusion.Resources.Logic.csproj
+++ b/src/backend/api/Fusion.Resources.Logic/Fusion.Resources.Logic.csproj
@@ -14,8 +14,4 @@
     <ProjectReference Include="..\Fusion.Resources.Domain\Fusion.Resources.Domain.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Events\" />
-  </ItemGroup>
-
 </Project>

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -46,8 +46,6 @@ namespace Fusion.Resources.Logic.Commands
                         if (dbRequest.OrgPositionId is null)
                             throw new InvalidOperationException("Position id cannot be empty when provisioning request");
 
-                        await DeleteResourceOwnerNotes(request.RequestId, cancellationToken);
-
                         var position = await client.GetPositionV2Async(dbRequest.Project.OrgProjectId, dbRequest.OrgPositionId.Value);
                         var draft = await CreateProvisionDraftAsync(dbRequest);
 
@@ -65,14 +63,6 @@ namespace Fusion.Resources.Logic.Commands
 
 
                         draft = await client.PublishAndWaitAsync(draft);
-                    }
-
-                    private async Task DeleteResourceOwnerNotes(Guid requestId, CancellationToken cancellationToken)
-                    {
-                        resourcesDb.RequestComments.RemoveRange(
-                            resourcesDb.RequestComments.Where(c => c.RequestId == requestId)
-                        );
-                        await resourcesDb.SaveChangesAsync(cancellationToken);
                     }
 
                     private async Task<ApiDraftV2> CreateProvisionDraftAsync(DbResourceAllocationRequest dbRequest)

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -46,6 +46,8 @@ namespace Fusion.Resources.Logic.Commands
                         if (dbRequest.OrgPositionId is null)
                             throw new InvalidOperationException("Position id cannot be empty when provisioning request");
 
+                        await DeleteResourceOwnerNotes(request.RequestId, cancellationToken);
+
                         var position = await client.GetPositionV2Async(dbRequest.Project.OrgProjectId, dbRequest.OrgPositionId.Value);
                         var draft = await CreateProvisionDraftAsync(dbRequest);
 
@@ -63,6 +65,14 @@ namespace Fusion.Resources.Logic.Commands
 
 
                         draft = await client.PublishAndWaitAsync(draft);
+                    }
+
+                    private async Task DeleteResourceOwnerNotes(Guid requestId, CancellationToken cancellationToken)
+                    {
+                        resourcesDb.RequestComments.RemoveRange(
+                            resourcesDb.RequestComments.Where(c => c.RequestId == requestId)
+                        );
+                        await resourcesDb.SaveChangesAsync(cancellationToken);
                     }
 
                     private async Task<ApiDraftV2> CreateProvisionDraftAsync(DbResourceAllocationRequest dbRequest)

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Provision.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Provision.cs
@@ -4,6 +4,7 @@ using Fusion.Integration.Org;
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Domain.Commands;
+using Fusion.Resources.Logic.Events;
 using Fusion.Resources.Logic.Workflows;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -88,6 +89,15 @@ namespace Fusion.Resources.Logic.Commands
                     }
 
                     await resourcesDb.SaveChangesAsync();
+
+                    if (dbRequest.ProvisioningStatus.State == DbResourceAllocationRequest.DbProvisionState.Provisioned)
+                    {
+                        await mediator.Publish(new RequestProvisioned(request.RequestId), cancellationToken);
+                    }
+                    else
+                    {
+                        await mediator.Publish(new RequestProvisioningFailed(request.RequestId), cancellationToken);
+                    }
                 }
 
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
@@ -58,7 +58,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             testProject = new FusionTestProjectBuilder()
                 .WithPositions(200)
                 .AddToMockService();
-            
+
             var taskOwnerPosition = PositionBuilder.NewPosition();
             taskOwnerPosition.IsTaskOwner = true;
             taskOwnerPosition.ProjectId = testProject.Project.ProjectId;
@@ -77,15 +77,16 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .AddTestAuthToken();
 
             // Create a default request we can work with
-            request = await adminClient.CreateDefaultRequestAsync(testProject, 
+            request = await adminClient.CreateDefaultRequestAsync(testProject,
                 r => r.AsTypeNormal(),
                 pos => pos.WithParentPosition(taskOwnerPosition.Id));
             //await adminClient.StartProjectRequestAsync(testProject, request.Id);
+            await adminClient.StartProjectRequestAsync(testProject, request.Id);
             await adminClient.AssignDepartmentAsync(request.Id, resourceOwner.FullDepartment);
 
             var comment = new { content = "Resource owner gossip." };
             var response = await adminClient.TestClientPostAsync<TestApiComment>($"/resources/requests/internal/{request.Id}/comments", comment);
-            
+
             commentId = response.Value.Id;
         }
 
@@ -151,6 +152,55 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var comments = await client.TestClientGetAsync<List<TestApiComment>>($"/resources/requests/internal/{request.Id}/comments");
 
             comments.Response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Fact]
+        public async Task ShouldBeHiddenWhenCompleted()
+        {
+            var client = fixture.ApiFactory
+                .CreateClient()
+                .WithTestUser(resourceOwner)
+                .AddTestAuthToken();
+
+            var proposed = fixture.AddProfile(FusionAccountType.Employee);
+
+
+            using (var scope = fixture.AdminScope())
+            {
+                await client.ProposePersonAsync(request.Id, proposed);
+                await client.ResourceOwnerApproveAsync(testDepartment, request.Id);
+                await client.TaskOwnerApproveAsync(testProject, request.Id);
+                await client.ProvisionRequestAsync(request.Id);
+            }
+
+            var comments = await client.TestClientGetAsync<List<TestApiComment>>($"/resources/requests/internal/{request.Id}/comments");
+
+            comments.Response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Fact]
+        public async Task ShouldBeHiddenFromOptionsWhenCompleted()
+        {
+            var client = fixture.ApiFactory
+                .CreateClient()
+                .WithTestUser(resourceOwner)
+                .AddTestAuthToken();
+
+            var proposed = fixture.AddProfile(FusionAccountType.Employee);
+
+
+            using (var scope = fixture.AdminScope())
+            {
+                await client.ProposePersonAsync(request.Id, proposed);
+                await client.ResourceOwnerApproveAsync(testDepartment, request.Id);
+                await client.TaskOwnerApproveAsync(testProject, request.Id);
+                await client.ProvisionRequestAsync(request.Id);
+            }
+
+            var comments = await client.TestClientOptionsAsync($"/resources/requests/internal/{request.Id}/comments");
+
+            comments.Response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            comments.Response.Headers.Should().NotContain(h => h.Key == "Allow" && h.Value.Contains("GET"));
         }
 
         public Task DisposeAsync() => Task.CompletedTask;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
@@ -155,7 +155,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
-        public async Task ShouldBeHiddenWhenCompleted()
+        public async Task ShouldBeForbiddenWhenCompleted()
         {
             var client = fixture.ApiFactory
                 .CreateClient()
@@ -175,7 +175,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             var comments = await client.TestClientGetAsync<List<TestApiComment>>($"/resources/requests/internal/{request.Id}/comments");
 
-            comments.Response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            comments.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
 
         [Fact]

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
@@ -4,10 +4,12 @@ using Fusion.Integration.Profile.ApiClient;
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Logic.Commands;
+using Fusion.Resources.Logic.Workflows;
 using Fusion.Testing.Mocks.OrgService;
 using Fusion.Testing.Mocks.ProfileService;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
 using System;
@@ -30,7 +32,7 @@ namespace Fusion.Resources.Logic.Tests
         private readonly Guid testProjectId;
         private readonly Guid draftId;
 
-        public AllocationTests() 
+        public AllocationTests()
         {
             var options = new DbContextOptionsBuilder<ResourcesDbContext>()
                 .UseInMemoryDatabase($"{Guid.NewGuid()}")
@@ -245,6 +247,54 @@ namespace Fusion.Resources.Logic.Tests
         }
 
         [Fact]
+        public async Task ShouldSendNotificationWhenProvisioning()
+        {
+            ApiPositionInstanceV2 testInstance = null!;
+
+            var testPerson = GenerateTestPerson();
+            var testPosition = GeneratePosition(p =>
+            {
+                p.WithInstances(s =>
+                {
+                    // Future instance
+                    testInstance = s.AddInstance(DateTime.UtcNow.AddDays(100), TimeSpan.FromDays(200))
+                        .SetExternalId("123");
+                });
+            });
+
+            var editor = new DbPerson
+            {
+                AccountType = "Employee",
+                AzureUniqueId = testPerson.AzureUniqueId!.Value,
+                Name = testPerson.Name
+            };
+            var request = GenerateRequest(testInstance, r => r.WithProposedPerson(testPerson));
+            var workflow = new AllocationNormalWorkflowV1().CreateDatabaseEntity(request.Id, DbRequestType.InternalRequest);
+            var wf = WorkflowDefinition.ResolveWorkflow(workflow);
+            wf.Step("created").Start();
+            wf.SaveChanges();
+
+            var mediatorMock = new Mock<IMediator>(MockBehavior.Loose);
+            mediatorMock
+                .Setup(x => x.Send(It.IsAny<IRequest<DbWorkflow>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(workflow);
+
+            var handler = new ResourceAllocationRequest.Provision.Handler(
+                logger: new Mock<ILogger<ResourceAllocationRequest.Provision.Handler>>().Object,
+                dbContext,
+                mediator: mediatorMock.Object
+            ) as IRequestHandler<ResourceAllocationRequest.Provision>;
+
+            var provisioningReq = new ResourceAllocationRequest.Provision(request.Id);
+            provisioningReq.SetEditor(editor.AzureUniqueId, editor);
+
+
+            await handler.Handle(provisioningReq, CancellationToken.None);
+
+            mediatorMock.Verify(x => x.Publish(It.Is<Events.RequestProvisioned>(x => x.RequestId == request.Id), It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
         public async Task ShouldDeleteRequestComments()
         {
             #region setup
@@ -271,7 +321,8 @@ namespace Fusion.Resources.Logic.Tests
             await dbContext.SaveChangesAsync();
             #endregion
 
-            await RunProvisioningAsync(request);
+            var handler = new DeleteNotesHandler(dbContext);
+            await handler.Handle(new Events.RequestProvisioned(request.Id), CancellationToken.None);
 
             var rqComments = await dbContext.RequestComments
                 .Where(c => c.RequestId == request.Id)


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
- Hide `GET` from options when request is completed to make it easier for frontend
- Delete comments when provisioning request.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

