### PR TITLE
External - Fixed provisining issue where persons have no mail

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
@@ -1,4 +1,5 @@
 ﻿using Fusion.ApiClients.Org;
+using Fusion.Resources.Database.Entities;
 using System;
 
 #nullable enable
@@ -81,6 +82,18 @@ namespace Fusion.Resources.Domain
             {
                 PersonId.IdentifierType.UniqueId => new ApiPersonV2 { AzureUniqueId = personId.Value.UniqueId },
                 _ => new ApiPersonV2 { Mail = personId.Value.OriginalIdentifier }
+            };
+        }
+
+        public static implicit operator PersonId?(DbExternalPersonnelPerson? person)
+        {
+            if (person is null)
+                return null;
+
+            return person.AzureUniqueId.HasValue switch
+            {
+                true => new PersonId(person.AzureUniqueId.Value),
+                _ => new PersonId(person.Mail)
             };
         }
     }

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ContractorPersonnelRequest/Provision.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ContractorPersonnelRequest/Provision.cs
@@ -70,7 +70,7 @@ namespace Fusion.Resources.Logic.Commands
                         Workload = dbRequest.Position.Workload,
                         Obs = dbRequest.Position.Obs,
                         BasePositionId = dbRequest.Position.BasePositionId,
-                        AssignedPerson = dbRequest.Person.Person.Mail,
+                        AssignedPerson =  dbRequest.Person.Person,
                         ParentPositionId = dbRequest.Position.TaskOwner.PositionId
                     };
 
@@ -107,7 +107,7 @@ namespace Fusion.Resources.Logic.Commands
                         Workload = dbRequest.Position.Workload,
                         Obs = dbRequest.Position.Obs,
                         BasePositionId = dbRequest.Position.BasePositionId,
-                        AssignedPerson = dbRequest.Person.Person.Mail,
+                        AssignedPerson = dbRequest.Person.Person,
                         ParentPositionId = dbRequest.Position.TaskOwner.PositionId
                     };
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When provisioning allocations to the org service the request only used mail to identify person. 
When the account has no mail, this fails.

Fixed by using azure id primarily, and only use mail as a fallback.


**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Can be verified by creating request on a person with no mail. Provisioning step should be successfull.


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Skipping automatic test to get functionality out quickly. Simple fix with low risk.
