### PR TITLE
Avoid internal server error when missing department

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -62,17 +62,10 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion
 
-            try
-            {
-                var resourceOwnerProfile = await DispatchAsync(new GetResourceOwnerProfile(personId));
+            var resourceOwnerProfile = await DispatchAsync(new GetResourceOwnerProfile(personId));
+            if (resourceOwnerProfile is null) return ApiErrors.NotFound($"No profile found for user {personId}.");
 
-                var respObject = new ApiResourceOwnerProfile(resourceOwnerProfile);
-                return respObject;
-            }
-            catch (NotAuthorizedException ex)
-            {
-                return FusionApiError.Forbidden(ex.Message);
-            }
+            return new ApiResourceOwnerProfile(resourceOwnerProfile);
         }
 
         [HttpGet("/persons/{personId}/resources/notes")]

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Fusion.Authorization;
 using Fusion.Resources.Domain;
+using Fusion.Resources.Domain.Errors;
 
 namespace Fusion.Resources.Api.Controllers
 {
@@ -61,10 +62,17 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion
 
-            var resourceOwnerProfile = await DispatchAsync(new GetResourceOwnerProfile(personId));
+            try
+            {
+                var resourceOwnerProfile = await DispatchAsync(new GetResourceOwnerProfile(personId));
 
-            var respObject = new ApiResourceOwnerProfile(resourceOwnerProfile);
-            return respObject;
+                var respObject = new ApiResourceOwnerProfile(resourceOwnerProfile);
+                return respObject;
+            }
+            catch (NotAuthorizedException ex)
+            {
+                return FusionApiError.Forbidden(ex.Message);
+            }
         }
 
         [HttpGet("/persons/{personId}/resources/notes")]

--- a/src/backend/api/Fusion.Resources.Domain/Errors/NotAuthorizedException.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Errors/NotAuthorizedException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Fusion.Resources.Domain.Errors
+{
+
+    [Serializable]
+    public class NotAuthorizedException : Exception
+    {
+        public NotAuthorizedException() { }
+        public NotAuthorizedException(string message) : base(message) { }
+        public NotAuthorizedException(string message, Exception inner) : base(message, inner) { }
+        protected NotAuthorizedException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -1,9 +1,8 @@
 ﻿using Fusion.Integration;
 using Fusion.Integration.Profile;
+using Fusion.Resources.Domain.Errors;
 using MediatR;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,9 +49,9 @@ namespace Fusion.Resources.Domain.Queries
                 var user = await profileResolver.ResolvePersonBasicProfileAsync(request.ProfileId.OriginalIdentifier);
 
                 if (user is null)
-                    throw new InvalidOperationException($"Could not resolve profile '{request.ProfileId.OriginalIdentifier}'");
+                    throw new PersonNotFoundError(request.ProfileId.OriginalIdentifier);
                 if (user.FullDepartment is null) 
-                    throw new Exception();
+                    throw new NotAuthorizedException("No department found for the current user.");
 
                 var sector = await ResolveSector(user.FullDepartment);
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -43,15 +43,11 @@ namespace Fusion.Resources.Domain.Queries
 
             }
 
-            public async Task<QueryResourceOwnerProfile> Handle(GetResourceOwnerProfile request, CancellationToken cancellationToken)
+            public async Task<QueryResourceOwnerProfile?> Handle(GetResourceOwnerProfile request, CancellationToken cancellationToken)
             {
-                
                 var user = await profileResolver.ResolvePersonBasicProfileAsync(request.ProfileId.OriginalIdentifier);
 
-                if (user is null)
-                    throw new PersonNotFoundError(request.ProfileId.OriginalIdentifier);
-                if (user.FullDepartment is null) 
-                    throw new NotAuthorizedException("No department found for the current user.");
+                if (user is null) return null;
 
                 var sector = await ResolveSector(user.FullDepartment);
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -77,6 +77,22 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             }
         }
 
+        [Fact]
+        public async Task GetProfile_ShouldBeUnauthorized_WhenUserHasNoDepartment()
+        {
+            using (var userScope = fixture.UserScope(testUser))
+            {
+                testUser.FullDepartment = null;
+                var client = fixture.ApiFactory.CreateClient();
+                var resp = await client.TestClientGetAsync(
+                    $"/persons/me/resources/profile?api-version=1.0-preview",
+                    new { responsibilityInDepartments = Array.Empty<string>() }
+                );
+
+                resp.Should().BeUnauthorized();
+            }
+        }
+
 
 
         public Task InitializeAsync() => Task.CompletedTask;


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Return empty resource owner profile when user has no department, i.e. user is an affiliate account. 
Return 404 when user does not exist at all.

[AB#22337](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/22337)


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

