### PR TITLE
Add full control role for external personnel endpoints

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -24,6 +24,17 @@ namespace Fusion.Resources.Api.Controllers
             return builder;
         }
 
+        public static IAuthorizationRequirementRule FullControlExternal(this IAuthorizationRequirementRule builder)
+        {
+            var policy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(c => c.User.IsInRole("Fusion.Resources.External.FullControl"))
+                .Build();
+
+            builder.AddRule((auth, user) => auth.AuthorizeAsync(user, policy));
+
+            return builder;
+        }
+
         public static IAuthorizationRequirementRule GlobalRoleAccess(this IAuthorizationRequirementRule builder, params string[] roles)
         {
             return builder.AddRule(new GlobalRoleRequirement(roles));

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Contracts/ContractsController.cs
@@ -46,7 +46,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -103,7 +103,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -139,7 +139,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -192,7 +192,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -239,7 +239,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -287,7 +287,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -349,7 +349,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -413,7 +413,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -445,7 +445,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -515,7 +515,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -574,7 +574,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -620,7 +620,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Mpp/MppController.cs
@@ -20,7 +20,7 @@ namespace Fusion.Resources.Api.Controllers.Mpp
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -55,7 +55,7 @@ namespace Fusion.Resources.Api.Controllers.Mpp
         {
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
@@ -38,6 +38,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     or.BeTrustedApplication();
                     or.FullControl();
+                    or.FullControlExternal();
                 });
             });
 
@@ -62,7 +63,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -92,7 +93,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -131,6 +132,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     or.BeTrustedApplication();
                     or.FullControl();
+                    or.FullControlExternal();
                 });
             });
 
@@ -174,7 +176,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -216,7 +218,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -266,7 +268,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -298,7 +300,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -334,7 +336,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -363,7 +365,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Projects/ProjectsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Projects/ProjectsController.cs
@@ -17,7 +17,7 @@ namespace Fusion.Resources.Api.Controllers.Projects
         {
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
                 r.AnyOf(a => a.BeTrustedApplication());
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestsController.cs
@@ -34,7 +34,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -63,7 +63,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -105,7 +105,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -155,7 +155,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -197,7 +197,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -239,7 +239,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -271,7 +271,7 @@ namespace Fusion.Resources.Api.Controllers
         {
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -304,6 +304,7 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     or.BeTrustedApplication();
                     or.FullControl();
+                    or.FullControlExternal();
                 });
             });
 
@@ -334,7 +335,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
                 r.AnyOf(or =>
                 {
                     or.ContractAccess(ContractRole.Any, projectIdentifier, contractIdentifier);
@@ -366,7 +367,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
                 r.Must().BeCommentAuthor(comment);
 
                 // Not sure if these are even evaluated, if the comment author req is not successfull.
@@ -401,7 +402,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
                 r.Must(r => r.BeCommentAuthor(comment));
                 r.AnyOf(or =>
                 {
@@ -430,7 +431,7 @@ namespace Fusion.Resources.Api.Controllers
         {
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -454,7 +455,7 @@ namespace Fusion.Resources.Api.Controllers
         {
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {
@@ -486,7 +487,7 @@ namespace Fusion.Resources.Api.Controllers
             {
                 var commentAuthResult = await Request.RequireAuthorizationAsync(r =>
                 {
-                    r.AlwaysAccessWhen().FullControl();
+                    r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                     r.AnyOf(or =>
                     {
@@ -508,7 +509,7 @@ namespace Fusion.Resources.Api.Controllers
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl();
+                r.AlwaysAccessWhen().FullControl().FullControlExternal();
 
                 r.AnyOf(or =>
                 {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -23,7 +23,9 @@ namespace Fusion.Resources.Api.Tests.Fixture
         public readonly ResourcesApiWebAppFactory ApiFactory;
 
         public ApiPersonProfileV3 AdminUser { get; }
+        public ApiPersonProfileV3 ExternalAdminUser { get; }
 
+        public TestClientScope ExternalAdminScope() => new TestClientScope(ExternalAdminUser);
         public TestClientScope AdminScope() => new TestClientScope(AdminUser);
         public TestClientScope UserScope(ApiPersonProfileV3 profile) => new TestClientScope(profile);
 
@@ -54,6 +56,10 @@ namespace Fusion.Resources.Api.Tests.Fixture
             ApiFactory = new ResourcesApiWebAppFactory();
             AdminUser = PeopleServiceMock.AddTestProfile()
                 .WithRoles("Fusion.Resources.FullControl")
+                .SaveProfile();
+
+            ExternalAdminUser = PeopleServiceMock.AddTestProfile()
+                .WithRoles("Fusion.Resources.External.FullControl")
                 .SaveProfile();
 
         }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ExternalPersonnel/ExternalPersonnelTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ExternalPersonnel/ExternalPersonnelTests.cs
@@ -85,7 +85,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         {
             var testPersonnel = fixture.AddProfile(FusionAccountType.External);
 
-            using (var adminScope = fixture.AdminScope())
+            using (var adminScope = fixture.ExternalAdminScope())
             {
                 var person = await client.CreatePersonnelAsync(projectId, contractId, s => { s.Mail = testPersonnel.Mail; });
 
@@ -104,7 +104,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         {
             var testPersonnel = fixture.AddProfile(FusionAccountType.External);
 
-            using (var adminScope = fixture.AdminScope())
+            using (var adminScope = fixture.ExternalAdminScope())
             {
                 var person = await client.CreatePersonnelAsync(projectId, contractId, s => { s.Mail = testPersonnel.Mail; });
 
@@ -122,7 +122,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         {
             var testPersonnel = fixture.AddProfile(FusionAccountType.External);
 
-            using (var adminScope = fixture.AdminScope())
+            using (var adminScope = fixture.ExternalAdminScope())
             {
                 var person = await client.CreatePersonnelAsync(projectId, contractId, s => { s.Mail = testPersonnel.Mail; });
                 person.PreferredContactMail = "mail@other-company.com";
@@ -141,7 +141,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
             var testPersonnelA = fixture.AddProfile(FusionAccountType.External);
             var testPersonnelB = fixture.AddProfile(FusionAccountType.External);
 
-            using (var adminScope = fixture.AdminScope())
+            using (var adminScope = fixture.ExternalAdminScope())
             {
                 var personA = await client.CreatePersonnelAsync(projectId, contractId, s => { s.Mail = testPersonnelA.Mail; });
                 var personB = await client.CreatePersonnelAsync(projectId, contractId, s => { s.Mail = testPersonnelB.Mail; });
@@ -166,7 +166,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         [Fact]
         public async Task PreferredMail_UpdateBatchPersonnel_ShouldValidateEmail()
         {
-            using (var adminScope = fixture.AdminScope())
+            using (var adminScope = fixture.ExternalAdminScope())
             {
                 var person = await client.CreatePersonnelAsync(projectId, contractId);
 
@@ -184,7 +184,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         [Fact]
         public async Task RefreshProfile_UserRemoved_ShouldMarkAsDeleted()
         {
-            using var adminScope = fixture.AdminScope();
+            using var adminScope = fixture.ExternalAdminScope();
             var person = await client.CreatePersonnelAsync(projectId, contractId);
             var resp = await client.TestClientPostAsync<TestApiPersonnel>($"resources/personnel/{person.Mail}/refresh", new { userRemoved = true });
             resp.Should().BeSuccessfull();
@@ -193,7 +193,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
         [Fact]
         public async Task RefreshProfile_UserUpdated_ShouldUpdate()
         {
-            using var adminScope = fixture.AdminScope();
+            using var adminScope = fixture.ExternalAdminScope();
             var profile = Testing.Mocks.ProfileService.PeopleServiceMock.AddTestProfile().SaveProfile();
             var person = new PersonnelApiHelpers.TestCreatePersonnelRequest
             {
@@ -222,7 +222,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests.ExternalPersonnel
                 .AddContext(testProject.Project);
 
             var client = fixture.ApiFactory.CreateClient()
-                .WithTestUser(fixture.AdminUser)
+                .WithTestUser(fixture.ExternalAdminUser)
                 .AddTestAuthToken();
 
             (var contract, var positions) = testProject.ContractsWithPositions.First();


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added new full control role for external endpoints. This will allow grant admin permissions to external parts of the api only.
Role name `Fusion.Resources.External.FullControl`. The role should be bound to a group as a claimable role.

Fixes [AB#22411](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/22411)

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Updated all integration tests to use the new role instead of the global full control role. However this does not cover every part.
Will be difficult to test a pr branch, so should roll out and verify in CI. 

The new role should not interfear with existing functionality.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

