### PR TITLE
API - TokenProvider setup

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -74,6 +74,7 @@ namespace Fusion.Resources.Api
                 {
                     opts.ClientId = Configuration["AzureAd:ClientId"];
                     opts.ClientSecret = Configuration["AzureAd:ClientSecret"];
+                    opts.CertificateThumbprint = Configuration["AzureAd:CertThumbprint"];
                 });
 
                 options.ServiceInfo.Environment = Configuration["ENVNAME"];


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Add suport for CertificateThumbprint in setup of UseDefaultTokenProvider
Instead of maintaining a client secret, it would be better to just use the certificate thumbprint issued to developers.


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~

To be used locally, tested by adding cert thumbprint in user secrets


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

