### PR TITLE
API - ExternalPersonnel handle/expose properties indicating users deleted in azure

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiContractPersonnel.cs
@@ -27,6 +27,9 @@ namespace Fusion.Resources.Api.Controllers
             Created = personnel.Created;
             Updated = personnel.Updated;
 
+            IsDeleted = personnel.IsDeleted;
+            Deleted = personnel.Deleted;
+
             Positions = personnel.Positions?.Select(p => new ApiPositionInstanceReference(p)).ToList();
             Requests = personnel.Requests?.Select(r => new ApiRequestReference(r)).ToList();
         }
@@ -58,6 +61,8 @@ namespace Fusion.Resources.Api.Controllers
         public DateTimeOffset Created { get; set; }
         public DateTimeOffset? Updated { get; set; }
 
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
 
 
         public List<ApiPositionInstanceReference>? Positions { get; set; }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using Fusion.Resources.Logic.Commands;
 
 namespace Fusion.Resources.Api.Controllers
 {
@@ -22,6 +23,8 @@ namespace Fusion.Resources.Api.Controllers
             LinkedInProfile = person.LinkedInProfile;
             PreferredContactMail = person.PreferredContactMail;
             AzureAdStatus = Enum.Parse<ApiAccountStatus>($"{person.AzureAdStatus}", true);
+            IsDeleted = person.IsDeleted;
+            Deleted = person.Deleted;
             Disciplines = person.Disciplines?.Select(d => new ApiPersonnelDiscipline(d)).ToList() ?? new List<ApiPersonnelDiscipline>();
         }
 
@@ -47,6 +50,8 @@ namespace Fusion.Resources.Api.Controllers
         public ApiAccountStatus AzureAdStatus { get; set; }
 
         public bool HasCV { get; set; }
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
 
         public List<ApiPersonnelDiscipline> Disciplines { get; set; }
     }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiExternalPersonnelPerson.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using Fusion.Resources.Logic.Commands;
 
 namespace Fusion.Resources.Api.Controllers
 {

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
@@ -38,6 +38,7 @@ namespace Fusion.Resources.Database.Entities
         public string? LinkedInProfile { get; set; }
 
         public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
         public ICollection<DbPersonnelDiscipline> Disciplines { get; set; } = null!;
 
         internal static void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20220114134754_ExternalPersonnel DELETED property added.Designer.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20220114134754_ExternalPersonnel DELETED property added.Designer.cs
@@ -4,14 +4,16 @@ using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Fusion.Resources.Database.Migrations
 {
     [DbContext(typeof(ResourcesDbContext))]
-    partial class ResourcesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220114134754_ExternalPersonnel DELETED property added")]
+    partial class ExternalPersonnelDELETEDpropertyadded
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20220114134754_ExternalPersonnel DELETED property added.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20220114134754_ExternalPersonnel DELETED property added.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fusion.Resources.Database.Migrations
+{
+    public partial class ExternalPersonnelDELETEDpropertyadded : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "Deleted",
+                table: "ExternalPersonnel",
+                type: "datetimeoffset",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "ExternalPersonnel");
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryContractPersonnel.cs
@@ -26,7 +26,8 @@ namespace Fusion.Resources.Domain
             DawinciCode = item.Person.DawinciCode;
             LinkedInProfile = item.Person.LinkedInProfile;
             PreferredContactMail = item.Person.PreferredContractMail;
-
+            IsDeleted = item.Person.IsDeleted;
+            Deleted = item.Person.Deleted;
             Created = item.Created;
             Updated = item.Updated;
             CreatedBy = new QueryPerson(item.CreatedBy);
@@ -63,6 +64,8 @@ namespace Fusion.Resources.Domain
         public QueryPerson? UpdatedBy { get; set; }
         public DateTimeOffset Created { get; set; }
         public DateTimeOffset? Updated { get; set; }
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
 
         //public QueryProject Project { get; set; }
         //public QueryContract Contract { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryExternalPersonnelPerson.cs
@@ -22,6 +22,8 @@ namespace Fusion.Resources.Domain
             DawinciCode = item.DawinciCode;
             LinkedInProfile = item.LinkedInProfile;
             PreferredContactMail = item.PreferredContractMail;
+            IsDeleted = item.IsDeleted;
+            Deleted = item.Deleted;
 
             if (item.Disciplines == null)
                 throw new ArgumentNullException(nameof(item.Disciplines), "Disciplines must be included or initialized on the entity when constructing query model");
@@ -41,6 +43,8 @@ namespace Fusion.Resources.Domain
         public string? PreferredContactMail { get; set; }
 
         public DbAzureAccountStatus AzureAdStatus { get; set; }
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
 
         public List<QueryPersonnelDiscipline> Disciplines { get; set; }
     }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnel.cs
@@ -81,6 +81,7 @@ namespace Fusion.Resources.Domain
                         m.MapField("name", p => p.Person.Name);
                         m.MapField("phoneNumber", p => p.Person.Phone);
                         m.MapField("created", p => p.Created);
+                        m.MapField("isDeleted", p => p.Person.IsDeleted);
                     });
 
                 var items = await itemQuery

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetContractPersonnelRequests.cs
@@ -112,6 +112,7 @@ namespace Fusion.Resources.Domain.Queries
                         m.MapField("person.firstName", e => e.Person.Person.FirstName);
                         m.MapField("person.lastName", e => e.Person.Person.LastName);
                         m.MapField("person.azureAdStatus", e => e.Person.Person.AccountStatus);
+                        m.MapField("person.isDeleted", e => e.Person.Person.IsDeleted);
                     });
                 }
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetExternalPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetExternalPersonnel.cs
@@ -36,6 +36,7 @@ namespace Fusion.Resources.Domain
                     query = query.ApplyODataFilters(request.Query, mapper =>
                     {
                         mapper.MapField("azureAdStatus", p => p.AccountStatus);
+                        mapper.MapField("isDeleted", p => p.IsDeleted);
                         mapper.MapField("name", p => p.Name);
                         mapper.MapField("phoneNumber", p => p.Phone);
                     });

--- a/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
@@ -66,6 +66,7 @@ namespace Fusion.Resources.Domain.Services
                 resolvedPerson.Phone = profile.MobilePhone ?? string.Empty;
                 resolvedPerson.PreferredContractMail = profile.PreferredContactMail;
                 resolvedPerson.IsDeleted = false;
+                resolvedPerson.Deleted = null;
 
             }
             else
@@ -73,9 +74,10 @@ namespace Fusion.Resources.Domain.Services
                 // Refreshed person exists in resources but not anymore as a valid profile in PEOPLE service
                 resolvedPerson.AccountStatus = DbAzureAccountStatus.NoAccount;
                 if (considerRemovedProfile)
+                {
                     resolvedPerson.IsDeleted = true;
-
-
+                    resolvedPerson.Deleted = DateTimeOffset.UtcNow;
+                }
             }
 
             var changedProperties = resourcesDb.Entry(resolvedPerson).Properties

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnel.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnel.cs
@@ -13,5 +13,8 @@ namespace Fusion.Resources.Api.Tests
         public string Name { get; set; }
         public string PhoneNumber { get; set; }
         public string PreferredContactMail { get; set; }
+
+        public bool IsDeleted { get; set; }
+        public DateTimeOffset? Deleted { get; set; }
     }
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
* Added DELETED property to DBExternalPersonnel
* Added IsDeleted & DELETED to query models (QueryContractPersonnel/QueryExternalPersonnelPerson)
* Added IsDeleted & DELETED to api models/odata filters (ApiContractPersonnel/ApiExternalPersonnelPerson)
* Added DELETED to be updated during profile refresh (IsDeleted already being updated)

[AB#25133](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/25133)

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

