### PR TITLE
Added option to enable resource owner request on specific projects

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/ResourceControllerBase.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/ResourceControllerBase.cs
@@ -90,6 +90,9 @@ namespace Fusion.Resources.Api.Controllers
             if (project is null)
                 throw new InvalidOperationException("Could not locate project");
 
+            if (project.Properties.GetProperty<bool>("resourceOwnerRequestsEnabled", false))
+                return (false, null);
+
             var writeEnabled = project.Properties.GetProperty<bool>("pimsWriteSyncEnabled", false);
             if (writeEnabled)
                 return (false, null);


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added support for additional flag on the project to enable resource owner change requests. 
This is needed as checking the pims write flag exclude too many projects in test environments.


**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [ ] Local tests are passing

n/a


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

