### PR TITLE
Now possible to sort internal requests using the orderby Odata query …

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -185,19 +185,15 @@ namespace Fusion.Resources.Domain.Queries
 
                 if (HasOrderByClause(request))
                 {
-                    // er en liste - skal man kunne sortere på mer enn ett felt?
                     var oDataOrderByOption = request.Query.OrderBy.First();
 
                     var sortKey = oDataOrderByOption.Field;
                     var sortDirection = oDataOrderByOption.Direction;
 
-                    //check if valid field?
-                    // boxing of value-types to match the return-type of the expression
-                    var param = Expression.Parameter(typeof(DbResourceAllocationRequest), nameof(DbResourceAllocationRequest));
-                    //var orderExpression = Expression.Lambda<Func<DbResourceAllocationRequest, object>>(Expression.Property(param, field), param);
-
-                    var body = Expression.Convert(Expression.Property(param, sortKey), typeof(object));
-                    var sortExpression = Expression.Lambda<Func<DbResourceAllocationRequest, object>>(body, param);
+                    // konvertere strengverdi i query option til property på entitet
+                    var parameterExpression = Expression.Parameter(typeof(DbResourceAllocationRequest), nameof(DbResourceAllocationRequest));
+                    var convertedExpression = Expression.Convert(Expression.Property(parameterExpression, sortKey), typeof(object));
+                    var sortExpression = Expression.Lambda<Func<DbResourceAllocationRequest, object>>(convertedExpression, parameterExpression);
 
                     query = sortDirection.Equals(SortDirection.asc)
                         ? query.OrderBy(sortExpression)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -482,6 +482,34 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             result.Value.value.First(x => x.id == requestB.Id).actions[0].id.Should().Be(taskB.id);
         }
 
+        [Fact]
+        public async Task GetRequests_OrderedByLastActivity_ShouldBeDescending()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var position = testProject.AddPosition();
+            await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, position);
+            var ordered = await Client.TestClientGetAsync<ApiCollection<TestApiInternalRequestModel>>($"/projects/{projectId}/resources/requests?$orderby=lastactivity%20desc");
+            ordered.Should().BeSuccessfull();
+            var dateTimeOffset = ordered.Value.Value.First().LastActivity.GetValueOrDefault();
+            var dateTimeOffset2 = ordered.Value.Value.Last().LastActivity.GetValueOrDefault();
+            dateTimeOffset.Should().BeAfter(dateTimeOffset2);
+        }
+        
+        [Fact]
+        public async Task GetRequests_OrderedByLastActivity_ShouldBeAscending()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var position = testProject.AddPosition();
+            await Client.CreateAndStartDefaultRequestOnPositionAsync(testProject, position);
+            var ordered = await Client.TestClientGetAsync<ApiCollection<TestApiInternalRequestModel>>($"/projects/{projectId}/resources/requests?$orderby=lastactivity");
+            ordered.Should().BeSuccessfull();
+            var dateTimeOffset = ordered.Value.Value.First().LastActivity.GetValueOrDefault();
+            var dateTimeOffset2 = ordered.Value.Value.Last().LastActivity.GetValueOrDefault();
+            dateTimeOffset.Should().BeBefore(dateTimeOffset2);
+        }
+
         //[Fact]
         //public async Task UnassignedRequests_ShouldReturnRequestsWithoutDepartment()
         //{


### PR DESCRIPTION
…option. E.g., $orderby=lastactivity. WIP