### PR TITLE
Person search endpoint for resource owners

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.Preview.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.Preview.cs
@@ -1,0 +1,52 @@
+﻿using Fusion.AspNetCore.FluentAuthorization;
+using Fusion.AspNetCore.OData;
+using Fusion.Resources.Domain.Commands;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public partial class InternalPersonnelController
+    {
+        [MapToApiVersion("1.0-preview")]
+        [HttpGet("/projects/{projectIdentifier}/resources/persons")]
+        [Obsolete]
+        public async Task<ActionResult> SearchPreview([FromRoute] PathProjectIdentifier? projectIdentifier, [FromQuery] ODataQueryParams query)
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal();
+                r.AnyOf(or =>
+                {
+                    if (projectIdentifier is not null)
+                        or.OrgChartReadAccess(projectIdentifier.ProjectId);
+
+                    or.BeResourceOwner();
+                });
+            });
+
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var command = new SearchAllPersonnel(query.Search);
+            if (query.HasFilter)
+            {
+                var departmentFilter = query.Filter.GetFilterForField("department");
+                if (departmentFilter.Operation != FilterOperation.Eq)
+                    return FusionApiError.InvalidOperation("InvalidQueryFilter", "Only the 'eq' operator is supported.");
+
+                command = command.WithDepartmentFilter(departmentFilter.Value);
+            }
+            var result = await DispatchAsync(command);
+
+            return Ok(result.Select(x => ApiInternalPersonnelPerson.CreateWithoutConfidentialTaskInfo(x)));
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -15,12 +15,13 @@ namespace Fusion.Resources.Api.Controllers
     [ApiVersion("1.0-preview")]
     [Authorize]
     [ApiController]
-    public class InternalPersonnelController : ResourceControllerBase
+    public partial class InternalPersonnelController : ResourceControllerBase
     {
 
         public InternalPersonnelController()
         {
         }
+
         /// <summary>
         /// Get personnel for a department
         /// </summary>
@@ -257,8 +258,11 @@ namespace Fusion.Resources.Api.Controllers
             return NoContent();
         }
 
+
+        [MapToApiVersion("1.0")]
+        [HttpGet("/departments/resources/persons")]
         [HttpGet("/projects/{projectIdentifier}/resources/persons")]
-        public async Task<ActionResult> Search([FromRoute] PathProjectIdentifier projectIdentifier, [FromQuery] ODataQueryParams query)
+        public async Task<ActionResult<ApiCollection<ApiInternalPersonnelPerson>>> Search([FromRoute] PathProjectIdentifier? projectIdentifier, [FromQuery] ODataQueryParams query)
         {
             #region Authorization
 
@@ -267,7 +271,9 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.OrgChartReadAccess(projectIdentifier.ProjectId);
+                    if (projectIdentifier is not null)
+                        or.OrgChartReadAccess(projectIdentifier.ProjectId);
+
                     or.BeResourceOwner();
                 });
             });
@@ -278,19 +284,24 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion
 
-            var command = new SearchPersonnel(query.Search);
-            if(query.HasFilter)
+            var command = new SearchPersonnel(query.Search)
+                .WithPaging(query);
+
+            if (query.HasFilter)
             {
                 var departmentFilter = query.Filter.GetFilterForField("department");
                 if (departmentFilter.Operation != FilterOperation.Eq)
-                    return BadRequest("Only the 'eq' operator is supported.");
+                    return FusionApiError.InvalidOperation("InvalidQueryFilter", "Only the 'eq' operator is supported.");
 
                 command = command.WithDepartmentFilter(departmentFilter.Value);
             }
             var result = await DispatchAsync(command);
 
-            return Ok(result.Select(x => ApiInternalPersonnelPerson.CreateWithoutConfidentialTaskInfo(x)));
+            return new ApiCollection<ApiInternalPersonnelPerson>(result.Select(x => ApiInternalPersonnelPerson.CreateWithoutConfidentialTaskInfo(x)))
+            {
+                TotalCount = result.TotalCount
+            };
         }
-    }
 
+    }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/SearchAllPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/SearchAllPersonnel.cs
@@ -1,0 +1,56 @@
+﻿using Fusion.Integration.Http;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Commands
+{
+    /// <summary>
+    /// Search for persons and return all results without paging.
+    /// Note: This can cause stress on the search index and produce large result set.
+    /// </summary>
+    [Obsolete("Use SearchPersonnel instead to get paged result. Use only if required.")]
+    public class SearchAllPersonnel : IRequest<IEnumerable<QueryInternalPersonnelPerson>>
+    {
+        private string search;
+
+        public SearchAllPersonnel(string search)
+        {
+            this.search = search;
+        }
+
+        public string? DepartmentFilter { get; private set; }
+
+        public SearchAllPersonnel WithDepartmentFilter(string? departmentFilter)
+        {
+            DepartmentFilter = departmentFilter;
+            return this;
+        }
+
+        public class Handler : IRequestHandler<SearchAllPersonnel, IEnumerable<QueryInternalPersonnelPerson>>
+        {
+            private readonly IHttpClientFactory httpClientFactory;
+
+            public Handler(IHttpClientFactory httpClientFactory)
+            {
+                this.httpClientFactory = httpClientFactory;
+            }
+
+            public async Task<IEnumerable<QueryInternalPersonnelPerson>> Handle(SearchAllPersonnel request, CancellationToken cancellationToken)
+            {
+                string? filter = null;
+                if (request.DepartmentFilter is not null)
+                {
+                    filter = $"search.ismatch('{request.DepartmentFilter}','fullDepartment','simple','all')";
+                }
+
+                var peopleClient = httpClientFactory.CreateClient(HttpClientNames.ApplicationPeople);
+                return await PeopleSearchUtils.GetPersonsFromSearchIndexAsync(peopleClient, request.search, filter);
+            }
+        }
+    }
+
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/SearchPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/SearchPersonnel.cs
@@ -1,23 +1,24 @@
-﻿using Fusion.Integration.Http;
-using Fusion.Integration.Org;
+﻿using Fusion.AspNetCore.OData;
+using Fusion.Integration.Http;
 using MediatR;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fusion.Resources.Domain.Commands
 {
-    public class SearchPersonnel : IRequest<IEnumerable<QueryInternalPersonnelPerson>>
+    public class SearchPersonnel : IRequest<QueryRangedList<QueryInternalPersonnelPerson>>
     {
-        private string search;
 
         public SearchPersonnel(string search)
         {
-            this.search = search;
+            Search = search;
         }
 
         public string? DepartmentFilter { get; private set; }
+        public string Search { get; private set; }
+        public int? Skip { get; set; }
+        public int? Top { get; set; }
 
         public SearchPersonnel WithDepartmentFilter(string? departmentFilter)
         {
@@ -25,7 +26,20 @@ namespace Fusion.Resources.Domain.Commands
             return this;
         }
 
-        public class Handler : IRequestHandler<SearchPersonnel, IEnumerable<QueryInternalPersonnelPerson>>
+        /// <summary>
+        /// Sets skip and top token from the query params.
+        /// </summary>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public SearchPersonnel WithPaging(ODataQueryParams query)
+        {
+            Skip = query.Skip;
+            Top = query.Top;
+
+            return this;
+        }
+
+        public class Handler : IRequestHandler<SearchPersonnel, QueryRangedList<QueryInternalPersonnelPerson>>
         {
             private readonly IHttpClientFactory httpClientFactory;
 
@@ -34,7 +48,7 @@ namespace Fusion.Resources.Domain.Commands
                 this.httpClientFactory = httpClientFactory;
             }
 
-            public async Task<IEnumerable<QueryInternalPersonnelPerson>> Handle(SearchPersonnel request, CancellationToken cancellationToken)
+            public async Task<QueryRangedList<QueryInternalPersonnelPerson>> Handle(SearchPersonnel request, CancellationToken cancellationToken)
             {
                 string? filter = null;
                 if (request.DepartmentFilter is not null)
@@ -43,8 +57,14 @@ namespace Fusion.Resources.Domain.Commands
                 }
 
                 var peopleClient = httpClientFactory.CreateClient(HttpClientNames.ApplicationPeople);
-                return await PeopleSearchUtils.GetPersonsFromSearchIndexAsync(peopleClient, request.search, filter);
+                var items = await PeopleSearchUtils.Search(peopleClient, request.Search, s => s
+                    .WithFilter(filter)
+                    .WithSkip(request.Skip)
+                    .WithTop(request.Top));
+
+                return items;
             }
         }
     }
+
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryRangedList.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryRangedList.cs
@@ -63,5 +63,10 @@ namespace Fusion.Resources.Domain
             var pageCount = await source.Skip(skip).Take(take).CountAsync();
             return new QueryRangedList<T>(pageCount, count, skip);
         }
+
+        public static QueryRangedList<T> FromItems<T>(IEnumerable<T> items, int totalCount, int skip)
+        {
+            return new QueryRangedList<T>(items, totalCount, skip);
+        }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
@@ -53,6 +53,25 @@ namespace Fusion.Resources.Domain
             return await GetFromSearchIndexAsync(peopleClient, filter, search);
         }
 
+        /// <summary>
+        /// Perform normal search on the index. The resultset will be paged but includes the total result. 
+        /// Paging can be done by using the paramSetup: q => q.WithSkip(100).
+        /// </summary>
+        /// <param name="peopleClient"></param>
+        /// <param name="search"></param>
+        /// <param name="paramSetup"></param>
+        /// <returns></returns>
+        public static async Task<QueryRangedList<QueryInternalPersonnelPerson>> Search(HttpClient peopleClient, string search, Action<SearchParams>? paramSetup = null)
+        {
+            var query = new SearchParams(search);
+
+            paramSetup?.Invoke(query);
+
+            var searchResult = await SearchIndexAsync(peopleClient, query);
+
+            return QueryRangedList.FromItems(searchResult.items, searchResult.totalCount, query.Skip);
+        }
+
         private static async Task<List<QueryInternalPersonnelPerson>> GetFromSearchIndexAsync(HttpClient peopleClient, string? filter, string? search = null)
         {
             var result = new List<QueryInternalPersonnelPerson>();
@@ -112,7 +131,68 @@ namespace Fusion.Resources.Domain
             return result;
         }
 
-        
+        private static async Task<(List<QueryInternalPersonnelPerson> items, int totalCount)> SearchIndexAsync(HttpClient peopleClient, SearchParams query)
+        {
+            var result = new List<QueryInternalPersonnelPerson>();
+
+            if (query.Top > 1000)
+                throw new InvalidOperationException("Max page size is 1000");
+
+
+            var top = query.Top;
+            var skip = query.Skip;
+
+            var response = await peopleClient.PostAsJsonAsync("/search/persons/query", new
+            {
+                filter = query.Filter,
+                search = query.Search,
+                top = query.Top,
+                skip = query.Skip,
+                includeTotalResultCount = true
+            });
+
+            var data = await response.Content.ReadAsStringAsync();
+
+            response.EnsureSuccessStatusCode();
+
+            var items = JsonConvert.DeserializeAnonymousType(data, new
+            {
+                results = new[]
+                {
+                        new { document = new SearchPersonDTO() }
+                    },
+                count = (int?)0
+            });
+
+
+            var resultItems = items.results.Select(i => new QueryInternalPersonnelPerson(i.document.azureUniqueId, i.document.mail, i.document.name, i.document.accountType)
+            {
+                PhoneNumber = i.document.mobilePhone,
+                JobTitle = i.document.jobTitle,
+                OfficeLocation = i.document.officeLocation,
+                Department = i.document.department,
+                IsResourceOwner = i.document.isResourceOwner,
+                FullDepartment = i.document.fullDepartment,
+                ManagerAzureId = i.document.managerAzureId,
+                PositionInstances = i.document.positions.Select(p => new QueryPersonnelPosition
+                {
+                    PositionId = p.id,
+                    InstanceId = p.instanceId,
+                    AppliesFrom = p.appliesFrom!.Value,
+                    AppliesTo = p.appliesTo!.Value,
+                    Name = p.name,
+                    Location = p.locationName,
+                    BasePosition = new QueryBasePosition(p.basePosition.id, p.basePosition.name, p.basePosition.discipline, p.basePosition.type),
+                    Project = new QueryProjectRef(p.project.id, p.project.name, p.project.domainId, p.project.type),
+                    Workload = p.workload,
+                    AllocationState = p.allocationState,
+                    AllocationUpdated = p.allocationUpdated
+                }).OrderBy(p => p.AppliesFrom).ToList()
+            }).ToList();
+
+            return (resultItems, items.count ?? 0);
+        }
+
 
         private class SearchProjectDTO
         {
@@ -162,6 +242,39 @@ namespace Fusion.Resources.Domain
             public Guid? managerAzureId { get; set; }
             public List<SearchPositionDTO> positions { get; set; } = new();
 
+        }
+
+        public class SearchParams
+        {
+            public const int DEFAULT_PAGE_SIZE = 50;
+
+            public SearchParams(string search)
+            {
+                Search = search;
+            }
+
+            public int Top { get; set; } = DEFAULT_PAGE_SIZE;
+            public int Skip { get; set; } = 0;
+            public string Search { get; set; }
+            public string? Filter { get; set; }
+
+            public SearchParams WithSkip(int? skip)
+            {
+                Skip = skip ?? 0;
+                return this;
+            }
+
+            public SearchParams WithTop(int? top)
+            {
+                Top = top ?? DEFAULT_PAGE_SIZE;
+                return this;
+            }
+
+            public SearchParams WithFilter(string? filter)
+            {
+                Filter = filter;
+                return this;
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Made person search endpoint available for resource owners. New endpoint added under `/departments/resources/persons` path.
The existing endpoint did a full search, expanding each page from the search index, resulting in a total dump of index if no search params is sent. 
This is not optimal for performance, so existing endpoint has been left intact with the `1.0-preview` version, while a new endpoint has been set up and promoted to `1.0`, which will support paging.
The performance is noticable quicker and stress on downstream systems should be less.

New preview only endpoint has been refactored to a partial class to move away.
eofg


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [ ] Local tests are passing

Can be verified in postman by hitting the endpoint at `/departments/resources/persons?api-version=1.0&$search=test`. Paging params like `&$top=10&$skip=335` can be used.
Existing endpoint should still provide a simple list response @ ex `/projects/df22e2b7-78b5-482f-a5ca-e45440f3eb64/resources/persons?api-version=1.0-preview&$search=hans`


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Automatic tests difficult when relying on search index.
