### PR TITLE
AI - Added sql command text to dependency traces

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -7,6 +7,7 @@ using Fusion.Resources.Api.Authentication;
 using Fusion.Resources.Api.Middleware;
 using Fusion.Resources.Domain;
 using MediatR;
+using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -116,6 +117,8 @@ namespace Fusion.Resources.Api
                 .AddDbContextCheck<Database.ResourcesDbContext>("db", tags: new[] { "ready" });
 
             services.AddApplicationInsightsTelemetry();
+            // Enable AI sql dependency telemetry to include sql commands in data
+            services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) => { module.EnableSqlCommandTextInstrumentation = true; });
 
             services.AddCommonLibHttpClient();
             services.AddLineOrgHttpClient();


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Enabled displaying the sql command texts in the AI dependency traces.
This was disabled by default some time ago. This change has apparently not been done in this api.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

Verified by debugging and checking that AI traces actually contains sql commands.


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Fixes [AB#23320](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/23320)

