### PR TITLE
Do not return CEO's department as relevant when baseposition department is empty string

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/AddDelegatedResourceOwnerRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/AddDelegatedResourceOwnerRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Fusion.Resources.Api.Controllers.Departments
+namespace Fusion.Resources.Api.Controllers
 {
     public class AddDelegatedResourceOwnerRequest
     {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/AddDepartmentRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/AddDepartmentRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Fusion.Resources.Api.Controllers.Departments
+namespace Fusion.Resources.Api.Controllers
 {
     public class AddDepartmentRequest
     {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiDepartment.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiDepartment.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Fusion.Resources.Api.Controllers.Departments
+namespace Fusion.Resources.Api.Controllers
 {
     public class ApiDepartment
     {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
@@ -9,14 +9,11 @@ namespace Fusion.Resources.Api.Controllers
     {
         public ApiRelatedDepartments(QueryRelatedDepartments relevantDepartments)
         {
-            Children = relevantDepartments.Children is not null 
-                ? relevantDepartments.Children.Select(x => new ApiDepartment(x)).ToList()
-                : new List<ApiDepartment>();
-            Siblings = relevantDepartments.Siblings is not null
-                ? relevantDepartments.Siblings.Select(x => new ApiDepartment(x)).ToList()
-                : new List<ApiDepartment>();
+            Children = relevantDepartments.Children.Select(x => new ApiDepartment(x)).ToList();
+            Siblings = relevantDepartments.Siblings.Select(x => new ApiDepartment(x)).ToList();
         }
-        public List<ApiDepartment> Children { get; set; }
-        public List<ApiDepartment> Siblings { get; set; }
+
+        public List<ApiDepartment> Children { get; }
+        public List<ApiDepartment> Siblings { get; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
@@ -1,5 +1,4 @@
-﻿using Fusion.Resources.Api.Controllers.Departments;
-using Fusion.Resources.Domain;
+﻿using Fusion.Resources.Domain;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelatedDepartments.cs
@@ -1,0 +1,22 @@
+﻿using Fusion.Resources.Api.Controllers.Departments;
+using Fusion.Resources.Domain;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiRelatedDepartments
+    {
+        public ApiRelatedDepartments(QueryRelatedDepartments relevantDepartments)
+        {
+            Children = relevantDepartments.Children is not null 
+                ? relevantDepartments.Children.Select(x => new ApiDepartment(x)).ToList()
+                : new List<ApiDepartment>();
+            Siblings = relevantDepartments.Siblings is not null
+                ? relevantDepartments.Siblings.Select(x => new ApiDepartment(x)).ToList()
+                : new List<ApiDepartment>();
+        }
+        public List<ApiDepartment> Children { get; set; }
+        public List<ApiDepartment> Siblings { get; set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelevantDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelevantDepartments.cs
@@ -1,22 +1,10 @@
-﻿using Fusion.Resources.Api.Controllers.Departments;
-using Fusion.Resources.Domain;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
-namespace Fusion.Resources.Api.Controllers
+namespace Fusion.Resources.Api.Controllers.Departments
 {
     public class ApiRelevantDepartments
     {
-        public ApiRelevantDepartments(QueryRelevantDepartments relevantDepartments)
-        {
-            Children = relevantDepartments.Children is not null 
-                ? relevantDepartments.Children.Select(x => new ApiDepartment(x)).ToList()
-                : new List<ApiDepartment>();
-            Siblings = relevantDepartments.Siblings is not null
-                ? relevantDepartments.Siblings.Select(x => new ApiDepartment(x)).ToList()
-                : new List<ApiDepartment>();
-        }
-        public List<ApiDepartment> Children { get; set; }
-        public List<ApiDepartment> Siblings { get; set; }
+        public ApiDepartment? Department { get; set; }
+        public List<ApiDepartment> Relevant { get; set; } = new();
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelevantDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiRelevantDepartments.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Fusion.Resources.Api.Controllers.Departments
+namespace Fusion.Resources.Api.Controllers
 {
     public class ApiRelevantDepartments
     {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/UpdateDepartmentRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/UpdateDepartmentRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Fusion.Resources.Api.Controllers.Departments
+﻿namespace Fusion.Resources.Api.Controllers
 {
     public class UpdateDepartmentRequest
     {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
@@ -1,7 +1,5 @@
 ﻿using Fusion.AspNetCore.FluentAuthorization;
-using Fusion.Resources.Database;
 using Fusion.Resources.Domain;
-using Fusion.Resources.Domain.Commands;
 using Fusion.Resources.Domain.Commands.Departments;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Fusion.Resources.Api.Controllers.Departments
+namespace Fusion.Resources.Api.Controllers
 {
     [ApiVersion("1.0-preview")]
     [Authorize]

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -1,5 +1,4 @@
 ﻿using Fusion.ApiClients.Org;
-using Fusion.Resources.Api.Controllers.Departments;
 using Fusion.Resources.Domain;
 using System;
 using System.Collections.Generic;

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Departments/GetRelatedDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Departments/GetRelatedDepartments.cs
@@ -1,28 +1,24 @@
 ﻿using Fusion.Resources.Application.LineOrg;
 using MediatR;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fusion.Resources.Domain
 {
-    public class GetRelevantDepartments : IRequest<QueryRelevantDepartments?>
+    public class GetRelatedDepartments : IRequest<QueryRelatedDepartments?>
     {
-        public GetRelevantDepartments(string department)
+        public GetRelatedDepartments(string department)
         {
             Department = department;
         }
 
         public string Department { get; }
 
-        public class Handler : IRequestHandler<GetRelevantDepartments, QueryRelevantDepartments?>
+        public class Handler : IRequestHandler<GetRelatedDepartments, QueryRelatedDepartments?>
         {
             private readonly ILogger<Handler> logger;
             private readonly IMediator mediator;
@@ -35,11 +31,11 @@ namespace Fusion.Resources.Domain
                 this.lineOrgResolver = lineOrgResolver;
             }
 
-            public async Task<QueryRelevantDepartments?> Handle(GetRelevantDepartments request, CancellationToken cancellationToken)
+            public async Task<QueryRelatedDepartments?> Handle(GetRelatedDepartments request, CancellationToken cancellationToken)
                 => await TryGetRelevantDepartmentsAsync(request.Department);
 
 
-            private async Task<QueryRelevantDepartments?> TryGetRelevantDepartmentsAsync(string? fullDepartment)
+            private async Task<QueryRelatedDepartments?> TryGetRelevantDepartmentsAsync(string? fullDepartment)
             {
                 if (fullDepartment is null)
                     return null;
@@ -57,9 +53,9 @@ namespace Fusion.Resources.Domain
                 }
             }
 
-            private async Task<QueryRelevantDepartments?> ResolveRelevantDepartmentsAsync(string fullDepartmentPath)
+            private async Task<QueryRelatedDepartments?> ResolveRelevantDepartmentsAsync(string fullDepartmentPath)
             {
-                var relevantDepartments = new QueryRelevantDepartments();
+                var relevantDepartments = new QueryRelatedDepartments();
 
                 var children = await lineOrgResolver.GetChildren(fullDepartmentPath);
                 if (children is null) return null;

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryRelatedDepartments.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryRelatedDepartments.cs
@@ -2,7 +2,7 @@
 
 namespace Fusion.Resources.Domain
 {
-    public class QueryRelevantDepartments
+    public class QueryRelatedDepartments
     {
         public List<QueryDepartment> Children { get; set; } = new List<QueryDepartment>();
         public List<QueryDepartment> Siblings { get; set; } = new List<QueryDepartment>();

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -73,7 +73,7 @@ namespace Fusion.Resources.Domain.Queries
                 // Resolve info from line org, will be cached.. If integration fails null is returned.
                 
 
-                var lineOrgDepartmentProfile = await mediator.Send(new GetRelevantDepartments(user.FullDepartment), cancellationToken);
+                var lineOrgDepartmentProfile = await mediator.Send(new GetRelatedDepartments(user.FullDepartment), cancellationToken);
 
 
                 var resourceOwnerProfile = new QueryResourceOwnerProfile(user.FullDepartment, isDepartmentManager, departmentsWithResponsibility, relevantSectors)


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Ignore CEO's department when getting relevant department. [AB#21348](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/21348)


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

