### PR TITLE
Disable change requests for personnel in projects not in pilot

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/ApiErrors.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/ApiErrors.cs
@@ -33,6 +33,23 @@ namespace Fusion.Resources.Api.Controllers
             };
         }
 
+        public static ActionResult InvalidOperation(string code, string message)
+        {
+            var problem = new ProblemDetails()
+            {
+                Type = rfcProblemDetails,
+                Detail = message,
+                Title = "Invalid Operation",
+                Status = (int)System.Net.HttpStatusCode.BadRequest
+            };
+            problem.Extensions.Add("error", new ApiProblem.ApiError(code, message));
+
+            return new ObjectResult(problem)
+            {
+                StatusCode = problem.Status
+            };
+        }
+
         public static ActionResult InvalidOperation(Exception error)
         {
             var problem = new ProblemDetails()

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -667,7 +667,7 @@ namespace Fusion.Resources.Api.Controllers
                 });
             });
             #endregion
-            
+
             var allowedMethods = new List<string> { "OPTIONS" };
 
             if (authResult.Success)
@@ -791,7 +791,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (request == null)
                 return FusionApiError.NotFound(requestId, "Request not found");
-            
+
             if (comment is null)
                 return FusionApiError.NotFound(commentId, "Comment not found");
 
@@ -952,6 +952,43 @@ namespace Fusion.Resources.Api.Controllers
             else
                 Response.Headers.Add("Allow", "GET");
 
+            return NoContent();
+        }
+
+
+        /// <summary>
+        /// Check if request type is supported to create on the specific allocation.
+        /// 
+        /// The endpoint will return 'POST' in the 'Allow' header.
+        /// </summary>
+        /// <param name="projectIdentifier">Project the position exists on</param>
+        /// <param name="positionId">Position id to create the request on</param>
+        /// <param name="instanceId">Instance / allocation to target</param>
+        /// <param name="requestType">The request type to create</param>
+        /// <returns></returns>
+        [HttpOptions("/projects/{projectIdentifier}/positions/{positionId}/instances/{instanceId}/resources/requests")]
+        public async Task<ActionResult> CheckInstanceRequestTypeAsync([FromRoute] ProjectIdentifier projectIdentifier, Guid positionId, Guid instanceId, [FromQuery]string? requestType)
+        {
+
+            switch (requestType?.ToLower())
+            {
+                case "resourceownerchange":
+                    // Check if change requests are disabled.
+                    // This is mainly relevant when there is a mix of projects synced FROM pims and some TO pims. 
+                    // Change requests are only enabled on projects that have pims write sync enabled for now.
+                    var projectCheck = await IsChangeRequestsDisabledAsync(projectIdentifier.ProjectId);
+                    if (projectCheck.isDisabled)
+                    {
+                        return projectCheck.response!;
+                    }
+
+                    break;
+
+                default:
+                    return ApiErrors.InvalidInput("Request type is not supported. Supported types are 'ResourceOwnerChange'");
+            }
+
+            Response.Headers.Add("Allow", "POST");
             return NoContent();
         }
     }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -115,6 +115,15 @@ namespace Fusion.Resources.Api.Controllers
             if (position is null)
                 return ApiErrors.InvalidInput($"Could not resolve org chart position with id '{request.OrgPositionId}'");
 
+            // Check if change requests are disabled.
+            // This is mainly relevant when there is a mix of projects synced FROM pims and some TO pims. 
+            // Change requests are only enabled on projects that have pims write sync enabled for now.
+            var projectCheck = await IsChangeRequestsDisabledAsync(position.ProjectId);
+            if (projectCheck.isDisabled)
+            {
+                return projectCheck.response;
+            }
+
             var command = new CreateInternalRequest(InternalRequestOwner.ResourceOwner, request.ResolveType())
             {
                 SubType = request.SubType,

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -979,7 +979,10 @@ namespace Fusion.Resources.Api.Controllers
                     var projectCheck = await IsChangeRequestsDisabledAsync(projectIdentifier.ProjectId);
                     if (projectCheck.isDisabled)
                     {
-                        return projectCheck.response!;
+                        // Creating custom response payload here, as bad request would be confusing with regards for unsupported request types. 
+                        // Instead lets return ok response without any allow header, but with an error payload.
+                        Response.Headers.Add("Allow", "");
+                        return Ok(new { error = new { code = "ChangeRequestsDisabled", message = "The project does not currently support change requests from resource owners..." } });
                     }
 
                     break;

--- a/src/backend/api/Fusion.Resources.Api/Controllers/ResourceControllerBase.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/ResourceControllerBase.cs
@@ -72,6 +72,26 @@ namespace Fusion.Resources.Api.Controllers
             return orgResolver.ResolvePositionAsync(positionId);
         }
 
+        protected Task<ApiProjectV2?> ResolveProjectAsync(Guid projectId)
+        {
+            var orgResolver = HttpContext.RequestServices.GetRequiredService<IProjectOrgResolver>();
+            return orgResolver.ResolveProjectAsync(projectId);
+        }
+
+        protected async Task<(bool isDisabled, ActionResult? response)> IsChangeRequestsDisabledAsync(Guid orgProjectId)
+        {
+            var project = await ResolveProjectAsync(orgProjectId);
+
+            if (project is null)
+                throw new InvalidOperationException("Could not locate project");
+
+            var writeEnabled = project.Properties.GetProperty<bool>("pimsWriteSyncEnabled", false);
+            if (writeEnabled)
+                return (false, null);
+
+            return (true, ApiErrors.InvalidOperation("ChangeRequestsDisabled", "The project does not currently support change requests from resource owners..."));
+        }
+
         public class CommandDispatcher
         {
             public readonly IMediator mediator;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -352,7 +352,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
 
             var response = await Client.TestClientOptionsAsync($"/projects/{position.ProjectId}/positions/{position.Id}/instances/{instance.Id}/resources/requests?requestType=resourceOwnerChange");
-            response.Should().BeBadRequest();
+            response.Should().BeSuccessfull();
+            response.Should().NotHaveAllowHeaders(HttpMethod.Post);
 
             var error = JsonConvert.DeserializeAnonymousType(response.Content, new { error = new { code = string.Empty, message = string.Empty } });
             error!.error.code.Should().Be("ChangeRequestsDisabled");

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -326,6 +326,55 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             error!.error.code.Should().Be("ChangeRequestsDisabled");
             
         }
+
+
+        [Fact]
+        public async Task CheckChangeRequest_Should_BeBadRequest_When_PimsWriteSyncNotEnabled()
+        {
+
+            // Mock project
+            var disabledTestProject = new FusionTestProjectBuilder()
+                .WithPositions(200)
+                .WithProperty("pimsWriteSyncEnabled", false)
+                .AddToMockService();
+
+            // Prepare context resolver.
+            fixture.ContextResolver
+                .AddContext(disabledTestProject.Project);
+
+
+            using var adminScope = fixture.AdminScope();
+
+            var position = disabledTestProject.AddPosition()
+                .WithInstances(s => s.AddInstance(DateTime.Today.Subtract(TimeSpan.FromDays(10)), TimeSpan.FromDays(30)))
+                .WithAssignedPerson(testUser);
+            var instance = position.Instances.First();
+
+
+            var response = await Client.TestClientOptionsAsync($"/projects/{position.ProjectId}/positions/{position.Id}/instances/{instance.Id}/resources/requests?requestType=resourceOwnerChange");
+            response.Should().BeBadRequest();
+
+            var error = JsonConvert.DeserializeAnonymousType(response.Content, new { error = new { code = string.Empty, message = string.Empty } });
+            error!.error.code.Should().Be("ChangeRequestsDisabled");
+        }
+
+        [Fact]
+        public async Task CheckChangeRequest_Should_HaveAllowedPost_When_PimsWriteSyncEnabled()
+        {
+
+            using var adminScope = fixture.AdminScope();
+
+            var position = testProject.AddPosition()
+                .WithInstances(s => s.AddInstance(DateTime.Today.Subtract(TimeSpan.FromDays(10)), TimeSpan.FromDays(30)))
+                .WithAssignedPerson(testUser);
+            var instance = position.Instances.First();
+
+
+            var response = await Client.TestClientOptionsAsync($"/projects/{position.ProjectId}/positions/{position.Id}/instances/{instance.Id}/resources/requests?requestType=resourceOwnerChange");
+            
+            response.Should().BeSuccessfull();
+            response.Should().HaveAllowHeaders(HttpMethod.Post);
+        }
     }
 
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -81,6 +81,14 @@ namespace Fusion.Testing.Mocks.OrgService
             return this;
         }
 
+        public FusionTestProjectBuilder WithProperty(string key, object value)
+        {
+            if (project.Properties is null)
+                project.Properties = new ApiPropertiesCollectionV2();
+
+            project.Properties[key] = value;
+            return this;
+        }
 
         public FusionTestProjectBuilder WithPositions(int count) => WithPositions(count, count);
         public FusionTestProjectBuilder WithPositions(int min = 3, int max = 10)

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -3,6 +3,7 @@ using Fusion.Integration.Profile.ApiClient;
 using Fusion.Testing.Mocks.ProfileService.Api;
 using Microsoft.AspNetCore.Mvc.Testing;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 
@@ -12,7 +13,7 @@ namespace Fusion.Testing.Mocks.ProfileService
     {
         readonly WebApplicationFactory<Startup> factory;
 
-        internal static List<ApiPersonProfileV3> profiles = new List<ApiPersonProfileV3>();
+        internal static ConcurrentBag<ApiPersonProfileV3> profiles = new ConcurrentBag<ApiPersonProfileV3>();
         internal static List<ApiCompanyInfo> companies = new List<ApiCompanyInfo>();
 
         public PeopleServiceMock()


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
As some projects in pilot will be synced TO pims, while the rest is synced FROM pims, we must disable the possibility for resource owners to create change requests on allocations that will be overwritten from pims nightly.
The projects with pims write sync enabled should be safe to create change requests on.
We can do this by checking the property on the project. This is however a temporary solution in the pilot phase.

A check has been placed on `/projects/:orgProject/positions/:orgPositionId/instances/:orgInstanceId/resources/requests?requestType=resourceOwnerChange`. This will return `POST` in the `Allowed` header if request type can be created. For now only the `resourceOwnerChange` type is supported. If the request type is not supported, a bad request with `InvalidInput` will be returned. The endpoint can return a error payload with `error.code` and `error.message` to give further details if no allowed headers. 

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Verified by creating a new test project where write sync is disabled. Existing tests have been updated by letting test project have write property.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

