### PR TITLE
Pipeline - Re-added aks deployment step to prod stage

### DIFF
--- a/pipelines/api-pipeline.yml
+++ b/pipelines/api-pipeline.yml
@@ -218,16 +218,12 @@ stages:
                 parameters:
                   artifact: 'k8s-deployment'
                   environment: $(envName)
-
-              ##
-              ## Disable this until production cluster is at correct version to handle proper ingres version.
-              ##
-                  
-              # - task: KubernetesManifest@0
-              #   displayName: Deploy to Kubernetes cluster
-              #   inputs:
-              #     action: deploy
-              #     manifests: $(deploymentManifest)
+  
+              - task: KubernetesManifest@0
+                displayName: Deploy to Kubernetes cluster
+                inputs:
+                  action: deploy
+                  manifests: $(deploymentManifest)
 
               - template: templates/deploy-container-app.yml
                 parameters:


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
There was different version of aks cluster for prod/test. To handle this short term the production cluster step was disabled. 
The cluster is now updated to latest version and ingress should work both locations, so the prod deployment step should be included.


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~

n/a


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

