### PR TITLE
API - Add option to add scheduled enqueue time for service bus message

### DIFF
--- a/src/backend/api/Fusion.Resources.Application/ServiceBus/IQueueSender.cs
+++ b/src/backend/api/Fusion.Resources.Application/ServiceBus/IQueueSender.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Fusion.Resources
 {
     public interface IQueueSender
     {
         Task SendMessageAsync(QueuePath queue, object message);
+        Task SendMessageDelayedAsync(QueuePath queue, object message, int delayInSeconds);
     }
 
 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
@@ -59,6 +59,7 @@ namespace Fusion.Resources.Api.Tests.Fixture
             roleClientMock = new RolesClientMock();
             queueMock = new Mock<IQueueSender>();
             queueMock.Setup(c => c.SendMessageAsync(It.IsAny<QueuePath>(), It.IsAny<object>())).Returns(Task.CompletedTask);
+            queueMock.Setup(c => c.SendMessageDelayedAsync(It.IsAny<QueuePath>(), It.IsAny<object>(), It.IsAny<int>())).Returns(Task.CompletedTask);
 
             EnsureDatabase();
         }
@@ -103,8 +104,8 @@ namespace Fusion.Resources.Api.Tests.Fixture
                 services.TryRemoveImplementationService("OrgEventReceiver");
                 services.TryRemoveImplementationService("ContextEventReceiver");
                 services.TryRemoveImplementationService<ICompanyResolver>();
-                
-                if(isMemorycacheDisabled)
+
+                if (isMemorycacheDisabled)
                 {
                     services.TryRemoveImplementationService<IMemoryCache>();
                     services.AddScoped<IMemoryCache, AlwaysEmptyCache>();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -97,7 +97,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync($"/projects/{projectId}/requests", new
             {
                 type = "normal",
-                subType ="direct",
+                subType = "direct",
                 orgPositionId = position.Id,
                 orgPositionInstanceId = position.Instances.Last().Id
             }, new
@@ -127,7 +127,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync($"/projects/{newTestProject.Project.ProjectId}/requests", new
             {
                 type = "normal",
-                subType ="direct",
+                subType = "direct",
                 orgPositionId = position.Id,
                 orgPositionInstanceId = position.Instances.Last().Id
             }, new { });
@@ -144,7 +144,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests", new
             {
                 type = "normal",
-                subType ="direct",
+                subType = "direct",
                 orgPositionId = position.Id,
                 orgPositionInstanceId = position.Instances.Last().Id
             });
@@ -191,7 +191,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests", new
             {
                 type = "normal",
-                subType ="direct",
+                subType = "direct",
                 orgPositionId = position.Id,
                 orgPositionInstanceId = position.Instances.Last().Id,
                 assignedDepartment = department
@@ -199,7 +199,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeSuccessfull();
             response.Value.AssignedDepartment.Should().Be(department);
         }
-       
+
         [Fact]
         public async Task DirectRequest_Create_ShouldBeAbleToProposePersonDirectly()
         {
@@ -210,7 +210,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests", new
             {
                 type = "normal",
-                subType ="direct",
+                subType = "direct",
                 orgPositionId = position.Id,
                 orgPositionInstanceId = position.Instances.Last().Id,
                 proposedPersonAzureUniqueId = proposedPerson.AzureUniqueId
@@ -234,7 +234,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests/{directRequest.Id}/start", null);
             response.Should().BeSuccessfull();
         }
-        
+
         [Theory]
         [InlineData("isDraft", false)]
         [InlineData("state", "created")]
@@ -262,7 +262,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var proposedPerson = fixture.AddProfile(FusionAccountType.Employee);
             proposedPerson.FullDepartment = "TST DPT 123";
 
-            var request = await Client.CreateDefaultRequestAsync(testProject, 
+            var request = await Client.CreateDefaultRequestAsync(testProject,
                 r => r.AsTypeDirect().WithProposedPerson(proposedPerson).WithAssignedDepartment(null)
             );
 
@@ -335,7 +335,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task DirectRequest_Approval_ShouldBeSuccessful_WhenApproving()
         {
             using var adminScope = fixture.AdminScope();
-            
+
             await Client.StartProjectRequestAsync(testProject, directRequest.Id);
 
             await FastForward_ProposedRequest();
@@ -368,7 +368,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             await FastForward_ApprovalRequest();
 
-            fixture.ApiFactory.queueMock.Verify(q => q.SendMessageAsync(QueuePath.ProvisionPosition, It.Is<ProvisionPositionMessageV1>(q => q.RequestId == directRequest.Id)), Times.Once);
+            fixture.ApiFactory.queueMock.Verify(q => q.SendMessageDelayedAsync(QueuePath.ProvisionPosition,  It.Is<ProvisionPositionMessageV1>(q => q.RequestId == directRequest.Id), It.IsAny<int>()), Times.Once);
         }
 
         [Fact]

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -96,7 +96,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeBadRequest();
         }
 
-        
+
 
         [Fact]
         public async Task NormalRequest_Create_ShouldGetNewNumber()
@@ -270,7 +270,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             var department = "ABC DEF";
             LineOrgServiceMock.AddDepartment("ABC", new[] { department });
-            
+
             using var adminScope = fixture.AdminScope();
 
             var position = testProject.AddPosition()
@@ -446,7 +446,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             await FastForward_ApprovalRequest();
 
-            fixture.ApiFactory.queueMock.Verify(q => q.SendMessageAsync(QueuePath.ProvisionPosition, It.Is<ProvisionPositionMessageV1>(q => q.RequestId == normalRequest.Id)), Times.Once);
+            fixture.ApiFactory.queueMock.Verify(q => q.SendMessageDelayedAsync(QueuePath.ProvisionPosition, It.Is<ProvisionPositionMessageV1>(q => q.RequestId == normalRequest.Id), It.IsAny<int>()), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
* Implement delayed service bus message sender, and use this option when enqueueing provisioning request.

[AB#25126](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/25126)

**Testing:**
- [ ] ~~Can be tested~~
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

