### PR TITLE
Allow resource owners access to responsebility matrix for their department

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Utils/DepartmentPath.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/DepartmentPath.cs
@@ -24,6 +24,8 @@ namespace Fusion.Resources.Domain
 
         public int Level => path.Length;
 
+        public DepartmentPath ParentDeparment => new DepartmentPath(this.Parent());
+
         public string Parent(int levelsToJump = 1) => string.Join(" ", path.SkipLast(levelsToJump));
         public string GoToLevel(int level) => string.Join(" ", path.Take(level <= 0 ? 1 : level));
 
@@ -40,6 +42,22 @@ namespace Fusion.Resources.Domain
 
             return (levelDelta <= 2 && fullDepartmentPath.StartsWith(other.fullDepartmentPath, StringComparison.OrdinalIgnoreCase))
                 || (other.fullDepartmentPath.StartsWith(fullDepartmentPath, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool IsParent(string? path)
+        {
+            if (path is null)
+                return false;
+
+            return path.StartsWith(fullDepartmentPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool IsDepartment(string? path)
+        {
+            if (path is null)
+                return false;
+
+            return path.Equals(fullDepartmentPath, StringComparison.OrdinalIgnoreCase);
         }
 
         public string GetShortName() => string.Join(' ', path.TakeLast(3));

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
@@ -7,13 +7,13 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Fusion.Resources.Api.Controllers;
 using Fusion.Testing.Authentication.User;
 using Fusion.Testing.Mocks.OrgService;
 using Xunit;
 using Xunit.Abstractions;
 using Fusion.Testing.Mocks.LineOrgService;
 using Fusion.Testing.Mocks.ProfileService;
+using System.Collections.Generic;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
@@ -74,7 +74,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task PutMatrix_ShouldBeOk_WhenAdmin()
         {
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new
             {
                 ProjectId = testProject.Project.ProjectId,
                 LocationId = Guid.NewGuid(),
@@ -99,13 +99,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task PutMatrix_NullablesTest_ShouldBeOk_WhenAdmin()
         {
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new 
             {
-                ProjectId = null,
-                LocationId = null,
-                Discipline = null,
-                BasePositionId = null,
-                Sector = null,
                 Unit = "PDP PRD EAS",
             };
 
@@ -122,15 +117,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
-        public async Task PutMatrix_ShouldBeBadRequest_WhenUnitIsNull()
+        public async Task PutMatrix_ShouldBeBadRequest_WhenUnitIsEmpty()
         {
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new
             {
-                ProjectId = null,
-                LocationId = null,
-                Discipline = null,
-                BasePositionId = null,
-                Sector = null,
                 Unit = "",
             };
 
@@ -146,7 +136,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             var resourceOwner = fixture.AddResourceOwner(department);
 
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new
             {
                 ProjectId = testProject.Project.ProjectId,
                 LocationId = Guid.NewGuid(),
@@ -171,7 +161,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .WithTestUser(fixture.AdminUser)
                 .AddTestAuthToken();
 
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new 
             {
                 ProjectId = testProject.Project.ProjectId,
                 LocationId = Guid.NewGuid(),
@@ -200,6 +190,147 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeSuccessfull();
         }
 
+        [Theory]
+        [InlineData("L1 L2 L3", "L1 L2", true)]         // Parent department
+        [InlineData("L1 L2 L3", "L1 L2 L3 L4A", true)]  // Child department
+        [InlineData("L1 L2 L3A", "L1 L2 L3A", true)]    // Same department
+        [InlineData("L1 L2 L3A", "L1 L2 L3B", true)]    // sibling department
+        [InlineData("L1 L2 L3A", "L1 L2A L3A", false)]  // Different L2 node
+        [InlineData("L1 L2 L3A", "L1A L2A L3A", false)] // Different L1 node
+        public async Task CreateMatrixItem_AccessTest(string targetDepartment, string resourceOwnerDepartment, bool shouldHaveAccess)
+        {
+            var resourceOwner = fixture.AddResourceOwner(resourceOwnerDepartment);
+
+            var request = new
+            {
+                Unit = targetDepartment,
+            };
+
+            using var authScope = fixture.UserScope(resourceOwner);
+            var response = await client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", request);
+
+            if (shouldHaveAccess)
+                response.Should().BeSuccessfull();
+            else
+                response.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData("L1 L2 L3", "L1 L2", true)]         // Parent department
+        [InlineData("L1 L2 L3", "L1 L2 L3 L4A", true)]  // Child department
+        [InlineData("L1 L2 L3A", "L1 L2 L3A", true)]    // Same department
+        [InlineData("L1 L2 L3A", "L1 L2 L3B", true)]    // sibling department
+        [InlineData("L1 L2 L3A", "L1 L2A L3A", false)]  // Different L2 node
+        [InlineData("L1 L2 L3A", "L1A L2A L3A", false)] // Different L1 node
+        public async Task UpdateMatrixItem_AccessTest(string targetDepartment, string resourceOwnerDepartment, bool shouldHaveAccess)
+        {
+            var resourceOwner = fixture.AddResourceOwner(resourceOwnerDepartment);
+
+            Guid? itemId = null;
+            using (var adminScope = fixture.AdminScope())
+            {
+                var request = new
+                {
+                    Unit = targetDepartment,
+                };
+                var createResp = await client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", request);
+                createResp.Should().BeSuccessfull();
+                itemId = createResp.Value.Id;
+            }
+
+            var updateRequest = new
+            {
+                ProjectId = testProject.Project.ProjectId,
+                Unit = targetDepartment,
+            };
+
+            using var authScope = fixture.UserScope(resourceOwner);
+            var response = await client.TestClientPutAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix/{itemId}", updateRequest);
+
+            if (shouldHaveAccess)
+                response.Should().BeSuccessfull();
+            else
+                response.Should().BeUnauthorized();
+        }
+
+        [Fact]
+        public async Task ListMatrixItem_ShouldListRelevantItems_WhenResourceOwner()
+        {
+
+            using (var adminScope = fixture.AdminScope())
+            {
+                // Create some random items
+                var units = new List<string>()
+                {
+                    "PDP PRD",
+                    "PDP PRD PMC",
+                    "PDP PRD PMC PCA",
+                    "PDP PRD PMC PCA PCA1",
+                    "PDP PRD PMC PCA PCA2",
+                    "PDP PRD FE",
+                    "PDP DW"
+                };
+
+                foreach (var unit in units)
+                {
+                    var seedResp = await client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", new { unit = unit });
+                    seedResp.Should().BeSuccessfull();
+                }
+            }
+
+
+            var resourceOwner = fixture.AddResourceOwner("PDP PRD PMC PCA PCA1");
+            using var authScope = fixture.UserScope(resourceOwner);
+            var response = await client.TestClientGetAsync($"/internal-resources/responsibility-matrix", new
+            {
+                value = new[] { new { unit = string.Empty } }
+            });
+
+            response.Should().BeSuccessfull();
+            response.Value.value.Should().OnlyContain(i => i.unit.StartsWith("PDP PRD PMC PCA"));
+            response.Value.value.Should().HaveCountGreaterOrEqualTo(3); // Unknown if any other test affect us. Should at least have the ones relevant to PCA.
+            
+        }
+
+        [Fact]
+        public async Task ListMatrixItem_ShouldListAllChildItems_WhenParentResourceOwner()
+        {
+
+            using (var adminScope = fixture.AdminScope())
+            {
+                // Create some random items
+                var units = new List<string>()
+                {
+                    "PDP PRD",
+                    "PDP PRD PMC",
+                    "PDP PRD PMC PCA",
+                    "PDP PRD PMC PCA PCA1",
+                    "PDP PRD PMC PCA PCA2",
+                    "PDP PRD FE",
+                    "PDP DW"
+                };
+
+                foreach (var unit in units)
+                {
+                    var seedResp = await client.TestClientPostAsync<TestResponsibilitMatrix>($"/internal-resources/responsibility-matrix", new { unit = unit });
+                    seedResp.Should().BeSuccessfull();
+                }
+            }
+
+
+            var resourceOwner = fixture.AddResourceOwner("PDP PRD PMC");
+            using var authScope = fixture.UserScope(resourceOwner);
+            var response = await client.TestClientGetAsync($"/internal-resources/responsibility-matrix", new
+            {
+                value = new[] { new { unit = string.Empty } }
+            });
+
+            response.Should().BeSuccessfull();
+            response.Value.value.Should().OnlyContain(i => i.unit.StartsWith("PDP PRD"));
+            response.Value.value.Should().NotContain(i => i.unit.StartsWith("PDP PDP FE"));
+            response.Value.value.Should().HaveCountGreaterOrEqualTo(5); // Should include the parent unit as well, but should not include FE and DW
+
+        }
 
         public async Task InitializeAsync()
         {
@@ -215,7 +346,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .WithTestUser(fixture.AdminUser)
                 .AddTestAuthToken();
 
-            var request = new UpdateResponsibilityMatrixRequest
+            var request = new 
             {
                 ProjectId = testProject.Project.ProjectId,
                 LocationId = Guid.NewGuid(),


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Updated authorization rules for the responebility matrix, to allow resource owners access to items relevant for their department.

This allows them to create items targeting their own department, as well as their sibling/parent to increase the usability. 
The sibling/parent can be removed if found to broad. However I do belive they should be able to cooperate on this across a typical sector.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Should deploy app to use the pr api


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Fixes [AB#24008](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/24008)
