### PR TITLE
Fix validation of rolename/baseposition in task details

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -57,9 +57,9 @@ namespace Fusion.Resources.Api.Controllers
                     .WithMessage("Cannot set task details when type is not 'other tasks'.");
 
                 RuleFor(x => x.TaskDetails!.RoleName)
-                    .NotEmpty()
-                    .When(x => x.TaskDetails != null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && x.TaskDetails?.BasePositionId != null)
-                    .WithMessage("Either role name or base position must be set.");
+                   .NotEmpty()
+                   .When(x => x.TaskDetails is not null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
+                   .WithMessage("Either role name or base position must be set.");
             }
         }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
@@ -53,7 +53,7 @@ namespace Fusion.Resources.Api.Controllers
 
                 RuleFor(x => x.TaskDetails!.RoleName)
                     .NotEmpty()
-                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
+                    .When(x => x.TaskDetails is not null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
                     .WithMessage("Either role name or base position must be set.");
             }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -214,13 +214,15 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task AddTaskWithBasePosition_ShouldBeAllowed()
         {
-            var task = new CreatePersonAbsenceRequest {
+            var task = new CreatePersonAbsenceRequest
+            {
                 AbsencePercentage = 50,
-                AppliesFrom = new DateTime(2021,08,12),
-                AppliesTo = new DateTime(2021,09,03),
+                AppliesFrom = new DateTime(2021, 08, 12),
+                AppliesTo = new DateTime(2021, 09, 03),
                 Comment = "",
                 IsPrivate = false,
-                TaskDetails = new ApiTaskDetails {
+                TaskDetails = new ApiTaskDetails
+                {
                     BasePositionId = new Guid("b97703e6-cdc8-4a3f-a889-21a1d375422f"),
                     Location = "",
                     TaskName = "Test"
@@ -231,6 +233,38 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var authScope = fixture.AdminScope();
             var response = await client.TestClientPostAsync<TestAbsence>($"/persons/{testUser.AzureUniqueId}/absence/", task);
             response.Should().BeSuccessfull();
+        }
+
+        [Theory]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public async Task AddTaskWithoutBasePositionOrRoleName_ShouldNotBeAllowed(string method)
+        {
+            var task = new CreatePersonAbsenceRequest
+            {
+                AbsencePercentage = 50,
+                AppliesFrom = new DateTime(2021, 08, 12),
+                AppliesTo = new DateTime(2021, 09, 03),
+                Comment = "",
+                IsPrivate = false,
+                TaskDetails = new ApiTaskDetails
+                {
+                    Location = "",
+                    TaskName = "Test"
+                },
+                Type = ApiPersonAbsence.ApiAbsenceType.OtherTasks
+            };
+
+            using var authScope = fixture.AdminScope();
+            
+            var response = method switch
+            {
+                "POST" => await client.TestClientPostAsync<TestAbsence>($"/persons/{testUser.AzureUniqueId}/absence/", task),
+                "PUT" => await client.TestClientPutAsync<TestAbsence>($"/persons/{testUser.AzureUniqueId}/absence/{this.TestAbsenceId}", task),
+                _ => null
+            };
+
+            response.Should().BeBadRequest();
         }
 
         public async Task InitializeAsync()

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -211,6 +211,27 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeBadRequest();
         }
 
+        [Fact]
+        public async Task AddTaskWithBasePosition_ShouldBeAllowed()
+        {
+            var task = new CreatePersonAbsenceRequest {
+                AbsencePercentage = 50,
+                AppliesFrom = new DateTime(2021,08,12),
+                AppliesTo = new DateTime(2021,09,03),
+                Comment = "",
+                IsPrivate = false,
+                TaskDetails = new ApiTaskDetails {
+                    BasePositionId = new Guid("b97703e6-cdc8-4a3f-a889-21a1d375422f"),
+                    Location = "",
+                    TaskName = "Test"
+                },
+                Type = ApiPersonAbsence.ApiAbsenceType.OtherTasks
+            };
+
+            using var authScope = fixture.AdminScope();
+            var response = await client.TestClientPostAsync<TestAbsence>($"/persons/{testUser.AzureUniqueId}/absence/", task);
+            response.Should().BeSuccessfull();
+        }
 
         public async Task InitializeAsync()
         {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Fix validation so that either base position id or role name is required for task details.

[AB#21184](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/21184)


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

