### PR TITLE
Add task details to other tasks

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -6,7 +6,7 @@ namespace Fusion.Resources.Api.Controllers
 {
     public class ApiPersonAbsence
     {
-        public ApiPersonAbsence(QueryPersonAbsence absence)
+        public ApiPersonAbsence(QueryPersonAbsence absence, bool hidePrivateNotes)
         {
             Id = absence.Id;
             Created = absence.Created;
@@ -16,18 +16,32 @@ namespace Fusion.Resources.Api.Controllers
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<ApiAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
+
+            IsPrivate = absence.IsPrivate;
+
+            if (absence.TaskDetails != null)
+            {
+                TaskDetails = (hidePrivateNotes && absence.IsPrivate)
+                    ? ApiTaskDetails.Hidden
+                    : new ApiTaskDetails(absence.TaskDetails);
+            }
         }
 
         public Guid Id { get; set; }
         public DateTimeOffset Created { get; set; }
         public ApiPerson CreatedBy { get; set; }
+
+        public bool IsPrivate { get; set; }
+
         public string? Comment { get; set; }
+
+        public ApiTaskDetails? TaskDetails { get; set; }
         public DateTimeOffset AppliesFrom { get; set; }
         public DateTimeOffset? AppliesTo { get; set; }
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public ApiAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
-        
+
         public enum ApiAbsenceType { Absence, Vacation, OtherTasks }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -11,19 +11,19 @@ namespace Fusion.Resources.Api.Controllers
             Id = absence.Id;
             Created = absence.Created;
             CreatedBy = new ApiPerson(absence.CreatedBy);
-            Comment = absence.Comment;
             AppliesFrom = absence.AppliesFrom;
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<ApiAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
 
             IsPrivate = absence.IsPrivate;
+            Comment = absence.Comment;
+            TaskDetails = (absence.TaskDetails != null) ? new ApiTaskDetails(absence.TaskDetails) : null;
 
-            if (absence.TaskDetails != null)
+            if (hidePrivateNotes && absence.IsPrivate)
             {
-                TaskDetails = (hidePrivateNotes && absence.IsPrivate)
-                    ? ApiTaskDetails.Hidden
-                    : new ApiTaskDetails(absence.TaskDetails);
+                Comment = "Not disclosed.";
+                TaskDetails = (absence.TaskDetails != null) ? ApiTaskDetails.Hidden : null;
             }
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiTaskDetails.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiTaskDetails.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiTaskDetails
+    {
+        public static readonly ApiTaskDetails Hidden = new ApiTaskDetails
+        {
+            IsHidden = true,
+            BasePositionId = null,
+            TaskName = "Not disclosed",
+            RoleName = "Not disclosed",
+            Location = "Not disclosed"
+        };
+
+        public ApiTaskDetails(){}
+        public ApiTaskDetails(Domain.QueryTaskDetails taskDetails)
+        {
+            BasePositionId = taskDetails.BasePositionId;
+            TaskName = taskDetails.TaskName;
+            RoleName = taskDetails.RoleName;
+            Location = taskDetails.Location;
+        }
+
+        public bool IsHidden { get; set; } = false;
+        public Guid? BasePositionId { get; set; }
+        public string? TaskName { get; set; }
+        public string? RoleName { get; set; }
+        public string? Location { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiTaskDetails.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiTaskDetails.cs
@@ -13,6 +13,9 @@ namespace Fusion.Resources.Api.Controllers
             Location = "Not disclosed"
         };
 
+        /// <summary>
+        /// Use ApiTaskDetails(Domain.QueryTaskDetails taskDetails). Only for MVC Model binder
+        /// </summary>
         public ApiTaskDetails(){}
         public ApiTaskDetails(Domain.QueryTaskDetails taskDetails)
         {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -36,7 +36,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                });
+                r.LimitedAccessWhen(x =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
             if (authResult.Unauthorized)
@@ -46,7 +51,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var personAbsence = await DispatchAsync(new GetPersonAbsence(id));
 
-            var returnItems = personAbsence.Select(p => new ApiPersonAbsence(p));
+            var returnItems = personAbsence.Select(p => new ApiPersonAbsence(p, authResult.LimitedAuth));
 
             var collection = new ApiCollection<ApiPersonAbsence>(returnItems);
             return collection;
@@ -72,7 +77,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                });
+                r.LimitedAccessWhen(x =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
             if (authResult.Unauthorized)
@@ -85,7 +95,7 @@ namespace Fusion.Resources.Api.Controllers
             if (personAbsence == null)
                 return FusionApiError.NotFound(absenceId, "Could not locate absence registration");
 
-            var returnItem = new ApiPersonAbsence(personAbsence);
+            var returnItem = new ApiPersonAbsence(personAbsence, authResult.LimitedAuth);
             return returnItem;
         }
 
@@ -110,7 +120,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                });
+                r.LimitedAccessWhen(x =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -129,7 +144,7 @@ namespace Fusion.Resources.Api.Controllers
                     var newAbsence = await DispatchAsync(createCommand);
                     await scope.CommitAsync();
 
-                    var item = new ApiPersonAbsence(newAbsence);
+                    var item = new ApiPersonAbsence(newAbsence, hidePrivateNotes: authResult.LimitedAuth);
                     return Created($"/persons/{personId}/absence/{item.Id}", item);
                 }
             }
@@ -158,7 +173,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                });
+                r.LimitedAccessWhen(x =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -176,7 +196,7 @@ namespace Fusion.Resources.Api.Controllers
 
                 await scope.CommitAsync();
 
-                var item = new ApiPersonAbsence(updatedAbsence);
+                var item = new ApiPersonAbsence(updatedAbsence, hidePrivateNotes: authResult.LimitedAuth);
                 return item;
             }
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -262,7 +262,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success) allowedVerbs.Add("GET", "POST");
 
-            Response.Headers["Allow"] = string.Join(',', allowedVerbs);
+            Response.Headers["Allow"] = string.Join(',', allowedVerbs.Distinct());
             return NoContent();
         }
 
@@ -303,7 +303,7 @@ namespace Fusion.Resources.Api.Controllers
 
             if (authResult.Success) allowedVerbs.Add("PUT", "DELETE");
 
-            Response.Headers["Allow"] = string.Join(',', allowedVerbs);
+            Response.Headers["Allow"] = string.Join(',', allowedVerbs.Distinct());
             return NoContent();
         }
     }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -36,12 +36,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
                 r.LimitedAccessWhen(x =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                 });
             });
             if (authResult.Unauthorized)
@@ -77,12 +77,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
                 r.LimitedAccessWhen(x =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                 });
             });
             if (authResult.Unauthorized)
@@ -120,12 +120,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
-                });
-                r.LimitedAccessWhen(x =>
-                {
-                    if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -144,7 +139,7 @@ namespace Fusion.Resources.Api.Controllers
                     var newAbsence = await DispatchAsync(createCommand);
                     await scope.CommitAsync();
 
-                    var item = new ApiPersonAbsence(newAbsence, hidePrivateNotes: authResult.LimitedAuth);
+                    var item = new ApiPersonAbsence(newAbsence, hidePrivateNotes: false);
                     return Created($"/persons/{personId}/absence/{item.Id}", item);
                 }
             }
@@ -173,12 +168,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AnyOf(or =>
                 {
                     if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        or.BeResourceOwner(profile.FullDepartment, includeParents: false, includeDescendants: false);
-                });
-                r.LimitedAccessWhen(x =>
-                {
-                    if (!String.IsNullOrEmpty(profile.FullDepartment))
-                        x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -196,7 +186,7 @@ namespace Fusion.Resources.Api.Controllers
 
                 await scope.CommitAsync();
 
-                var item = new ApiPersonAbsence(updatedAbsence, hidePrivateNotes: authResult.LimitedAuth);
+                var item = new ApiPersonAbsence(updatedAbsence, hidePrivateNotes: false);
                 return item;
             }
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -234,6 +234,19 @@ namespace Fusion.Resources.Api.Controllers
             var profile = await DispatchAsync(new GetPersonProfile(id));
             if (profile is null)
                 return ApiErrors.NotFound($"Person with id '{personId}' could not be found.");
+            
+            var getAuthResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
+
+                r.AnyOf(or =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
+                });
+            });
+            if (getAuthResult.Success) allowedVerbs.Add("GET");
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
@@ -263,6 +276,19 @@ namespace Fusion.Resources.Api.Controllers
             if (profile is null)
                 return ApiErrors.NotFound($"Person with id '{personId}' could not be found.");
 
+            var getAuthResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControlInternal();
+
+                r.AnyOf(or =>
+                {
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
+                });
+            });
+            if (getAuthResult.Success) allowedVerbs.Add("GET");
+
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl();
@@ -275,7 +301,7 @@ namespace Fusion.Resources.Api.Controllers
                 });
             });
 
-            if (authResult.Success) allowedVerbs.Add("GET", "PUT", "DELETE");
+            if (authResult.Success) allowedVerbs.Add("PUT", "DELETE");
 
             Response.Headers["Allow"] = string.Join(',', allowedVerbs);
             return NoContent();

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -56,9 +56,9 @@ namespace Fusion.Resources.Api.Controllers
                     .When(x => x.Type != ApiPersonAbsence.ApiAbsenceType.OtherTasks)
                     .WithMessage("Cannot set task details when type is not 'other tasks'.");
 
-                RuleFor(x => x.TaskDetails.RoleName)
+                RuleFor(x => x.TaskDetails!.RoleName)
                     .NotEmpty()
-                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails.BasePositionId.HasValue)
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && x.TaskDetails?.BasePositionId != null)
                     .WithMessage("Either role name or base position must be set.");
             }
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -58,7 +58,7 @@ namespace Fusion.Resources.Api.Controllers
 
                 RuleFor(x => x.TaskDetails!.RoleName)
                     .NotEmpty()
-                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && x.TaskDetails?.BasePositionId != null)
+                    .When(x => x.TaskDetails != null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && x.TaskDetails?.BasePositionId != null)
                     .WithMessage("Either role name or base position must be set.");
             }
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -55,6 +55,11 @@ namespace Fusion.Resources.Api.Controllers
                     .Empty()
                     .When(x => x.Type != ApiPersonAbsence.ApiAbsenceType.OtherTasks)
                     .WithMessage("Cannot set task details when type is not 'other tasks'.");
+
+                RuleFor(x => x.TaskDetails.RoleName)
+                    .NotEmpty()
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails.BasePositionId.HasValue)
+                    .WithMessage("Either role name or base position must be set.");
             }
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -16,6 +16,8 @@ namespace Fusion.Resources.Api.Controllers
 
         public double? AbsencePercentage { get; set; }
 
+        public bool IsPrivate { get; set; }
+        public ApiTaskDetails? TaskDetails { get; set; }
 
         public void LoadCommand(CreatePersonAbsence command)
         {
@@ -27,6 +29,11 @@ namespace Fusion.Resources.Api.Controllers
             command.AppliesTo = AppliesTo;
             command.Type = Enum.Parse<QueryAbsenceType>($"{Type}", true);
             command.AbsencePercentage = AbsencePercentage;
+            command.IsPrivate = IsPrivate;
+            command.BasePositionId = TaskDetails?.BasePositionId;
+            command.TaskName = TaskDetails?.TaskName;
+            command.RoleName = TaskDetails?.RoleName;
+            command.Location = TaskDetails?.Location;
         }
 
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -51,6 +51,10 @@ namespace Fusion.Resources.Api.Controllers
                 RuleFor(x => x.AppliesTo).GreaterThan(x => x.AppliesFrom)
                     .WithMessage(x => "To date cannot be earlier than from date");
 
+                RuleFor(x => x.TaskDetails)
+                    .Empty()
+                    .When(x => x.Type != ApiPersonAbsence.ApiAbsenceType.OtherTasks)
+                    .WithMessage("Cannot set task details when type is not 'other tasks'.");
             }
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
@@ -15,6 +15,8 @@ namespace Fusion.Resources.Api.Controllers
         public ApiPersonAbsence.ApiAbsenceType Type { get; set; }
 
         public double? AbsencePercentage { get; set; }
+        public ApiTaskDetails? TaskDetails { get; set; }
+        public bool IsPrivate { get; set; }
 
         public void LoadCommand(UpdatePersonAbsence command)
         {
@@ -23,7 +25,11 @@ namespace Fusion.Resources.Api.Controllers
             command.AppliesTo = AppliesTo;
             command.Type = Enum.Parse<QueryAbsenceType>($"{Type}", true);
             command.AbsencePercentage = AbsencePercentage;
-
+            command.BasePositionId = TaskDetails?.BasePositionId;
+            command.TaskName = TaskDetails?.TaskName;
+            command.RoleName = TaskDetails?.RoleName;
+            command.Location = TaskDetails?.Location;
+            command.IsPrivate = IsPrivate;
         }
 
         #region Validation
@@ -40,6 +46,15 @@ namespace Fusion.Resources.Api.Controllers
                 RuleFor(x => x.AppliesTo).GreaterThan(x => x.AppliesFrom)
                     .WithMessage(x => "To date cannot be earlier than from date");
 
+                RuleFor(x => x.TaskDetails)
+                    .Empty()
+                    .When(x => x.Type != ApiPersonAbsence.ApiAbsenceType.OtherTasks)
+                    .WithMessage("Cannot set task details when type is not 'other tasks'.");
+
+                RuleFor(x => x.TaskDetails.RoleName)
+                    .NotEmpty()
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails.BasePositionId.HasValue)
+                    .WithMessage("Either role name or base position must be set.");
             }
 
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
@@ -51,9 +51,9 @@ namespace Fusion.Resources.Api.Controllers
                     .When(x => x.Type != ApiPersonAbsence.ApiAbsenceType.OtherTasks)
                     .WithMessage("Cannot set task details when type is not 'other tasks'.");
 
-                RuleFor(x => x.TaskDetails.RoleName)
+                RuleFor(x => x.TaskDetails!.RoleName)
                     .NotEmpty()
-                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails.BasePositionId.HasValue)
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
                     .WithMessage("Either role name or base position must be set.");
             }
 

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
@@ -19,7 +19,7 @@ namespace Fusion.Resources.Database.Entities
         public double? AbsencePercentage { get; set; }
 
         public bool IsPrivate { get; set; }
-        public DbTaskDetails? TaskDetails { get; set; } = null!;
+        public DbOpTaskDetails? TaskDetails { get; set; } = null!;
 
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -33,7 +33,7 @@ namespace Fusion.Resources.Database.Entities
         }
     }
 
-    public class DbTaskDetails
+    public class DbOpTaskDetails
     {
         public Guid? BasePositionId { get; set; }
         public string? TaskName { get; set; }

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbPersonAbsence.cs
@@ -18,6 +18,9 @@ namespace Fusion.Resources.Database.Entities
         public DbAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
 
+        public bool IsPrivate { get; set; }
+        public DbTaskDetails? TaskDetails { get; set; } = null!;
+
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<DbPersonAbsence>(entity =>
@@ -25,10 +28,17 @@ namespace Fusion.Resources.Database.Entities
                 entity.Property(e => e.Type).HasConversion(new EnumToStringConverter<DbAbsenceType>());
                 entity.HasOne(e => e.Person).WithMany().OnDelete(DeleteBehavior.Restrict);
                 entity.HasOne(e => e.CreatedBy).WithMany().OnDelete(DeleteBehavior.Restrict);
-
+                entity.OwnsOne(e => e.TaskDetails);
             });
-
         }
+    }
+
+    public class DbTaskDetails
+    {
+        public Guid? BasePositionId { get; set; }
+        public string? TaskName { get; set; }
+        public string RoleName { get; set; } = null!;
+        public string? Location { get; set; }
     }
 
     public enum DbAbsenceType

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.Designer.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.Designer.cs
@@ -4,14 +4,16 @@ using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Fusion.Resources.Database.Migrations
 {
     [DbContext(typeof(ResourcesDbContext))]
-    partial class ResourcesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210526142847_add_task_details_to_absence")]
+    partial class add_task_details_to_absence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fusion.Resources.Database.Migrations
+{
+    public partial class add_task_details_to_absence : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPrivate",
+                table: "PersonAbsences",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "TaskDetails_BasePositionId",
+                table: "PersonAbsences",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TaskDetails_Location",
+                table: "PersonAbsences",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TaskDetails_RoleName",
+                table: "PersonAbsences",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TaskDetails_TaskName",
+                table: "PersonAbsences",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PersonNotes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AzureUniqueId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
+                    Content = table.Column<string>(type: "nvarchar(2500)", maxLength: 2500, nullable: true),
+                    IsShared = table.Column<bool>(type: "bit", nullable: false),
+                    Updated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonNotes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PersonNotes_Persons_UpdatedById",
+                        column: x => x.UpdatedById,
+                        principalTable: "Persons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonNotes_AzureUniqueId",
+                table: "PersonNotes",
+                column: "AzureUniqueId")
+                .Annotation("SqlServer:Clustered", false)
+                .Annotation("SqlServer:Include", new[] { "Id", "Title", "Content", "IsShared", "Updated", "UpdatedById" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonNotes_UpdatedById",
+                table: "PersonNotes",
+                column: "UpdatedById");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PersonNotes");
+
+            migrationBuilder.DropColumn(
+                name: "IsPrivate",
+                table: "PersonAbsences");
+
+            migrationBuilder.DropColumn(
+                name: "TaskDetails_BasePositionId",
+                table: "PersonAbsences");
+
+            migrationBuilder.DropColumn(
+                name: "TaskDetails_Location",
+                table: "PersonAbsences");
+
+            migrationBuilder.DropColumn(
+                name: "TaskDetails_RoleName",
+                table: "PersonAbsences");
+
+            migrationBuilder.DropColumn(
+                name: "TaskDetails_TaskName",
+                table: "PersonAbsences");
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210526142847_add_task_details_to_absence.cs
@@ -37,48 +37,10 @@ namespace Fusion.Resources.Database.Migrations
                 table: "PersonAbsences",
                 type: "nvarchar(max)",
                 nullable: true);
-
-            migrationBuilder.CreateTable(
-                name: "PersonNotes",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    AzureUniqueId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
-                    Content = table.Column<string>(type: "nvarchar(2500)", maxLength: 2500, nullable: true),
-                    IsShared = table.Column<bool>(type: "bit", nullable: false),
-                    Updated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
-                    UpdatedById = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_PersonNotes", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_PersonNotes_Persons_UpdatedById",
-                        column: x => x.UpdatedById,
-                        principalTable: "Persons",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_PersonNotes_AzureUniqueId",
-                table: "PersonNotes",
-                column: "AzureUniqueId")
-                .Annotation("SqlServer:Clustered", false)
-                .Annotation("SqlServer:Include", new[] { "Id", "Title", "Content", "IsShared", "Updated", "UpdatedById" });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_PersonNotes_UpdatedById",
-                table: "PersonNotes",
-                column: "UpdatedById");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "PersonNotes");
-
             migrationBuilder.DropColumn(
                 name: "IsPrivate",
                 table: "PersonAbsences");

--- a/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/CreatePersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/CreatePersonAbsence.cs
@@ -77,7 +77,7 @@ namespace Fusion.Resources.Domain.Commands
                         roleName = basePosition.Name;
                     }
 
-                    newItem.TaskDetails = new DbTaskDetails
+                    newItem.TaskDetails = new DbOpTaskDetails
                     {
                         BasePositionId = request.BasePositionId,
                         TaskName = request.TaskName,

--- a/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/CreatePersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/CreatePersonAbsence.cs
@@ -1,7 +1,9 @@
-﻿using Fusion.Resources.Database;
+﻿using Fusion.ApiClients.Org;
+using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using MediatR;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,16 +23,23 @@ namespace Fusion.Resources.Domain.Commands
         public DateTimeOffset? AppliesTo { get; set; }
         public QueryAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
+        public bool IsPrivate { get; set; }
+        public string? TaskName { get; set; }
+        public string? RoleName { get; set; }
+        public string? Location { get; set; }
+        public Guid? BasePositionId { get; set; }
 
         public class Handler : IRequestHandler<CreatePersonAbsence, QueryPersonAbsence>
         {
             private readonly ResourcesDbContext resourcesDb;
             private readonly IProfileService profileService;
+            private readonly IOrgApiClient orgApiClient;
 
-            public Handler(ResourcesDbContext resourcesDb, IProfileService profileService)
+            public Handler(ResourcesDbContext resourcesDb, IProfileService profileService, IOrgApiClientFactory orgApiClientFactory)
             {
                 this.resourcesDb = resourcesDb;
                 this.profileService = profileService;
+                this.orgApiClient = orgApiClientFactory.CreateClient(ApiClientMode.Application);
             }
 
             public async Task<QueryPersonAbsence> Handle(CreatePersonAbsence request, CancellationToken cancellationToken)
@@ -49,11 +58,35 @@ namespace Fusion.Resources.Domain.Commands
                     AppliesFrom = request.AppliesFrom.Date,
                     AppliesTo = request.AppliesTo?.Date,
                     Type = Enum.Parse<DbAbsenceType>($@"{request.Type}"),
-                    AbsencePercentage = request.AbsencePercentage
+                    AbsencePercentage = request.AbsencePercentage,
+                    IsPrivate = request.IsPrivate
                 };
 
-                await resourcesDb.PersonAbsences.AddAsync(newItem);
-                await resourcesDb.SaveChangesAsync();
+                if(request.Type == QueryAbsenceType.OtherTasks)
+                {
+                    var roleName = request.RoleName;
+                    if (request.BasePositionId.HasValue && String.IsNullOrEmpty(request.RoleName))
+                    {
+                        var basePosition = await orgApiClient.GetAsync<ApiBasePositionV2>($"/positions/basepositions/{request.BasePositionId}");
+                        if(!basePosition.IsSuccessStatusCode)
+                        {
+                            throw new IntegrationError("Unable to retrieve baseposition", new OrgApiError(basePosition.Response, basePosition.Content));
+                        }
+
+                        roleName = basePosition.Value.Name;
+                    }
+
+                    newItem.TaskDetails = new DbTaskDetails
+                    {
+                        BasePositionId = request.BasePositionId,
+                        TaskName = request.TaskName,
+                        RoleName = roleName!,
+                        Location = request.Location
+                    };
+                }
+
+                resourcesDb.PersonAbsences.Add(newItem);
+                await resourcesDb.SaveChangesAsync(cancellationToken);
 
                 return new QueryPersonAbsence(newItem);
             }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
@@ -78,7 +78,7 @@ namespace Fusion.Resources.Domain.Commands
                         roleName = basePosition.Name;
                     }
 
-                    absence.TaskDetails = new DbTaskDetails
+                    absence.TaskDetails = new DbOpTaskDetails
                     {
                         BasePositionId = request.BasePositionId,
                         TaskName = request.TaskName,

--- a/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
@@ -81,7 +81,7 @@ namespace Fusion.Resources.Domain.Commands
                     {
                         BasePositionId = request.BasePositionId,
                         TaskName = request.TaskName,
-                        RoleName = roleName,
+                        RoleName = roleName!,
                         Location = request.Location
                     };
                 }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/EmploymentStatus/UpdatePersonAbsence.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Fusion.Resources.Database.Entities;
+using Fusion.ApiClients.Org;
 
 namespace Fusion.Resources.Domain.Commands
 {
@@ -24,36 +25,66 @@ namespace Fusion.Resources.Domain.Commands
         public DateTimeOffset? AppliesTo { get; set; }
         public QueryAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
+        public string? TaskName { get; set; }
+        public string? RoleName { get; set; }
+        public string? Location { get; set; }
+        public Guid? BasePositionId { get; set; }
+        public bool IsPrivate { get; set; }
 
         public class Handler : IRequestHandler<UpdatePersonAbsence, QueryPersonAbsence>
         {
             private readonly ResourcesDbContext resourcesDb;
             private readonly IMediator mediator;
+            private readonly IOrgApiClient orgApiClient;
 
-            public Handler(ResourcesDbContext resourcesDb, IMediator mediator)
+            public Handler(ResourcesDbContext resourcesDb, IMediator mediator, IOrgApiClientFactory orgApiClientFactory)
             {
                 this.resourcesDb = resourcesDb;
                 this.mediator = mediator;
+                this.orgApiClient = orgApiClientFactory.CreateClient(ApiClientMode.Application);
             }
 
             public async Task<QueryPersonAbsence> Handle(UpdatePersonAbsence request, CancellationToken cancellationToken)
             {
-                var absences = await resourcesDb.PersonAbsences
+                var absence = await resourcesDb.PersonAbsences
                     .GetById(request.PersonId, request.Id)
                     .Include(cp => cp.Person)
                     .FirstOrDefaultAsync(x => x.Id == request.Id);
 
-                if (absences is null)
+                if (absence is null)
                     throw new ArgumentException($"Cannot locate status using identifier '{request.Id}'");
 
-                absences.Comment = request.Comment;
-                absences.AppliesFrom = request.AppliesFrom;
-                absences.AppliesTo = request.AppliesTo;
-                absences.Created = DateTimeOffset.UtcNow;
-                absences.CreatedBy = request.Editor.Person;
-                absences.Type = Enum.Parse<DbAbsenceType>($"{request.Type}");
-                absences.AbsencePercentage = request.AbsencePercentage;
+                absence.Comment = request.Comment;
+                absence.AppliesFrom = request.AppliesFrom;
+                absence.AppliesTo = request.AppliesTo;
+                absence.Created = DateTimeOffset.UtcNow;
+                absence.CreatedBy = request.Editor.Person;
+                absence.Type = Enum.Parse<DbAbsenceType>($"{request.Type}");
+                absence.AbsencePercentage = request.AbsencePercentage;
+                absence.IsPrivate = request.IsPrivate;
 
+                if(absence.Type == DbAbsenceType.OtherTasks)
+                {
+                    var roleName = request.RoleName;
+                    if (request.BasePositionId.HasValue && String.IsNullOrEmpty(request.RoleName))
+                    {
+                        var basePosition = await orgApiClient.GetAsync<ApiBasePositionV2>($"/positions/basepositions/{request.BasePositionId}");
+                        if (!basePosition.IsSuccessStatusCode)
+                        {
+                            throw new IntegrationError("Unable to retrieve baseposition", new OrgApiError(basePosition.Response, basePosition.Content));
+                        }
+
+                        roleName = basePosition.Value.Name;
+                    }
+
+                    absence.TaskDetails = new DbTaskDetails
+                    {
+                        BasePositionId = request.BasePositionId,
+                        TaskName = request.TaskName,
+                        RoleName = roleName,
+                        Location = request.Location
+                    };
+                }
 
                 await resourcesDb.SaveChangesAsync();
 

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
@@ -46,7 +46,7 @@ namespace Fusion.Resources.Domain
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
-            TaskDetails = new QueryTaskDetails(absence.TaskDetails);
+            TaskDetails = absence.TaskDetails != null ? new QueryTaskDetails(absence.TaskDetails) : null;
         }
         public QueryPersonAbsenceBasic(QueryPersonAbsence absence)
         {
@@ -68,7 +68,7 @@ namespace Fusion.Resources.Domain
         public QueryAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
         public bool IsPrivate { get; }
-        public QueryTaskDetails TaskDetails { get; set; }
+        public QueryTaskDetails? TaskDetails { get; set; }
     }
 
     public class QueryTaskDetails

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
@@ -73,7 +73,7 @@ namespace Fusion.Resources.Domain
 
     public class QueryTaskDetails
     {
-        public QueryTaskDetails(DbTaskDetails taskDetails)
+        public QueryTaskDetails(DbOpTaskDetails taskDetails)
         {
             BasePositionId = taskDetails.BasePositionId;
             TaskName = taskDetails.TaskName;

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonAbsence.cs
@@ -15,6 +15,9 @@ namespace Fusion.Resources.Domain
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
+
+            IsPrivate = absence.IsPrivate;
+            TaskDetails = (absence.TaskDetails != null) ? new QueryTaskDetails(absence.TaskDetails) : null;
         }
 
         public Guid Id { get; set; }
@@ -25,6 +28,9 @@ namespace Fusion.Resources.Domain
         public DateTimeOffset? AppliesTo { get; set; }
         public QueryAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
+
+        public bool IsPrivate { get; set; }
+        public QueryTaskDetails? TaskDetails { get; set; }
     }
 
     /// <summary>
@@ -40,6 +46,7 @@ namespace Fusion.Resources.Domain
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
+            TaskDetails = new QueryTaskDetails(absence.TaskDetails);
         }
         public QueryPersonAbsenceBasic(QueryPersonAbsence absence)
         {
@@ -49,6 +56,9 @@ namespace Fusion.Resources.Domain
             AppliesTo = absence.AppliesTo;
             Type = Enum.Parse<QueryAbsenceType>($"{absence.Type}", true);
             AbsencePercentage = absence.AbsencePercentage;
+
+            IsPrivate = absence.IsPrivate;
+            TaskDetails = absence.TaskDetails;
         }
 
         public Guid Id { get; set; }
@@ -57,8 +67,32 @@ namespace Fusion.Resources.Domain
         public DateTimeOffset? AppliesTo { get; set; }
         public QueryAbsenceType Type { get; set; }
         public double? AbsencePercentage { get; set; }
+        public bool IsPrivate { get; }
+        public QueryTaskDetails TaskDetails { get; set; }
     }
 
+    public class QueryTaskDetails
+    {
+        public QueryTaskDetails(DbTaskDetails taskDetails)
+        {
+            BasePositionId = taskDetails.BasePositionId;
+            TaskName = taskDetails.TaskName;
+            RoleName = taskDetails.RoleName;
+            Location = taskDetails.Location;
+        }
+        public QueryTaskDetails(QueryTaskDetails taskDetails)
+        {
+            BasePositionId = taskDetails.BasePositionId;
+            TaskName = taskDetails.TaskName;
+            RoleName = taskDetails.RoleName;
+            Location = taskDetails.Location;
+        }
+
+        public Guid? BasePositionId { get; }
+        public string? TaskName { get; }
+        public string RoleName { get; }
+        public string? Location { get; }
+    }
 
     public enum QueryAbsenceType
     {

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
@@ -32,9 +32,8 @@ namespace Fusion.Resources.Domain
                 var items = await db.PersonAbsences.GetById(request.PersonId)
                     .Include(x => x.Person)
                     .Include(x => x.CreatedBy)
-                    .ToListAsync();
-
-
+                    .Include(x => x.TaskDetails)
+                    .ToListAsync(cancellationToken: cancellationToken);
 
                 var returnItems = items.Select(i => new QueryPersonAbsence(i))
                     .ToList();

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
@@ -33,7 +33,7 @@ namespace Fusion.Resources.Domain
                     .Include(x => x.Person)
                     .Include(x => x.CreatedBy)
                     .Include(x => x.TaskDetails)
-                    .ToListAsync(cancellationToken: cancellationToken);
+                    .ToListAsync(cancellationToken);
 
                 var returnItems = items.Select(i => new QueryPersonAbsence(i))
                     .ToList();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -366,15 +366,18 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             }
 
             using var userScope = fixture.UserScope(Users[role]);
+            {
 
-            var client = fixture.ApiFactory.CreateClient();
-            var result = await client.TestClientPostAsync<TestApiInternalRequestModel>(
-               $"/projects/{testProject.Project.ProjectId}/resources/requests/{request.Id}/approve",
-               null
-            );
 
-            if (shouldBeAllowed) result.Should().BeSuccessfull();
-            else result.Should().BeUnauthorized();
+                var client = fixture.ApiFactory.CreateClient();
+                var result = await client.TestClientPostAsync<TestApiInternalRequestModel>(
+                   $"/projects/{testProject.Project.ProjectId}/resources/requests/{request.Id}/approve",
+                   null
+                );
+
+                if (shouldBeAllowed) result.Should().BeSuccessfull();
+                else result.Should().BeUnauthorized();
+            }
         }
 
         [Theory]

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -233,9 +233,9 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             using var i = creatorInterceptor = OrgRequestMocker
                  .InterceptOption($"/{testPosition.Id}")
                  .RespondWithHeaders(HttpStatusCode.NoContent, h => h.Add("Allow", "PUT"));
-            
+
             var client = fixture.ApiFactory.CreateClient();
-            
+
             var result = await client.TestClientPostAsync<TestApiInternalRequestModel>(
                 $"/departments/{TestDepartment}/resources/requests",
                 new ApiCreateInternalRequestModel()
@@ -512,7 +512,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", TestDepartment, "GET,POST")]
         [InlineData("resourceOwner", SiblingDepartment, "GET,POST")]
         [InlineData("resourceOwner", ParentDepartment, "GET,POST")]
-        [InlineData("resourceOwner", SameL2Department, "!GET,!POST")]
+        [InlineData("resourceOwner", SameL2Department, "GET,!POST")]
         public async Task CanGetAbsenceOptionsForPerson(string role, string department, string allowed)
         {
             using var userScope = fixture.UserScope(Users[role]);
@@ -524,14 +524,14 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 $"/persons/{testUser.AzureUniqueId}/absence"
             );
 
-            CheckHeaders(allowed, result);
+            CheckAllowHeader(allowed, result);
         }
 
         [Theory]
         [InlineData("resourceOwner", TestDepartment, "GET,PUT,DELETE")]
         [InlineData("resourceOwner", SiblingDepartment, "GET,PUT,DELETE")]
         [InlineData("resourceOwner", ParentDepartment, "GET,PUT,DELETE")]
-        [InlineData("resourceOwner", SameL2Department, "!GET,!PUT,!DELETE")]
+        [InlineData("resourceOwner", SameL2Department, "GET,!PUT,!DELETE")]
         public async Task CanGetAbsenceOptions(string role, string department, string allowed)
         {
             var absence = await CreateAbsence();
@@ -545,7 +545,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 $"/persons/{testUser.AzureUniqueId}/absence/{absence.Id}"
             );
 
-            CheckHeaders(allowed, result);
+            CheckAllowHeader(allowed, result);
         }
 
         [Theory]
@@ -567,10 +567,10 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             if (shouldBeAllowed) result.Should().BeSuccessfull();
             else result.Should().BeUnauthorized();
-            
+
         }
 
-         private static void CheckHeaders(string allowed, TestClientHttpResponse<dynamic> result)
+        private static void CheckAllowHeader(string allowed, TestClientHttpResponse<dynamic> result)
         {
             var expectedVerbs = allowed
                             .Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -468,7 +468,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", TestDepartment, true)]
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
-        [InlineData("resourceOwner", SameL2Department, false)]
+        [InlineData("resourceOwner", SameL2Department, true)]
         public async Task CanGetPersonAbsence(string role, string department, bool shouldBeAllowed)
         {
             var absence = await CreateAbsence();
@@ -490,7 +490,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", TestDepartment, true)]
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
-        [InlineData("resourceOwner", SameL2Department, false)]
+        [InlineData("resourceOwner", SameL2Department, true)]
         public async Task CanGetAllAbsenceForPerson(string role, string department, bool shouldBeAllowed)
         {
             var absence = await CreateAbsence();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -367,8 +367,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             using var userScope = fixture.UserScope(Users[role]);
             {
-
-
                 var client = fixture.ApiFactory.CreateClient();
                 var result = await client.TestClientPostAsync<TestApiInternalRequestModel>(
                    $"/projects/{testProject.Project.ProjectId}/resources/requests/{request.Id}/approve",

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -104,7 +104,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task ShouldGetRoleNameFromBasePositionWhenEmpty()
         {
-            const string BasePositionName = "Test position name";
+            const string BasePositionName = "Base position name";
             var testProject = new FusionTestProjectBuilder();
             var basePosition = testProject
                 .AddBasePosition(BasePositionName);
@@ -131,7 +131,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await client.TestClientPutAsync<TestAbsence>($"/persons/{testUser.AzureUniqueId}/absence/{TestAbsenceId}", request);
             response.Should().BeSuccessfull();
 
-            response.Value.TaskDetails?.RoleName.Should().Be("Base position name");
+            response.Value.TaskDetails?.RoleName.Should().Be(BasePositionName);
         }
 
         [Fact]

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -15,6 +15,15 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
     [ApiVersion("2.0")]
     public class PositionsController : ControllerBase
     {
+        [ApiVersion("2.0")]
+        [HttpGet("/positions/basepositions/{basepositionId}")]
+        public ActionResult<ApiBasePositionV2> GetBaseposition(Guid basepositionId)
+        {
+            var bp = OrgServiceMock.basePositions.FirstOrDefault(bp => bp.Id == basepositionId);
+            if (bp is null) return NotFound();
+
+            return Ok(bp);
+        }
 
         [ApiVersion("2.0")]
         [HttpGet("/positions/{positionId}")]

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -19,7 +19,7 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
         [HttpGet("/positions/basepositions/{basepositionId}")]
         public ActionResult<ApiBasePositionV2> GetBaseposition(Guid basepositionId)
         {
-            var bp = OrgServiceMock.basePositions.FirstOrDefault(bp => bp.Id == basepositionId);
+            var bp = PositionBuilder.AllBasePositions.FirstOrDefault(bp => bp.Id == basepositionId);
             if (bp is null) return NotFound();
 
             return Ok(bp);

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -157,7 +157,7 @@ namespace Fusion.Testing.Mocks.OrgService
 
             try
             {
-                OrgServiceMock.basePositions.Add(bp.JsonClone());
+                PositionBuilder.AllBasePositions.Add(bp.JsonClone());
             }
             finally { OrgServiceMock.semaphore.Release(); }
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -153,7 +153,13 @@ namespace Fusion.Testing.Mocks.OrgService
             };
 
             setup?.Invoke(bp);
+            OrgServiceMock.semaphore.Wait();
 
+            try
+            {
+                OrgServiceMock.basePositions.Add(bp.JsonClone());
+            }
+            finally { OrgServiceMock.semaphore.Release(); }
 
             return bp;
         }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -73,8 +73,8 @@ namespace Fusion.Testing.Mocks.OrgService
         /// <summary>
         /// Add a random contract without any positions.
         /// </summary>
-        public FusionTestProjectBuilder WithContract() => WithContract(builder => { } );
-        public FusionTestProjectBuilder WithContractAndPositions() => WithContract(builder => builder.WithPositions() );
+        public FusionTestProjectBuilder WithContract() => WithContract(builder => { });
+        public FusionTestProjectBuilder WithContractAndPositions() => WithContract(builder => builder.WithPositions());
 
         public FusionTestProjectBuilder WithContract(Action<FusionTestContractBuilder> contractSetup)
         {
@@ -159,10 +159,8 @@ namespace Fusion.Testing.Mocks.OrgService
             };
 
             setup?.Invoke(bp);
-           
-                PositionBuilder.AddBaseposition(bp.JsonClone());
-            
 
+            PositionBuilder.AddBaseposition(bp.JsonClone());
             return bp;
         }
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -159,13 +159,9 @@ namespace Fusion.Testing.Mocks.OrgService
             };
 
             setup?.Invoke(bp);
-            OrgServiceMock.semaphore.Wait();
-
-            try
-            {
-                PositionBuilder.AllBasePositions.Add(bp.JsonClone());
-            }
-            finally { OrgServiceMock.semaphore.Release(); }
+           
+                PositionBuilder.AddBaseposition(bp.JsonClone());
+            
 
             return bp;
         }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/TestPositionBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/TestPositionBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using Fusion.ApiClients.Org;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -32,9 +31,9 @@ namespace Fusion.Testing.Mocks.OrgService
                 });
         }
 
-        
+
         private static List<ApiBasePositionV2> basePositionCache = null;
-        public static List<ApiBasePositionV2> AllBasePositions
+        public static IEnumerable<ApiBasePositionV2> AllBasePositions
         {
             get
             {
@@ -52,7 +51,7 @@ namespace Fusion.Testing.Mocks.OrgService
                     }).ToList();
                 }
 
-                return basePositionCache;
+                return basePositionCache.ToArray();
             }
         }
 
@@ -61,7 +60,7 @@ namespace Fusion.Testing.Mocks.OrgService
         private static List<ApiBasePositionV2> GetBasePositionCSVImport()
         {
             var resourceData = AssemblyUtils.GetResourceFromCurrentAssembly($@"Fusion.Testing.Mocks.OrgService.Data.BasePositions.csv");
-            var data = resourceData.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var data = resourceData.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
             List<ApiBasePositionV2> positions = data.Skip(1)
                 .Where(l => !string.IsNullOrEmpty(l))   // Trim any empty lines
@@ -110,8 +109,16 @@ namespace Fusion.Testing.Mocks.OrgService
                 }
             }
         }
+
+        public static void AddBaseposition(ApiBasePositionV2 basePosition)
+        {
+            OrgServiceMock.semaphore.Wait();
+
+            try
+            {
+                basePositionCache.Add(basePosition);
+            }
+            finally { OrgServiceMock.semaphore.Release(); }
+        }
     }
-
-    
-
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -33,7 +33,6 @@ namespace Fusion.Testing.Mocks.OrgService
         internal static Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>> contracts = new Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>>();
         internal static List<ApiClients.Org.ApiPositionV2> contractPositions = new List<ApiClients.Org.ApiPositionV2>();
         internal static List<ApiCompanyV2> companies = new List<ApiCompanyV2>();
-        internal static List<ApiBasePositionV2> basePositions = new List<ApiBasePositionV2>();
 
         internal static ConcurrentDictionary<Guid, Guid> taskOwnerMapping = new ConcurrentDictionary<Guid, Guid>();
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -33,6 +33,7 @@ namespace Fusion.Testing.Mocks.OrgService
         internal static Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>> contracts = new Dictionary<Guid, List<ApiClients.Org.ApiProjectContractV2>>();
         internal static List<ApiClients.Org.ApiPositionV2> contractPositions = new List<ApiClients.Org.ApiPositionV2>();
         internal static List<ApiCompanyV2> companies = new List<ApiCompanyV2>();
+        internal static List<ApiBasePositionV2> basePositions = new List<ApiBasePositionV2>();
 
         internal static ConcurrentDictionary<Guid, Guid> taskOwnerMapping = new ConcurrentDictionary<Guid, Guid>();
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Add `TaskDetails` to `PersonAbsence` to describe work on other tasks.
Hide this information for other resource owners except in parent and sibling departments.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

