### PR TITLE
Hide past allocations in timeline

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -93,8 +93,9 @@ namespace Fusion.Resources.Api.Controllers
             #endregion
 
             var command = new GetDepartmentPersonnel(fullDepartmentString, query)
+                .IncludeSubdepartments(includeSubdepartments)
+                .WithPastAllocationsHidden()
                 .WithTimeline(shouldExpandTimeline, timelineStart, timelineEnd);
-            command.IncludeSubdepartments(includeSubdepartments);
 
             var department = await DispatchAsync(command);
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -94,7 +94,6 @@ namespace Fusion.Resources.Api.Controllers
 
             var command = new GetDepartmentPersonnel(fullDepartmentString, query)
                 .IncludeSubdepartments(includeSubdepartments)
-                .WithPastAllocationsHidden()
                 .WithTimeline(shouldExpandTimeline, timelineStart, timelineEnd);
 
             var department = await DispatchAsync(command);

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -26,7 +26,6 @@ namespace Fusion.Resources.Domain
         private bool includeSubdepartments = false;
         public bool ExpandTimeline { get; set; }
         public string Department { get; set; }
-        public bool HidePastAllocations { get; set; } = false;
         public ODataQueryParams? QueryParams { get; }
 
         public DateTime? TimelineStart { get; set; }
@@ -39,12 +38,6 @@ namespace Fusion.Resources.Domain
             TimelineStart = start;
             TimelineEnd = end;
 
-            return this;
-        }
-
-        public GetDepartmentPersonnel WithPastAllocationsHidden(bool hidePastAllocations = true)
-        {
-            HidePastAllocations = hidePastAllocations;
             return this;
         }
 
@@ -86,18 +79,15 @@ namespace Fusion.Resources.Domain
 
                 departmentPersonnel.ForEach(p =>
                 {
-                    
+
                     p.Absence = departmentAbsence[p.AzureUniqueId];
 
                     if (request.ExpandTimeline)
                     {
-                        if (request.HidePastAllocations)
-                        {
-                            p.PositionInstances = p.PositionInstances
-                                .Where(instance => !(instance.AppliesTo < request.TimelineStart || instance.AppliesFrom > request.TimelineEnd))
-                                .ToList();
-                        }
-                            
+                        p.PositionInstances = p.PositionInstances
+                            .Where(instance => !(instance.AppliesTo < request.TimelineStart || instance.AppliesFrom > request.TimelineEnd))
+                            .ToList();
+
                         // Timeline date input has been verified when shouldExpandTimline is true.
                         p.Timeline = TimelineUtils.GeneratePersonnelTimeline(p.PositionInstances, p.Absence, request.TimelineStart!.Value, request.TimelineEnd!.Value).OrderBy(p => p.AppliesFrom)
                             //.Where(t => (t.AppliesTo - t.AppliesFrom).Days > 2) // We do not want 1 day intervals that occur due to from/to do not overlap

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -85,7 +85,7 @@ namespace Fusion.Resources.Domain
                     if (request.ExpandTimeline)
                     {
                         p.PositionInstances = p.PositionInstances
-                            .Where(instance => !(instance.AppliesTo < request.TimelineStart || instance.AppliesFrom > request.TimelineEnd))
+                            .Where(instance => instance.AppliesTo >= request.TimelineStart && instance.AppliesFrom <= request.TimelineEnd)
                             .ToList();
 
                         // Timeline date input has been verified when shouldExpandTimline is true.

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -23,9 +23,10 @@ namespace Fusion.Resources.Domain
             QueryParams = queryParams;
         }
 
-        private bool includeSubdepartments  = false;
+        private bool includeSubdepartments = false;
         public bool ExpandTimeline { get; set; }
         public string Department { get; set; }
+        public bool HidePastAllocations { get; set; } = false;
         public ODataQueryParams? QueryParams { get; }
 
         public DateTime? TimelineStart { get; set; }
@@ -38,6 +39,12 @@ namespace Fusion.Resources.Domain
             TimelineStart = start;
             TimelineEnd = end;
 
+            return this;
+        }
+
+        public GetDepartmentPersonnel WithPastAllocationsHidden(bool hidePastAllocations = true)
+        {
+            HidePastAllocations = hidePastAllocations;
             return this;
         }
 
@@ -79,10 +86,18 @@ namespace Fusion.Resources.Domain
 
                 departmentPersonnel.ForEach(p =>
                 {
+                    
                     p.Absence = departmentAbsence[p.AzureUniqueId];
 
                     if (request.ExpandTimeline)
                     {
+                        if (request.HidePastAllocations)
+                        {
+                            p.PositionInstances = p.PositionInstances
+                                .Where(instance => !(instance.AppliesTo < request.TimelineStart || instance.AppliesFrom > request.TimelineEnd))
+                                .ToList();
+                        }
+                            
                         // Timeline date input has been verified when shouldExpandTimline is true.
                         p.Timeline = TimelineUtils.GeneratePersonnelTimeline(p.PositionInstances, p.Absence, request.TimelineStart!.Value, request.TimelineEnd!.Value).OrderBy(p => p.AppliesFrom)
                             //.Where(t => (t.AppliesTo - t.AppliesFrom).Days > 2) // We do not want 1 day intervals that occur due to from/to do not overlap

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnelPerson.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnelPerson.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Fusion.ApiClients.Org;
+using System;
 
 namespace Fusion.Resources.Api.Tests
 {
@@ -14,9 +15,16 @@ namespace Fusion.Resources.Api.Tests
         public object fullDepartment { get; set; }
         public bool isResourceOwner { get; set; }
         public string accountType { get; set; }
-        public object[] disciplines { get; set; }
         public Employmentstatus[] employmentStatuses { get; set; }
         public TestTimeline[] timeline { get; set; }
+        public TestPersonPosition[] positionInstances { get; set; }
+    }
+
+    public class TestPersonPosition
+    {
+        public DateTime AppliesFrom { get; set; }
+        public DateTime AppliesTo { get; set; }
+
     }
 
     public class Employmentstatus
@@ -43,14 +51,14 @@ namespace Fusion.Resources.Api.Tests
         public DateTime appliesFrom { get; set; }
         public DateTime appliesTo { get; set; }
         public TestTimeLineItem[] items { get; set; }
-        public int workload { get; set; }
+        public double? workload { get; set; }
     }
 
     public class TestTimeLineItem
     {
         public string id { get; set; }
         public string type { get; set; }
-        public int workload { get; set; }
+        public double? workload { get; set; }
         public string description { get; set; }
         public string roleName { get; set; }
         public string taskName { get; set; }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -560,6 +560,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 $"/departments/{department}/resources/personnel/?$expand=timeline&{ApiVersion}&timelineStart={timelineStart:O}&timelineEnd={timelineEnd:O}"
             );
 
+            response.Should().BeSuccessfull();
             response.Value.value
                 .SelectMany(x => x.positionInstances)
                 .Any(x => x.AppliesTo < timelineStart || x.AppliesFrom > timelineEnd)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -10,13 +10,14 @@ using Fusion.Testing.Mocks.OrgService;
 using Fusion.Testing.Mocks.ProfileService;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-
+using static System.Linq.Enumerable;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
@@ -478,7 +479,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 $"/departments/{user.Department}/resources/personnel/?$expand=timeline&{ApiVersion}&timelineStart={timelineStart:O}&timelineEnd={timelineEnd:O}"
             );
 
-            var person = response.Value.Value
+            var person = response.Value.value
                 .FirstOrDefault(x => x.azureUniquePersonId == user.AzureUniqueId);
             person.employmentStatuses.Should().Contain(x => x.id == absence.Id);
 
@@ -521,7 +522,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                     $"/departments/{user.Department}/resources/personnel/?$expand=timeline&{ApiVersion}&timelineStart={timelineStart:O}&timelineEnd={timelineEnd:O}"
                 );
 
-                var person = response.Value.Value
+                var person = response.Value.value
                     .FirstOrDefault(x => x.azureUniquePersonId == user.AzureUniqueId);
                 var actualAbsence = person.employmentStatuses.FirstOrDefault(x => x.id == absence.Id);
 
@@ -537,6 +538,35 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             }
         }
 
+        [Fact]
+        public async Task GetTimelineShouldNotIncludePositionsOutsideTimeframe()
+        {
+            const string department = "PDP BTAD AWQ";
+            fixture.EnsureDepartment(department);
+
+            var project = new FusionTestProjectBuilder()
+                .WithPositions(10, 50)
+                .AddToMockService();
+
+            var profile = PeopleServiceMock.AddTestProfile().WithFullDepartment(department);
+            foreach(var position in project.Positions) profile.WithPosition(position);
+            profile.SaveProfile();
+
+            using var scope = fixture.AdminScope();
+            var timelineStart = new DateTime(2020, 03, 01);
+            var timelineEnd = new DateTime(2020, 03, 31);
+
+            var response = await Client.TestClientGetAsync<TestResponse>(
+                $"/departments/{department}/resources/personnel/?$expand=timeline&{ApiVersion}&timelineStart={timelineStart:O}&timelineEnd={timelineEnd:O}"
+            );
+
+            response.Value.value
+                .SelectMany(x => x.positionInstances)
+                .Any(x => x.AppliesTo < timelineStart || x.AppliesFrom > timelineEnd)
+                .Should()
+                .BeFalse();
+        }
+
         public Task DisposeAsync()
         {
             loggingScope.Dispose();
@@ -546,7 +576,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         class TestResponse
         {
-            public List<TestApiPersonnelPerson> Value { get; set; }
+            public List<TestApiPersonnelPerson> value { get; set; }
         }
 
 

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
@@ -94,7 +94,6 @@ namespace Fusion.Testing.Mocks.ProfileService.Api
 
                     doc["ManagerAzureId"] = PeopleServiceMock.profiles.FirstOrDefault(m => m.IsResourceOwner && m.FullDepartment == profile.FullDepartment)?.AzureUniqueId;
                     doc["IsExpired"] = false;
-                    doc["Positions"] = new List<ApiPersonPositionV3>();
 
                     return new
                     {

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="33.0.2" />
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="5.3.0" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.5" />

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -1,10 +1,12 @@
-﻿using Fusion.Integration.Profile;
+﻿using Fusion.ApiClients.Org;
+using Fusion.Integration.Profile;
 using Fusion.Integration.Profile.ApiClient;
 using Fusion.Testing.Mocks.ProfileService.Api;
 using Microsoft.AspNetCore.Mvc.Testing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 
 namespace Fusion.Testing.Mocks.ProfileService
@@ -37,6 +39,7 @@ namespace Fusion.Testing.Mocks.ProfileService
         public FusionTestUserBuilder()
         {
             profile = FusionTestProfiles.CreateTestUser();
+            profile.Positions = new List<ApiPersonPositionV3>();
         }
 
         public FusionTestUserBuilder(FusionAccountType type, AccountClassification? classification = null)
@@ -61,6 +64,42 @@ namespace Fusion.Testing.Mocks.ProfileService
             profile.Department = department;
             return this;
         }
+
+        public FusionTestUserBuilder WithPosition(ApiPositionV2 position)
+        {
+            var instance = position.Instances.FirstOrDefault();
+
+            profile.Positions.Add(new ApiPersonPositionV3
+            {
+                AppliesFrom = instance.AppliesFrom,
+                AppliesTo = instance.AppliesTo,
+                ParentPositionId = position.Id,
+                PositionExternalId = position.ExternalId,
+                BasePosition = new ApiPersonBasePositionV3
+                {
+                    Id = position.BasePosition.Id,
+                    Name = position.BasePosition.Name,
+                    Discipline = position.BasePosition.Discipline,
+                    SubDiscipline = position.BasePosition.SubDiscipline,
+                    Type = position.BasePosition.ProjectType
+                },
+                Project = new ApiPersonPositionProjectV3
+                {
+                    DomainId = position.Project.DomainId,
+                    Id = position.Project.ProjectId,
+                    Name = position.Project.Name,
+                    Type = position.Project.Name,
+                },
+                Workload = instance.Workload,
+                Obs = instance.Obs,
+                Name = position.Name,
+                Id = instance.Id,
+                PositionId = position.Id
+            });
+
+            return this;
+        }
+
         public FusionTestUserBuilder WithRoles(string name)
         {
             if (profile.Roles == null) profile.Roles = new List<ApiPersonRoleV3>();


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Avoid loading positions that are outside the timeline range. The current functionality wastes a lot of bandwith.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

