### PR TITLE
Nullable domain id

### DIFF
--- a/src/backend/api/Fusion.Resources.Database/Entities/DbProject.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbProject.cs
@@ -7,7 +7,7 @@ namespace Fusion.Resources.Database.Entities
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = null!;
-        public string DomainId { get; set; } = null!;
+        public string? DomainId { get; set; }
         public Guid OrgProjectId { get; set; }
 
         public ICollection<DbContract> Contracts { get; set; } = null!;

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210527140718_Nullable domainId.Designer.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210527140718_Nullable domainId.Designer.cs
@@ -4,14 +4,16 @@ using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Fusion.Resources.Database.Migrations
 {
     [DbContext(typeof(ResourcesDbContext))]
-    partial class ResourcesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210527140718_Nullable domainId")]
+    partial class NullabledomainId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20210527140718_Nullable domainId.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20210527140718_Nullable domainId.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fusion.Resources.Database.Migrations
+{
+    public partial class NullabledomainId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "DomainId",
+                table: "Projects",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "DomainId",
+                table: "Projects",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -15,7 +15,7 @@ namespace Fusion.Resources.Domain
 
         public Guid Id { get; set; }
         public string Name { get; set; }
-        public string DomainId { get; set; }
+        public string? DomainId { get; set; }
         public Guid OrgProjectId { get; set; }
 
     }
@@ -30,7 +30,7 @@ namespace Fusion.Resources.Domain
             Type = type;
         }
         public string Name { get; set; }
-        public string DomainId { get; set; }
+        public string? DomainId { get; set; }
         public Guid OrgProjectId { get; set; }
         public string Type { get; set; }
     }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Changed `DomainId` property to nullable in db. 
This has most likely been set to `not null` after converting to `#nullable enable`. The domain id is not required from org so this is causing internal error when creating requests on projects that does not have one.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Quick fix / low risk


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

