### PR TITLE
Allow removing proposed person when request is not proposed yet

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
@@ -41,7 +41,7 @@ namespace Fusion.Resources.Api.Controllers
 
                         return false;
                     })
-                    .When(x => x.ProposedPersonAzureUniqueId.HasValue);
+                    .When(x => x.ProposedPersonAzureUniqueId.HasValue && x.ProposedPersonAzureUniqueId.Value.HasValue);
 
 
                 RuleFor(x => x.AssignedDepartment)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -582,6 +582,48 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeBadRequest();
         }
 
+        [Fact]
+        public async Task UpdateRequest_ProposedPersonShouldBeNullable_WhenInDraft()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var response = await Client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/resources/requests/internal/{normalRequest.Id}", 
+                new {  proposedPersonAzureUniqueId = null as Guid? } 
+            );
+            response.Should().BeSuccessfull();
+            response.Value.ProposedPersonAzureUniqueId.Should().BeNull();
+        }
+        [Fact]
+        public async Task UpdateRequest_ProposedPersonShouldBeNullable_WhenCreated()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var request = await Client.StartProjectRequestAsync(testProject, normalRequest.Id);
+
+            var response = await Client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/resources/requests/internal/{normalRequest.Id}",
+                new { proposedPersonAzureUniqueId = null as Guid? }
+            );
+            response.Should().BeSuccessfull();
+            response.Value.ProposedPersonAzureUniqueId.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task UpdateRequest_ProposedPersonShouldNotBeNullable_WhenApproving()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var request = await Client.StartProjectRequestAsync(testProject, normalRequest.Id);
+            await Client.ProposePersonAsync(normalRequest.Id, testUser);
+            await Client.ResourceOwnerApproveAsync(TestDepartmentId, normalRequest.Id);
+
+            var response = await Client.TestClientPatchAsync<TestApiInternalRequestModel>(
+                $"/resources/requests/internal/{normalRequest.Id}",
+                new { proposedPersonAzureUniqueId = null as Guid? }
+            );
+            response.Should().BeBadRequest();
+        }
         #endregion
 
         #region Create request tests


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Allow unsetting proposed person when request is not sent for task owner approval.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

