### PR TITLE
Department search: return items from line org when department not tracked in db

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDepartments.cs
@@ -127,7 +127,7 @@ namespace Fusion.Resources.Domain
 
                     foreach (var resourceOwner in resourceOwners)
                     {
-                        if (!searchedDepartments.Contains(resourceOwner.DepartmentId)) continue;
+                        if (request.departmentIds is not null && !searchedDepartments.Contains(resourceOwner.DepartmentId)) continue;
                         // Department found in line org but is not tracked in db
                         if (!departments.ContainsKey(resourceOwner.DepartmentId))
                         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
@@ -140,6 +140,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var resp = await Client.TestClientGetAsync<TestDepartment>("/departments/TPD LIN ORG TST?api-version=1.0-preview");
 
             resp.Response.StatusCode.Should().Be(HttpStatusCode.OK);
+            resp.Value.Name.Should().Be("TPD LIN ORG TST");
         }
 
         [Fact]
@@ -167,9 +168,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             using var adminScope = fixture.AdminScope();
 
-            var resp = await Client.TestClientGetAsync<TestDepartment>($"/departments?$search={fakeResourceOwner.Name}&api-version=1.0-preview");
+            var resp = await Client.TestClientGetAsync<List<TestDepartment>>($"/departments?$search={fakeResourceOwner.Name}&api-version=1.0-preview");
 
             resp.Response.StatusCode.Should().Be(HttpStatusCode.OK);
+            resp.Value.Should().Contain(x => x.Name == "TPD LIN ORG TST");
         }
 
         [Fact]

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
@@ -143,6 +143,36 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task SearchShouldGetDepartmentNotInDbWhenInLineOrg()
+        {
+            var fakeResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            var lineorgData = new
+            {
+                Count = 1,
+                TotalCount = 1,
+                Value = new[]
+                {
+                    new
+                    {
+                        fakeResourceOwner.AzureUniqueId,
+                        fakeResourceOwner.Name,
+                        fakeResourceOwner.Mail,
+                        IsResourceOwner = true,
+                        FullDepartment = "TPD LIN ORG TST"
+                    }
+                }
+            };
+
+            fixture.LineOrg.WithResponse("/lineorg/persons", lineorgData);
+
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await Client.TestClientGetAsync<TestDepartment>($"/departments?$search={fakeResourceOwner.Name}&api-version=1.0-preview");
+
+            resp.Response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
         public async Task ShouldAllowAdminToAddDepartmentResponsible()
         {
             var testDepartment = "TPD LIN ORG TST";


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Correctly check if search is limited to specific departments before filtering results from line org.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

