### PR TITLE
Internal Requests - Notifications - Do not send notification to initiator

### DIFF
--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
@@ -116,7 +116,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var taskOwner = directRequest.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
-            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);
+            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(0);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == taskOwner).Should().Be(1);
         }
 
@@ -149,7 +149,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var taskOwner = patchPerson.Value.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
-            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);
+            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(0);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == taskOwner).Should().Be(1);
         }
 
@@ -171,7 +171,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var taskOwner = normalRequest.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
-            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(1);
+            NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == creator).Should().Be(0);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == taskOwner).Should().Be(1);
         }
         #endregion


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Should not send notitification to request initiator/user if user is creator/taskowner/resource owner of request


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Changed integration tests


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

