### PR TITLE
Pipeline - Disabled production k8s deploy

### DIFF
--- a/pipelines/api-pipeline.yml
+++ b/pipelines/api-pipeline.yml
@@ -218,12 +218,16 @@ stages:
                 parameters:
                   artifact: 'k8s-deployment'
                   environment: $(envName)
-    
-              - task: KubernetesManifest@0
-                displayName: Deploy to Kubernetes cluster
-                inputs:
-                  action: deploy
-                  manifests: $(deploymentManifest)
+
+              ##
+              ## Disable this until production cluster is at correct version to handle proper ingres version.
+              ##
+                  
+              # - task: KubernetesManifest@0
+              #   displayName: Deploy to Kubernetes cluster
+              #   inputs:
+              #     action: deploy
+              #     manifests: $(deploymentManifest)
 
               - template: templates/deploy-container-app.yml
                 parameters:


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
After update to latest kubernetes version the ingres version had to be updated to latest non-beta version. This has only been done on the test cluster, not the production cluster. 
This makes the deploy to production cluster step fail. As this is only a pilot and not used by production, this should be disabled untill the production cluster has been recreated.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [ ] ~~Performed developer testing~~
- [x] Checklist finalized / ready for review

