### PR TITLE
API - Don't send notification to task owner for enterprise positions

### DIFF
--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Domain.Notifications.InternalRequests;
 
 namespace Fusion.Resources.Logic.Commands
@@ -46,10 +47,21 @@ namespace Fusion.Resources.Logic.Commands
                     await resourcesDb.SaveChangesAsync();
 
                     await mediator.Publish(new RequestInitialized(dbRequest.Id, dbRequest.Type, dbRequest.SubType, request.Editor.Person));
-                    await mediator.Publish(new InternalRequestNotifications.AssignedDepartment(dbRequest.Id));
+
+                    if (ShouldDispatchNotification(dbRequest))
+                    {
+                        await mediator.Publish(new InternalRequestNotifications.AssignedDepartment(dbRequest.Id));
+                    }
                 }
 
+                private static bool ShouldDispatchNotification(DbResourceAllocationRequest dbRequest)
+                {
+                    // Should not notify for enterprise requests
+                    if (string.Equals(dbRequest.SubType, "enterprise", StringComparison.OrdinalIgnoreCase))
+                        return false;
 
+                    return true;
+                }
             }
 
         }

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Domain.Notifications.InternalRequests;
+using Fusion.Resources.Logic.Workflows;
 
 namespace Fusion.Resources.Logic.Commands
 {
@@ -57,7 +58,7 @@ namespace Fusion.Resources.Logic.Commands
                 private static bool ShouldDispatchNotification(DbResourceAllocationRequest dbRequest)
                 {
                     // Should not notify for enterprise requests
-                    if (string.Equals(dbRequest.SubType, "enterprise", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(dbRequest.SubType, AllocationEnterpriseWorkflowV1.SUBTYPE, StringComparison.OrdinalIgnoreCase))
                         return false;
 
                     return true;


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When a position is marked as enterprise position, and enterprise personnel is added and auto approved, there should not be sent a notification to task owner due to auto approval.

Starting the workflow should not dispatch AssignedDepartment notification for enterprise requests. 

[AB#24980](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/24980)


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

