### PR TITLE
Require unit for responsibility matrix

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/ResponsibilityMatrix/Requests/UpdateResponsibilityMatrixRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/ResponsibilityMatrix/Requests/UpdateResponsibilityMatrixRequest.cs
@@ -11,8 +11,7 @@ namespace Fusion.Resources.Api.Controllers
         public string? Discipline { get; set; }
         public Guid? BasePositionId { get; set; } 
         public string? Sector { get; set; }
-        public string? Unit { get; set; }
-        public Guid? ResponsibleId { get; set; }
+        public string Unit { get; set; } = null!;
 
 
 
@@ -24,7 +23,6 @@ namespace Fusion.Resources.Api.Controllers
             command.BasePositionId = BasePositionId;
             command.Sector = Sector;
             command.Unit = Unit;
-            command.ResponsibleId = ResponsibleId;
         }
 
         public void LoadCommand(UpdateResponsibilityMatrix command)
@@ -35,7 +33,6 @@ namespace Fusion.Resources.Api.Controllers
             command.BasePositionId = BasePositionId;
             command.Sector = Sector;
             command.Unit = Unit;
-            command.ResponsibleId = ResponsibleId;
         }
 
         #region Validation
@@ -48,11 +45,11 @@ namespace Fusion.Resources.Api.Controllers
                 RuleFor(x => x.Discipline).MaximumLength(5000);
                 RuleFor(x => x.Sector).NotContainScriptTag();
                 RuleFor(x => x.Sector).MaximumLength(100);
-                RuleFor(x => x.Unit).NotContainScriptTag();
-                RuleFor(x => x.Unit).MaximumLength(100);
-
+                RuleFor(x => x.Unit)
+                    .NotEmpty()
+                    .MaximumLength(100)
+                    .NotContainScriptTag();
             }
-
         }
 
         #endregion

--- a/src/backend/api/Fusion.Resources.Domain/Commands/ResponsibilityMatrix/UpdateResponsibilityMatrix.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/ResponsibilityMatrix/UpdateResponsibilityMatrix.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fusion.Integration.Org;
 using Fusion.Resources.Database.Entities;
+using Fusion.Resources.Application.LineOrg;
 
 namespace Fusion.Resources.Domain.Commands
 {
@@ -30,13 +31,15 @@ namespace Fusion.Resources.Domain.Commands
             private readonly IMediator mediator;
             private readonly IProfileService profileService;
             private readonly IProjectOrgResolver orgResolver;
+            private readonly ILineOrgResolver lineOrgResolver;
 
-            public Handler(ResourcesDbContext resourcesDb, IMediator mediator, IProfileService profileService, IProjectOrgResolver orgResolver)
+            public Handler(ResourcesDbContext resourcesDb, IMediator mediator, IProfileService profileService, IProjectOrgResolver orgResolver, ILineOrgResolver lineOrgResolver)
             {
                 this.resourcesDb = resourcesDb;
                 this.mediator = mediator;
                 this.profileService = profileService;
                 this.orgResolver = orgResolver;
+                this.lineOrgResolver = lineOrgResolver;
             }
 
             public async Task<QueryResponsibilityMatrix> Handle(UpdateResponsibilityMatrix request, CancellationToken cancellationToken)
@@ -94,6 +97,8 @@ namespace Fusion.Resources.Domain.Commands
                 {
                     status.Unit = request.Unit.Value;
                     isModified = true;
+
+                    status.Responsible = await GetResourceOwner(request.Unit.Value!);
                 }
 
                 if (isModified)
@@ -106,6 +111,18 @@ namespace Fusion.Resources.Domain.Commands
                 var returnItem = await mediator.Send(new GetResponsibilityMatrixItem(request.Id));
                 return returnItem!;
             }
+
+            private async Task<DbPerson?> GetResourceOwner(string departmentId)
+            {
+                var department = await lineOrgResolver.GetDepartment(departmentId);
+                if(department?.Responsible?.AzureUniqueId is not null)
+                {
+                    var azureUniqueId = department.Responsible.AzureUniqueId.Value;
+                    return await profileService.EnsurePersonAsync(new PersonId(azureUniqueId));
+                }
+                return null;
+            }
+
             private async Task<DbProject?> EnsureProjectAsync(Guid projectId)
             {
                 var orgProject = await orgResolver.ResolveProjectAsync(projectId);

--- a/src/backend/api/Fusion.Resources.Domain/Commands/ResponsibilityMatrix/UpdateResponsibilityMatrix.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/ResponsibilityMatrix/UpdateResponsibilityMatrix.cs
@@ -23,7 +23,6 @@ namespace Fusion.Resources.Domain.Commands
         public MonitorableProperty<Guid?> BasePositionId { get; set; } = new MonitorableProperty<Guid?>();
         public MonitorableProperty<string?> Sector { get; set; } = new MonitorableProperty<string?>();
         public MonitorableProperty<string?> Unit { get; set; } = new MonitorableProperty<string?>();
-        public MonitorableProperty<Guid?> ResponsibleId { get; set; } = new MonitorableProperty<Guid?>();
 
         public class Handler : IRequestHandler<UpdateResponsibilityMatrix, QueryResponsibilityMatrix>
         {
@@ -65,24 +64,6 @@ namespace Fusion.Resources.Domain.Commands
                     else
                     {
                         status.Project = null;
-                    }
-
-                    isModified = true;
-                }
-
-                if (request.ResponsibleId.HasBeenSet)
-                {
-                    if (request.ResponsibleId.Value != null)
-                    {
-                        var responsible = await profileService.EnsurePersonAsync(request.ResponsibleId.Value.Value);
-                        if (responsible == null)
-                            throw new ArgumentException(
-                                "Cannot create personnel without either a valid azure unique id or mail address");
-                        status.Responsible = responsible;
-                    }
-                    else
-                    {
-                        status.Responsible = null;
                     }
 
                     isModified = true;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -274,7 +274,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 BasePositionId = testProject.Positions.First().BasePosition.Id,
                 Sector = "ABC",
                 Unit = department,
-                ResponsibleId = testUser.AzureUniqueId.GetValueOrDefault()
             };
 
             var matrixResponse = await Client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", matrixRequest);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
@@ -114,6 +114,24 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task PutMatrix_ShouldBeBadRequest_WhenUnitIsNull()
+        {
+            var request = new UpdateResponsibilityMatrixRequest
+            {
+                ProjectId = null,
+                LocationId = null,
+                Discipline = null,
+                BasePositionId = null,
+                Sector = null,
+                Unit = "",
+            };
+
+            using var authScope = fixture.AdminScope();
+            var response = await client.TestClientPutAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix/{testResponsibilityMatrixId}", request);
+            response.Should().BeBadRequest();
+        }
+
+        [Fact]
         public async Task PutMatrix_ShouldSetResponsible_WhenSettingDepartment()
         {
             const string department = "PDP PRD FE ANE ANE5";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
@@ -74,7 +74,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 BasePositionId = testProject.Positions.First().BasePosition.Id,
                 Sector = "ABC DEF",
                 Unit = "ABC DEF GHI",
-                ResponsibleId = testUser.AzureUniqueId.GetValueOrDefault()
             };
 
             using var authScope = fixture.AdminScope();
@@ -99,8 +98,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 Discipline = null,
                 BasePositionId = null,
                 Sector = null,
-                Unit = null,
-                ResponsibleId = null
+                Unit = "PDP PRD EAS",
             };
 
             using var authScope = fixture.AdminScope();
@@ -111,7 +109,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Value.Project.Should().BeNull();
             response.Value.Discipline.Should().BeNull();
             response.Value.Sector.Should().BeNull();
-            response.Value.Unit.Should().BeNull();
+            response.Value.Unit.Should().NotBeNull();
             response.Value.Responsible.Should().BeNull();
             response.Value.Updated.Should().NotBeNull();
         }
@@ -147,7 +145,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 BasePositionId = testProject.Positions.First().BasePosition.Id,
                 Sector = "ABC",
                 Unit = "ABC DEF",
-                ResponsibleId = testUser.AzureUniqueId.GetValueOrDefault()
             };
 
             var response = await client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", request);


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Require a unit set for responsibility matrix so that requests are actually routed somewhere.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

