### PR TITLE
Fix relevant position scored too high in routing

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Services/RequestRouter.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/RequestRouter.cs
@@ -108,8 +108,7 @@ namespace Fusion.Resources.Domain
                 .Include(m => m.Project)
                 .Select(m => new ResponsibilityMatch
                 {
-                    Score = (props.BasePositionDepartment != null && m.Unit!.StartsWith(props.BasePositionDepartment) ? 7 : 0)
-                            + (m.Project!.OrgProjectId == props.OrgProjectId ? 5 : 0)
+                    Score = (m.Project!.OrgProjectId == props.OrgProjectId ? 5 : 0)
                             + (m.BasePositionId == props.BasePositionId ? 5 : 0)
                             + (m.Discipline == props.Discipline ? 2 : 0)
                             + (m.LocationId == props.LocationId ? 1 : 0),

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsController.cs
@@ -293,6 +293,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
             await Client.AddResponsibilityMatrixAsync(project, x => {
                 x.BasePositionId = pos.BasePosition.Id;
+                x.Discipline = null;
+                x.LocationId = null;
                 x.Unit = "PDP TST ABC QWE";
             });
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -293,11 +293,14 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             
             using var adminScope = fixture.AdminScope();
 
+            var position = testProject.AddPosition()
+               .WithEnsuredFutureInstances();
+            position.BasePosition = testProject.AddBasePosition("ABC Rescue Manager", x => x.Department = "ABC");
+
             var matrixRequest = new UpdateResponsibilityMatrixRequest
             {
                 ProjectId = testProject.Project.ProjectId,
-                Discipline = normalRequest.Discipline,
-                BasePositionId = testProject.Positions.First().BasePosition.Id,
+                BasePositionId = position.BasePosition.Id,
                 Sector = "ABC",
                 Unit = department,
             };
@@ -307,10 +310,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             using var scope = fixture.AdminScope();
             var adminClient = fixture.ApiFactory.CreateClient();
-
-            var position = testProject.AddPosition()
-                .WithEnsuredFutureInstances();
-            position.BasePosition = testProject.AddBasePosition("ABC Rescue Manager", x => x.Department = "ABC");
 
             var request = await adminClient.CreateDefaultRequestAsync(testProject, r => r.AsTypeNormal().WithPosition(position));
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Remove code that gave relevant positions a higher score leading to incorrect results now that only relevant positions should be considered.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

