### PR TITLE
Relevant departments for delegated leaders

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
@@ -23,6 +23,7 @@ namespace Fusion.Resources.Api.Controllers
                 .Union(IsResourceOwner ? resourceOwnerProfile.SiblingDepartments ?? new () : new ())       
                 .Union(resourceOwnerProfile.DelegatedChildDepartments ?? new ())
                 .Union(resourceOwnerProfile.DelegatedSiblingDepartments ?? new ())
+                .Union(resourceOwnerProfile.DelegatedParentDepartments ?? new ())
                 .Distinct()
                 .ToList();
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiResourceOwnerProfile.cs
@@ -19,12 +19,14 @@ namespace Fusion.Resources.Api.Controllers
 
             // Compile the relevant department list
             RelevantDepartments = ResponsibilityInDepartments
-                .Union(resourceOwnerProfile.ChildDepartments ?? new ())
-                .Union(resourceOwnerProfile.SiblingDepartments ?? new ())                
+                .Union(IsResourceOwner ? resourceOwnerProfile.ChildDepartments ?? new () : new ())
+                .Union(IsResourceOwner ? resourceOwnerProfile.SiblingDepartments ?? new () : new ())       
+                .Union(resourceOwnerProfile.DelegatedChildDepartments ?? new ())
+                .Union(resourceOwnerProfile.DelegatedSiblingDepartments ?? new ())
                 .Distinct()
                 .ToList();
 
-            if (Sector is not null && !RelevantDepartments.Contains(Sector))
+            if (IsResourceOwner && Sector is not null && !RelevantDepartments.Contains(Sector))
                 RelevantDepartments.Add(Sector);
         }
 

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceOwnerProfile.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Fusion.Resources.Domain.Queries
@@ -27,5 +28,20 @@ namespace Fusion.Resources.Domain.Queries
         /// </summary>
         public List<string>? SiblingDepartments { get; set; }
         public string? Sector { get; set; }
+
+        public List<string>? DelegatedSiblingDepartments { get; set; }
+        public List<string>? DelegatedChildDepartments { get; set; }
+
+        internal void AddDelegatedDepartments(QueryRelatedDepartments orgProfile)
+        {
+            if (DelegatedChildDepartments is null)
+                DelegatedChildDepartments = new List<string>();
+
+            if (DelegatedSiblingDepartments is null)
+                DelegatedSiblingDepartments = new List<string>();
+
+            DelegatedChildDepartments.AddRange(orgProfile.Children.Select(x => x.DepartmentId));
+            DelegatedSiblingDepartments.AddRange(orgProfile.Siblings.Select(x => x.DepartmentId));
+        }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceOwnerProfile.cs
@@ -31,6 +31,7 @@ namespace Fusion.Resources.Domain.Queries
 
         public List<string>? DelegatedSiblingDepartments { get; set; }
         public List<string>? DelegatedChildDepartments { get; set; }
+        public List<string>? DelegatedParentDepartments { get; set; }
 
         internal void AddDelegatedDepartments(QueryRelatedDepartments orgProfile)
         {
@@ -42,6 +43,14 @@ namespace Fusion.Resources.Domain.Queries
 
             DelegatedChildDepartments.AddRange(orgProfile.Children.Select(x => x.DepartmentId));
             DelegatedSiblingDepartments.AddRange(orgProfile.Siblings.Select(x => x.DepartmentId));
+        }
+
+        internal void AddDelegatedParentDepartment(string department)
+        {
+            if (DelegatedParentDepartments is null)
+                DelegatedParentDepartments = new List<string>();
+
+            DelegatedParentDepartments.Add(department);
         }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -81,6 +81,10 @@ namespace Fusion.Resources.Domain.Queries
                 // Resolve related departments for all departments where user has responsibility
                 foreach (var department in departmentsWithResponsibility.Where(d => d != user.FullDepartment))
                 {
+                    // Add the parent department, as when you have responsibility in a department, the parent department will always be relevant
+                    var parentDepartment = new DepartmentPath(department).Parent();
+                    resourceOwnerProfile.AddDelegatedParentDepartment(parentDepartment);
+
                     var orgProfile = await mediator.Send(new GetRelatedDepartments(department), cancellationToken);
                     if (orgProfile is not null)
                         resourceOwnerProfile.AddDelegatedDepartments(orgProfile);


### PR DESCRIPTION
- [x] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When a user has been delegated responsebility the sibling/child departments for that department is not included in the relevant list.
This reduce the functionality of the delegated department leader, to permissions only, not to "function" as the leader.

To fix this these child/sibling departments are included in the query for the user profile, but separated from the "default" which is the department for the user.
The response model has been changed to only include relevant department if the user is a resource owner/leader, and to include the delegated child/siblings.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Should try and deploy a test env that can target the pr api, so users can test things works as expected.


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

