### PR TITLE
Resource Allocation - Notification - Task Owner fix

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestsNotificationHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestsNotificationHandler.cs
@@ -97,10 +97,7 @@ namespace Fusion.Resources.Api.Notifications
 
         private async Task<QueryResourceAllocationRequest?> GetInternalRequestAsync(Guid requestId)
         {
-            var query = new GetResourceAllocationRequestItem(requestId)
-            {
-                Expands = GetResourceAllocationRequestItem.ExpandProperties.TaskOwner
-            }; ;
+            var query = new GetResourceAllocationRequestItem(requestId).ExpandTaskOwner();
             var request = await mediator.Send(query);
 
             return request;

--- a/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestsNotificationHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestsNotificationHandler.cs
@@ -97,7 +97,10 @@ namespace Fusion.Resources.Api.Notifications
 
         private async Task<QueryResourceAllocationRequest?> GetInternalRequestAsync(Guid requestId)
         {
-            var query = new GetResourceAllocationRequestItem(requestId);
+            var query = new GetResourceAllocationRequestItem(requestId)
+            {
+                Expands = GetResourceAllocationRequestItem.ExpandProperties.TaskOwner
+            }; ;
             var request = await mediator.Send(query);
 
             return request;
@@ -116,8 +119,13 @@ namespace Fusion.Resources.Api.Notifications
                     recipients.Add(ro.AzureUniqueId.Value);
             }
 
-            if (data.NotifyTaskOwner && data.Instance.TaskOwnerIds != null)
-                recipients.AddRange(data.Instance.TaskOwnerIds);
+            if (data.NotifyTaskOwner)
+            {
+                var taskOwnerPersonIds = data.AllocationRequest.TaskOwner?.Persons?.Where(x => x.AzureUniqueId != null).Select(taskOwnerPerson => taskOwnerPerson.AzureUniqueId!.Value) ?? new List<Guid>();
+                recipients.AddRange(taskOwnerPersonIds);
+
+
+            }
 
             return recipients.Distinct();// A person may be a creator and/or resource owner and/or task owner.
         }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -50,6 +50,11 @@ namespace Fusion.Resources.Domain.Queries
             Expands = ExpandProperties.All;
             return this;
         }
+        public GetResourceAllocationRequestItem ExpandTaskOwner()
+        {
+            Expands = ExpandProperties.TaskOwner;
+            return this;
+        }
 
         [Flags]
         public enum ExpandProperties

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -52,7 +52,7 @@ namespace Fusion.Resources.Domain.Queries
         }
         public GetResourceAllocationRequestItem ExpandTaskOwner()
         {
-            Expands = ExpandProperties.TaskOwner;
+            Expands |= ExpandProperties.TaskOwner;
             return this;
         }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiInternalRequestModel.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiInternalRequestModel.cs
@@ -42,6 +42,6 @@ namespace Fusion.Testing.Mocks
         public bool IsDraft { get; set; }
 
         public List<TestApiComment>? Comments { get; set; }
+        public TestApiTaskOwner? TaskOwner { get; set; }
     }
-
 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiTaskOwner.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiTaskOwner.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Fusion.Testing.Mocks
+{
+    public class TestApiTaskOwner 
+    {
+        public DateTime Date { get; set; }
+        public Guid? PositionId { get; set; }
+        public List<Guid>? InstanceIds { get; set; }
+        public List<TestApiPerson>? Persons { get; set; }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
@@ -48,7 +48,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
             loggingScope = new TestLoggingScope(output);
-            
+
             // Generate random test users
             resourceOwnerPerson = fixture.AddProfile(FusionAccountType.Employee);
             resourceOwnerPerson.IsResourceOwner = true;
@@ -85,7 +85,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             taskOwnerPosition = testProject.AddPosition().WithAssignedPerson(testUser);
             requestPosition = testProject.AddPosition().WithAssignedPerson(requestAssignedPerson).WithTaskOwner(taskOwnerPosition.Id);
-
+            testProject.SetTaskOwner(requestPosition.Id, taskOwnerPosition.Id);
             // Prepare context resolver.
             fixture.ContextResolver
                 .AddContext(testProject.Project);
@@ -113,7 +113,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeSuccessfull();
 
             var creator = response.Value.CreatedBy.AzureUniquePersonId.ToString();
-            var taskOwner = response.Value.OrgPositionInstance!.TaskOwnerIds.FirstOrDefault().ToString();
+            var taskOwner = directRequest.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);
@@ -126,7 +126,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             {
                 TestLogger.TryLog($"PersonIdentifier:{notification.PersonIdentifier}, Title:{notification.Title}");
             }
-            
+
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             // Assert
             var creator = response.Value.CreatedBy.AzureUniquePersonId.ToString();
-            var taskOwner = response.Value.OrgPositionInstance!.TaskOwnerIds.FirstOrDefault().ToString();
+            var taskOwner = patchPerson.Value.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);
@@ -168,7 +168,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             // Assert
             var creator = response.Value.CreatedBy.AzureUniquePersonId.ToString();
-            var taskOwner = response.Value.OrgPositionInstance!.TaskOwnerIds.FirstOrDefault().ToString();
+            var taskOwner = normalRequest.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Existing code tries to notify positionId and not the person that is a task owner.
Fetching proper person(s) id(s) and adjusted recipient list


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Tested manually, updated integration tests


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

