### PR TITLE
Notification - Do not send delete notification when request is in draft

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestNotification/RequestDeletedHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/Notifications/InternalRequestNotification/RequestDeletedHandler.cs
@@ -31,6 +31,11 @@ namespace Fusion.Resources.Api.Notifications
 
             public async Task Handle(InternalRequestDeleted notification, CancellationToken cancellationToken)
             {
+                if (notification.IsDraft)
+                {
+                    logger.LogInformation($"Request {notification.RequestId} was removed. Notification not sent due to request beeing a draft request.");
+                    return;
+                }
                 if (string.IsNullOrEmpty(notification.AssignedDepartment))
                 {
                     logger.LogInformation($"Request {notification.RequestId} was removed. Notification not sent due to missing assigned department.");

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/InternalRequests/InternalRequestDeleted.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/InternalRequests/InternalRequestDeleted.cs
@@ -8,6 +8,7 @@ namespace Fusion.Resources.Domain.Notifications.InternalRequests
         public InternalRequestDeleted(QueryResourceAllocationRequest req, string editor)
         {
             RequestId = req.RequestId;
+            IsDraft = req.IsDraft;
             OrgProjectId = req.Project.OrgProjectId;
             OrgPositionId = req.OrgPositionId;
             PositionInstanceId = req.OrgPositionInstanceId;
@@ -19,6 +20,7 @@ namespace Fusion.Resources.Domain.Notifications.InternalRequests
         }
 
         public Guid RequestId { get; set; }
+        public bool IsDraft { get; set; }
         public Guid OrgProjectId { get; set; }
         public Guid? OrgPositionId { get; set; }
         public Guid? PositionInstanceId { get; set; }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Currently a notification is beeing sent for requests being deleted.
Not required for notifications in draft state.

Check for IsDraft before dispatching notification

[AB#22988](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/22988)

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

