### PR TITLE
Fixed filter field mapping for request state

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -171,7 +171,8 @@ namespace Fusion.Resources.Domain.Queries
                         m.MapField("isDraft", i => i.IsDraft);
                         m.MapField("project.id", i => i.Project.OrgProjectId);
                         m.MapField("updated", i => i.Updated);
-                        m.MapField("state", i => i.State);
+                        m.MapField("state", i => i.State.State);
+                        m.MapField("state.isComplete", i => i.State.IsCompleted);
                         m.MapField("provisioningStatus.state", i => i.ProvisioningStatus.State);
                     });
                 }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Query filter field mapping was not updated after state changed from string column in db to complext object. Changed mapping to point to the the actual string value on the complex object.
Also added mapping for "hidden" field `state.isComplete`.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

