### PR TITLE
fix department requests when not tracked in db

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
@@ -23,8 +23,11 @@ namespace Fusion.Resources.Api.Controllers.Departments
                 .ExpandResourceOwners();
 
             var departments = await DispatchAsync(request);
+            var department = departments.FirstOrDefault();
 
-            return Ok(new ApiDepartment(departments.Single()));
+            if (department is null) return NotFound();
+
+            return Ok(new ApiDepartment(department));
         }
 
         [HttpGet("/departments")]

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
@@ -52,7 +52,7 @@ namespace Fusion.Resources.Domain
 
         public GetDepartments ById(string departmentId)
         {
-            departmentIds = new []{ departmentId };
+            departmentIds = new[] { departmentId };
             return this;
         }
         public GetDepartments ByIds(params string[] departmentIds)
@@ -107,6 +107,14 @@ namespace Fusion.Resources.Domain
                 if (request.shouldExpandResourceOwners)
                 {
                     var searchedDepartments = departments.Keys!.ToHashSet();
+                    if (request.departmentIds?.Any() == true)
+                    {
+                        foreach (var departmentId in request.departmentIds)
+                        {
+                            if (!searchedDepartments.Contains(departmentId))
+                                searchedDepartments.Add(departmentId);
+                        }
+                    }
 
                     // Optimize search when searching for a specific department
                     if (request.resourceOwnerSearch is null && request.departmentIds?.Length == 1)
@@ -120,6 +128,11 @@ namespace Fusion.Resources.Domain
                     foreach (var resourceOwner in resourceOwners)
                     {
                         if (!searchedDepartments.Contains(resourceOwner.DepartmentId)) continue;
+                        // Department found in line org but is not tracked in db
+                        if (!departments.ContainsKey(resourceOwner.DepartmentId))
+                        {
+                            departments[resourceOwner.DepartmentId] = new QueryDepartment(resourceOwner.DepartmentId, null);
+                        }
 
                         var department = departments[resourceOwner.DepartmentId];
                         department.LineOrgResponsible = resourceOwner.Responsible;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
@@ -94,6 +94,25 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task ShouldGiveNotFoundWhenRetreivingNotInLineOrg()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var lineorgData = new
+            {
+                Count = 0,
+                TotalCount = 0,
+                Value = Array.Empty<object>()
+            };
+
+            fixture.LineOrg.WithResponse("/lineorg/persons", lineorgData);
+
+            var resp = await Client.TestClientGetAsync<TestDepartment>("/departments/TPD LIN ORG TST?api-version=1.0-preview");
+
+            resp.Response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Fact]
         public async Task ShouldGetDepartmentNotInDbWhenInLineOrg()
         {
             var fakeResourceOwner = fixture.AddProfile(FusionAccountType.Employee);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
@@ -92,5 +92,35 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             resp.Response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+
+        [Fact]
+        public async Task ShouldGetDepartmentNotInDbWhenInLineOrg()
+        {
+            var fakeResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            var lineorgData = new
+            {
+                Count = 1,
+                TotalCount = 1,
+                Value = new[]
+                {
+                    new
+                    {
+                        fakeResourceOwner.AzureUniqueId,
+                        fakeResourceOwner.Name,
+                        fakeResourceOwner.Mail,
+                        IsResourceOwner = true,
+                        FullDepartment = "TPD LIN ORG TST"
+                    }
+                }
+            };
+
+            fixture.LineOrg.WithResponse("/lineorg/persons", lineorgData);
+
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await Client.TestClientGetAsync<TestDepartment>("/departments/TPD LIN ORG TST?api-version=1.0-preview");
+
+            resp.Response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
     }
 }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Fall back to line org when fetching departments that do not exist in our database.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

