### PR TITLE
Read access to requests for project update

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/AuthorizationConfigurationExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IAuthorizationHandler, ContractorInContractHandler>();
             services.AddScoped<IAuthorizationHandler, ContractorInProjectHandler>();
             services.AddScoped<IAuthorizationHandler, OrgPositionAccessHandler>();
+            services.AddScoped<IAuthorizationHandler, OrgProjectAccessHandler>();
             services.AddScoped<IAuthorizationHandler, RequestCreatorHandler>();
 
             return services;

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -32,6 +32,14 @@ namespace Fusion.Resources.Api.Controllers
         {
             return builder.AddRule(OrgPositionAccessRequirement.OrgPositionRead(orgProjectId, orgPositionId));
         }
+        public static IAuthorizationRequirementRule OrgChartReadAccess(this IAuthorizationRequirementRule builder, Guid orgProjectId)
+        {
+            return builder.AddRule(OrgProjectAccessRequirement.OrgRead(orgProjectId));
+        }
+        public static IAuthorizationRequirementRule OrgChartWriteAccess(this IAuthorizationRequirementRule builder, Guid orgProjectId)
+        {
+            return builder.AddRule(OrgProjectAccessRequirement.OrgWrite(orgProjectId));
+        }
 
         /// <summary>
         /// Indicates that the user is in any way or form a resource owner

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/OrgProjectAccessHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Handlers/OrgProjectAccessHandler.cs
@@ -1,0 +1,90 @@
+﻿using Fusion.Resources.Api.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Authorization.Handlers
+{
+    public class OrgProjectAccessHandler : AuthorizationHandler<Requirements.OrgProjectAccessRequirement>
+    {
+        private readonly IOrgApiClientFactory orgApiClientFactory;
+        private readonly IMemoryCache memCache;
+
+        public OrgProjectAccessHandler(IOrgApiClientFactory orgApiClientFactory, IMemoryCache memCache)
+        {
+            this.orgApiClientFactory = orgApiClientFactory;
+            this.memCache = memCache;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, OrgProjectAccessRequirement requirement)
+        {
+            if (context.User.GetAzureUniqueId() is null)
+            {
+                requirement.SetEvaluation("No unique object id located, cannot evaluate");
+                return;
+            }
+
+            var allowedMethods = await QueryAccessAsync(context, requirement);
+            
+            if (allowedMethods is null)
+                return;
+
+            switch (requirement.RequiredLevel)
+            {
+                case OrgProjectAccessRequirement.AccessLevel.Read:
+                    if (allowedMethods.Contains("get", StringComparer.OrdinalIgnoreCase))
+                        context.Succeed(requirement);
+                    break;
+
+                case OrgProjectAccessRequirement.AccessLevel.Write:
+                    if (allowedMethods.Contains("put", StringComparer.OrdinalIgnoreCase))
+                        context.Succeed(requirement);
+                    break;
+            }
+
+        }
+
+        private async Task<IEnumerable<string>?> QueryAccessAsync(AuthorizationHandlerContext context, OrgProjectAccessRequirement requirement)
+        {
+            string cacheKey = $"project-options-{requirement.OrgProjectId}-{context.User.GetAzureUniqueIdOrThrow()}";
+            
+            if (memCache.TryGetValue(cacheKey, out string[] cachedHeaders))
+            {
+                requirement.SetEvaluation("Using cached access info...");
+                return cachedHeaders;
+            }
+
+            var client = orgApiClientFactory.CreateClient(ApiClientMode.Delegate);
+
+            var request = new HttpRequestMessage(new HttpMethod("OPTIONS"), $"/projects/{requirement.OrgProjectId}");
+            var response = await client.SendAsync(request);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                requirement.SetEvaluation("Org service reported no access");
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                requirement.SetEvaluation($"Could not query access from org chart. Service responded with {response.StatusCode}");
+                return null;
+            }
+
+            var allowedMethods = response.Content.Headers.Allow;
+
+            if (!allowedMethods.Any())
+            {
+                requirement.SetEvaluation("No allow header located...");
+                return null;
+            }
+
+            memCache.Set(cacheKey, allowedMethods.ToArray(), TimeSpan.FromMinutes(5));
+            return allowedMethods;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/OrgProjectAccessRequirement.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Requirements/OrgProjectAccessRequirement.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Fusion.Resources.Api.Authorization.Requirements
+{
+    public class OrgProjectAccessRequirement : Fusion.Authorization.FusionAuthorizationRequirement
+    {
+        public Guid OrgProjectId { get; }
+        public AccessLevel RequiredLevel { get; }
+
+        public override string Description => $"Must atleast have '{RequiredLevel}' access on the specific org chart";
+
+        public override string Code => "OrgChartAccess";
+
+        public enum AccessLevel { Read, Write }
+
+        private OrgProjectAccessRequirement(AccessLevel requiredLevel, Guid orgProjectId)
+        {
+            RequiredLevel = requiredLevel;
+            OrgProjectId = orgProjectId;
+        }
+
+        public static OrgProjectAccessRequirement OrgRead(Guid orgProjectId) => new OrgProjectAccessRequirement(AccessLevel.Read, orgProjectId);
+        public static OrgProjectAccessRequirement OrgWrite(Guid orgProjectId) => new OrgProjectAccessRequirement(AccessLevel.Write, orgProjectId);
+
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -318,6 +318,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     // For now everyone with a position in the project can view requests
                     or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(projectIdentifier.ProjectId));
+                    or.OrgChartReadAccess(projectIdentifier.ProjectId);
                 });
             });
 
@@ -401,6 +402,7 @@ namespace Fusion.Resources.Api.Controllers
                     or.BeRequestCreator(requestId);
                     // For now everyone with a position in the project can view requests
                     or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(result.Project.OrgProjectId));
+                    or.OrgChartReadAccess(result.Project.OrgProjectId);
 
                     if (result.OrgPositionId.HasValue)
                         or.OrgChartPositionReadAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
@@ -1124,6 +1126,7 @@ namespace Fusion.Resources.Api.Controllers
                     or.BeRequestCreator(requestId);
                     // For now everyone with a position in the project can view requests
                     or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(item.Project.OrgProjectId));
+                    or.OrgChartReadAccess(item.Project.OrgProjectId);
 
                     if (item.OrgPositionId.HasValue)
                         or.OrgChartPositionReadAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -191,7 +191,10 @@ namespace Fusion.Testing.Mocks.OrgService
             };
 
             var clone = position.JsonClone();
-            OrgServiceMock.positions.Add(clone);
+            OrgServiceMock.semaphore.Wait();
+            try { OrgServiceMock.positions.Add(clone); }
+            finally { OrgServiceMock.semaphore.Release(); }
+
             return clone;
         }
     }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Resolvers/OrgResolverMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Resolvers/OrgResolverMock.cs
@@ -75,7 +75,10 @@ namespace Fusion.Testing.Mocks.OrgService.Resolvers
 
             try
             {
-                var pos = OrgServiceMock.positions.Union(OrgServiceMock.contractPositions).FirstOrDefault(p => p.Id == positionId);
+                var positions = OrgServiceMock.positions.ToList();
+                var contractPositions = OrgServiceMock.contractPositions.ToList();
+
+                var pos = positions.Union(contractPositions).FirstOrDefault(p => p.Id == positionId);
                 return Task.FromResult(pos);
             }
             finally
@@ -90,7 +93,10 @@ namespace Fusion.Testing.Mocks.OrgService.Resolvers
 
             try
             {
-                var allPositions = OrgServiceMock.positions.Union(OrgServiceMock.contractPositions).Where(p => positionIds.Contains(p.Id));
+                var positions = OrgServiceMock.positions.ToList();
+                var contractPositions = OrgServiceMock.contractPositions.ToList();
+
+                var allPositions = positions.Union(contractPositions).Where(p => positionIds.Contains(p.Id));
                 return Task.FromResult(allPositions.ToList().AsEnumerable());
             }
             finally


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added support for granting read access to request for a project when the user has read access in the org chart.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Added test to verify access is granted when project option endpoint is queried.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

