### PR TITLE
Profile Sync function -  External personnel improvements

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Extensions/FusionPersonProfileExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/FusionPersonProfileExtensions.cs
@@ -7,8 +7,12 @@ namespace Fusion.Resources.Domain
     {
         public static DbAzureAccountStatus GetDbAccountStatus(this FusionPersonProfile profile)
         {
-            if (profile.AzureUniqueId.HasValue && profile.InvitationStatus == null)
-                return DbAzureAccountStatus.Available;
+            if (profile.AzureUniqueId.HasValue && profile.InvitationStatus is null)
+            {
+                // External accounts should have a invitation status.
+                return profile.AccountType == FusionAccountType.External ? DbAzureAccountStatus.NoAccount : DbAzureAccountStatus.Available;
+            }
+
 
             return profile.InvitationStatus switch
             {

--- a/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
@@ -59,6 +59,7 @@ namespace Fusion.Resources.Domain.Services
                 resolvedPerson.Name = profile.Name;
                 resolvedPerson.Phone = profile.MobilePhone ?? string.Empty;
                 resolvedPerson.PreferredContractMail = profile.PreferredContactMail;
+                resolvedPerson.IsDeleted = false;
             }
             else
             {

--- a/src/backend/function/Fusion.Resources.Functions/Functions/ProfileSync.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/ProfileSync.cs
@@ -83,7 +83,7 @@ namespace Fusion.Resources.Functions.Functions
             }
 
             log.LogInformation($"Found {mailsToEnsureCount} profiles to ensure");
-            var ensureResult = await EnsurePeopleAsync(mailsToEnsure);
+            var ensureResult = await EnsurePersonsAsync(mailsToEnsure);
 
             var refreshFailed = false;
             var successCount = ensureResult.Count(x => x.Success);
@@ -119,7 +119,7 @@ namespace Fusion.Resources.Functions.Functions
             log.LogInformation("Profiles sync run successfully completed");
         }
 
-        private async Task<List<PersonValidationResult>> EnsurePeopleAsync(List<string> mailsToEnsure)
+        private async Task<List<PersonValidationResult>> EnsurePersonsAsync(List<string> mailsToEnsure)
         {
             var peopleRequest = new HttpRequestMessage(HttpMethod.Post, $"persons/ensure");
             peopleRequest.Headers.Add("api-version", "3.0");

--- a/src/backend/function/Fusion.Resources.Functions/Functions/ProfileSync.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/ProfileSync.cs
@@ -101,7 +101,9 @@ namespace Fusion.Resources.Functions.Functions
             foreach (var person in ensureResult)
             {
                 var resourcesPerson = personnel.Value.First(p => p.Mail == person.Identifier);
-                if (InvitationStatusMatches(person.Person?.InvitationStatus, resourcesPerson.AzureAdStatus)) continue;
+                // Person with no change in invitation status or azure unique id may be skipped for now.
+                // External personnel may receive a new account in azure. Check both for changes in invitation status and azure unique identifier.
+                if (InvitationStatusMatches(person.Person?.InvitationStatus, resourcesPerson.AzureAdStatus) && person.Person?.AzureUniqueId == resourcesPerson.AzureUniquePersonId) continue;
 
                 log.LogInformation($"Detected change in profile with identifier '{resourcesPerson.Mail}'. Initiating refresh.");
                 var refreshResponse = await resourcesClient.PostAsJsonAsync($"resources/personnel/{resourcesPerson.Mail}/refresh", new { userRemoved = !person.Success });
@@ -156,7 +158,8 @@ namespace Fusion.Resources.Functions.Functions
 
         public class Person
         {
-            public string Mail { get; set; }
+            public Guid? AzureUniqueId { get; set; }
+            public string? Mail { get; set; }
             public InvitationStatus? InvitationStatus { get; set; }
         }
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Azure function which synchronizes profiles does not properly consider removed profiles.
* When ensuring profiles, we currently only update profiles for successfully ensured profiles. Should include all.
* Expired profiles not ensured, should be considered and processed when updating/synchronizing external personnel.
* An external person without invitationstatus should not be considered available, but without an account.

Work item:
[AB#23690](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/23690)

~~Depends on:[AB#24244](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/24244)~~ Already COMPLETED & Deployed




**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

