### PR TITLE
External & Internal Requests - AppliesTo & AppliesFrom should be provided UTC-kind

### DIFF
--- a/src/backend/api/Fusion.Resources.Database/Entities/DbContractorRequest.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbContractorRequest.cs
@@ -56,6 +56,11 @@ namespace Fusion.Resources.Database.Entities
                 entity.OwnsOne(e => e.Position, op =>
                 {
                     op.OwnsOne(p => p.TaskOwner);
+                    op.Property(ps => ps.AppliesFrom)
+                        .HasConversion(x => x, dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+                    op.Property(ps => ps.AppliesTo)
+                        .HasConversion(x => x, dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+
                 });
 
                 entity.Property(e => e.State).HasConversion(new EnumToStringConverter<DbRequestState>());

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbResourceAllocationRequest.cs
@@ -89,7 +89,13 @@ namespace Fusion.Resources.Database.Entities
                 {
                     op.Property(ps => ps.State).HasConversion(new EnumToStringConverter<DbProvisionState>());
                 });
-                entity.OwnsOne(e => e.OrgPositionInstance);
+                entity.OwnsOne(e => e.OrgPositionInstance, op=>
+                {
+                    op.Property(ps => ps.AppliesFrom)
+                        .HasConversion(x => x, dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+                    op.Property(ps => ps.AppliesTo)
+                        .HasConversion(x => x, dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+                });
                 entity.OwnsOne(e => e.ProposedPerson);
                 entity.OwnsOne(e => e.State);
                 entity.OwnsOne(e => e.ProposalParameters, op => 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
DB columns AppliesFrom and AppliesTo didn't have utc kind specified.
This is causing incorrect output for the UI, since they don't get the Z suffix in the API model.

Now spefifying kind (DateTime.SpecifyKind(dt, DateTimeKind.Utc)) to requests.
Added both to external and internal requests (External Personnel, Personnel Allocation



**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

