### PR TITLE
Aggregated workload on a timeline segment should not include pending …

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Timeline/PersonnelTimelineBuilder.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Timeline/PersonnelTimelineBuilder.cs
@@ -47,6 +47,7 @@ namespace Fusion.Resources.Domain
             return view.Segments.Select(x => new QueryTimelineRange<QueryPersonnelTimelineItem>(x.FromDate, x.ToDate)
             {
                 Items = x.Items,
+                // Segments containing Pending requests (item.Type=Request) should not be calculated in aggregated workload. 
                 Workload = x.Items.Where(i => !i.Type.Equals("Request")).Sum(item => item.Workload ?? 0)
             })
             .OrderBy(x => x.AppliesFrom)

--- a/src/backend/api/Fusion.Resources.Domain/Timeline/PersonnelTimelineBuilder.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Timeline/PersonnelTimelineBuilder.cs
@@ -47,7 +47,7 @@ namespace Fusion.Resources.Domain
             return view.Segments.Select(x => new QueryTimelineRange<QueryPersonnelTimelineItem>(x.FromDate, x.ToDate)
             {
                 Items = x.Items,
-                Workload = x.Items.Sum(item => item.Workload ?? 0)
+                Workload = x.Items.Where(i => !i.Type.Equals("Request")).Sum(item => item.Workload ?? 0)
             })
             .OrderBy(x => x.AppliesFrom)
             .ToList();


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work**
Changed the logic for calculating aggregate workload on a timeline segments. Pending requests should be ignored.

Example:
![image](https://user-images.githubusercontent.com/83007828/140478560-f18c2953-e424-4292-8246-0c4f9679cca3.png)

**Testing:**

- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing 

**Checklist:**

- [x] Considered automated tests
- [ ] ~~Considered updating specification~~
- [ ] Considered work items
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review