### PR TITLE
fix k8s ingress cert renewal

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Deployment/k8s/deployment-test-env.yml
+++ b/src/backend/api/Fusion.Resources.Api/Deployment/k8s/deployment-test-env.yml
@@ -103,7 +103,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.org/client-max-body-size: "50m"

--- a/src/frontend/k8s/deployment.template.yml
+++ b/src/frontend/k8s/deployment.template.yml
@@ -77,7 +77,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.org/client-max-body-size: "50m"


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
Fix deprecated annotation for cert renewal.

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

