### PR TITLE
External Personnel - Not possible to add external contract responsible 

### DIFF
--- a/src/frontend/src/models/createPositionRequest.ts
+++ b/src/frontend/src/models/createPositionRequest.ts
@@ -1,9 +1,9 @@
 import { BasePosition } from '@equinor/fusion';
 
 export type AssignedPerson = {
-    azureUniqueId: string | null;
+    azureUniquePersonId: string | null;
     mail: string | null;
-}
+};
 
 type CreatePositionRequest = {
     basePosition: BasePosition | null;

--- a/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ContractDetailsPage/index.tsx
+++ b/src/frontend/src/pages/ProjectPage/pages/ContractPage/pages/ContractDetailsPage/index.tsx
@@ -1,4 +1,3 @@
-
 import { useContractContext } from '../../../../../../contractContex';
 import styles from './styles.less';
 import {
@@ -74,22 +73,28 @@ const DelegateAdminTitle = () => (
 );
 
 const renderPosition = (position: Position | null) => {
-    if (!position) {
-        return 'N/A';
-    }
+    if (!position) return 'N/A';
+
     const filterToDate = useMemo(() => new Date(), []);
-    const instance = useMemo(() => getInstances(position, filterToDate)[0], [
-        position,
-        filterToDate,
-    ]);
-    const isFuture = useMemo(() => isInstanceFuture(instance, filterToDate), [
-        position,
-        filterToDate,
-    ]);
-    const isPast = useMemo(() => isInstancePast(instance, filterToDate), [
-        position,
-        filterToDate,
-    ]);
+    const instance = useMemo(
+        () => getInstances(position, filterToDate)[0],
+        [position, filterToDate]
+    );
+    const isFuture = useMemo(
+        () => isInstanceFuture(instance, filterToDate),
+        [position, filterToDate]
+    );
+    const isPast = useMemo(() => isInstancePast(instance, filterToDate), [position, filterToDate]);
+
+    /**
+     * showTimeline throws an error "No Range" if it calculates the positions length to be 0 or below.
+     * Crashing the entire app.
+     */
+    const hasTimeline = useMemo(
+        () => instance.appliesTo.getTime() - instance.appliesFrom.getTime() > 0,
+        [instance]
+    );
+
     return (
         <PositionCard
             position={position}
@@ -98,7 +103,7 @@ const renderPosition = (position: Position | null) => {
             showExternalId
             showLocation
             showObs
-            showTimeline
+            showTimeline={hasTimeline}
             showRotation
             isFuture={isFuture}
             isPast={isPast}


### PR DESCRIPTION
CreatePositions assignedPerson model was using wrong ID field.
Was azureUniqueId, changed to azureUniquePersonId.
Changes in ExternalPositionSideSheet reflect this change.

renderPosition now checks if instance.appliesTo minus instance.appliesFrom is a positive number.
When fixed previous bug i added a position with start and end date on the same day.
This caused the PositionCard to throw an error and the entire app went into an error state on load.

Bug : https://statoil-proview.visualstudio.com/Fusion/_backlogs/backlog/Fusion%20Team/Epics/?showParents=true&workitem=22929****