### PR TITLE
Infra - Fix incorrect db connection string in pr environments

### DIFF
--- a/pipelines/environment-pipeline.yml
+++ b/pipelines/environment-pipeline.yml
@@ -46,6 +46,20 @@ stages:
               environment: $(environmentName)
               clientId: 5a842df8-3238-415d-b168-9f16a6a6031b
               sqlServer: fusion-test-sqlserver
+              
+          ## To get the pr slots to talk to the correct databases, we need to kill the key vault secret for connection string.
+          ## The secret would override the direct env property used to target the correct db.
+          - task: AzurePowerShell@5
+            displayName: 'Remove db connection string secret'
+            inputs:
+              azureSubscription: 'PROJECT_PORTAL (63b791ae-b2bc-41a1-ac66-806c4e69bffe)'
+              ScriptType: InlineScript
+              FailOnStandardError: true
+              azurePowerShellVersion: 'LatestVersion'
+              Inline: |
+                Write-Host "Deleting secret @ kv-fap-resources-pr/ConnectionStrings--ResourcesDbContext"
+                Remove-AzKeyVaultSecret -VaultName kv-fap-resources-pr -Name ConnectionStrings--ResourcesDbContext
+
 
 - stage: DeployQA
   displayName: QA Azure Infra

--- a/pipelines/environment-pipeline.yml
+++ b/pipelines/environment-pipeline.yml
@@ -46,7 +46,7 @@ stages:
               environment: $(environmentName)
               clientId: 5a842df8-3238-415d-b168-9f16a6a6031b
               sqlServer: fusion-test-sqlserver
-              
+
           ## To get the pr slots to talk to the correct databases, we need to kill the key vault secret for connection string.
           ## The secret would override the direct env property used to target the correct db.
           - task: AzurePowerShell@5
@@ -58,7 +58,7 @@ stages:
               azurePowerShellVersion: 'LatestVersion'
               Inline: |
                 Write-Host "Deleting secret @ kv-fap-resources-pr/ConnectionStrings--ResourcesDbContext"
-                Remove-AzKeyVaultSecret -VaultName kv-fap-resources-pr -Name ConnectionStrings--ResourcesDbContext
+                Remove-AzKeyVaultSecret -VaultName kv-fap-resources-pr -Name ConnectionStrings--ResourcesDbContext -Force
 
 
 - stage: DeployQA

--- a/src/backend/infrastructure/deploy-resources.ps1
+++ b/src/backend/infrastructure/deploy-resources.ps1
@@ -19,7 +19,7 @@ New-AzResourceGroupDeployment -Mode Incremental -Name "fusion-app-resources-envi
 
 Write-Host "Setting service principal key vault access"
 $spName = (Get-AzContext).Account.Id
-Set-AzKeyVaultAccessPolicy -VaultName $envKeyVault -ServicePrincipalName $spName -PermissionsToSecrets get,list,set
+Set-AzKeyVaultAccessPolicy -VaultName $envKeyVault -ServicePrincipalName $spName -PermissionsToSecrets get,list,set,delete
 
 Write-Host "Setting ad app service principal key vault access"
 $appSpId = (Get-AzADServicePrincipal -ApplicationId $clientId).Id


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
The PR env pipeline will generate a secret in the key vault, which is loaded on api startup. This secret will override the env variable used to direct the pr slot to the correct PR database. 
To solve this the secret should be deleted in key vault after template has been executed. This is a simpler solution than designing the templates to conditionally add the secret. 
Running pods should not be affected by the key vault, unless they are doing a restart at the exact same seconds..


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~

Verify by running pipeline on branch and PR stage.


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

