### PR TITLE
Add `ChangeRequestStatus` to Person Position Timeline

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/ApiModels/ApiInternalPersonnelPerson.cs
@@ -1,4 +1,5 @@
 ﻿using Fusion.Integration.Profile;
+using Fusion.Resources.Api.Controllers.Requests.ApiModels;
 using Fusion.Resources.Domain;
 using System;
 using System.Collections.Generic;
@@ -155,6 +156,7 @@ namespace Fusion.Resources.Api.Controllers
                 BasePosition = new ApiBasePosition(pos.BasePosition);
 
                 HasChangeRequest = pos.HasChangeRequest;
+                ChangeRequestStatus = pos.ChangeRequestStatus is not null ? new ApiRequestStatus(pos.ChangeRequestStatus) : null;
             }
 
             public Guid PositionId { get; set; }
@@ -173,6 +175,7 @@ namespace Fusion.Resources.Api.Controllers
             public ApiProjectReference Project { get; set; } = null!;
 
             public bool HasChangeRequest { get; set; }
+            public ApiRequestStatus? ChangeRequestStatus { get; }
         }
     }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiRequestStatus.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiRequestStatus.cs
@@ -1,0 +1,19 @@
+﻿using Fusion.Resources.Domain.Models;
+using System;
+
+namespace Fusion.Resources.Api.Controllers.Requests.ApiModels
+{
+    public class ApiRequestStatus
+    {
+        public ApiRequestStatus(QueryRequestStatus requestStatus)
+        {
+            Id = requestStatus.Id;
+            State = requestStatus.State;
+            IsDraft = requestStatus.IsDraft;
+        }
+
+        public Guid Id { get; }
+        public string? State { get; }
+        public bool IsDraft { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelPosition.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryPersonnelPosition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Fusion.Resources.Domain.Models;
+using System;
 
 namespace Fusion.Resources.Domain
 {
@@ -25,5 +26,6 @@ namespace Fusion.Resources.Domain
         public DateTime? AllocationUpdated { get; set; }
 
         public bool HasChangeRequest { get; set; }
+        public QueryRequestStatus? ChangeRequestStatus { get; internal set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryRequestStatus.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryRequestStatus.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Fusion.Resources.Domain.Models
+{
+    public class QueryRequestStatus
+    {
+        public QueryRequestStatus(QueryResourceAllocationRequest changeRequest)
+        {
+            Id = changeRequest.RequestId;
+            State = changeRequest.State;
+            IsDraft = changeRequest.IsDraft;
+        }
+
+        public Guid Id { get; }
+        public string? State { get; }
+        public bool IsDraft { get; } = false;
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -81,7 +81,7 @@ namespace Fusion.Resources.Domain
 
             public async Task<IEnumerable<QueryInternalPersonnelPerson>> Handle(GetDepartmentPersonnel request, CancellationToken cancellationToken)
             {
-                var departmentRequests = await GetProposedRequestsAsync(request.Department);
+                var departmentRequests = await GetPendingRequests(request.Department);
                 var requestsWithStateNullOrCreated = await GetRequestsWithStateNullOrCreatedAsync(request.Department);
                 var departmentPersonnel = await GetDepartmentFromSearchIndexAsync(request.Department, request.includeSubdepartments, requestsWithStateNullOrCreated);
                 var departmentAbsence = await GetPersonsAbsenceAsync(departmentPersonnel.Select(p => p.AzureUniqueId));
@@ -134,7 +134,7 @@ namespace Fusion.Resources.Domain
                 return departmentPersonnel;
             }
 
-            private async Task<Dictionary<Guid, List<QueryResourceAllocationRequest>>> GetProposedRequestsAsync(string department)
+            private async Task<Dictionary<Guid, List<QueryResourceAllocationRequest>>> GetPendingRequests(string department)
             {
                 var command = new GetResourceAllocationRequests()
                     .WithAssignedDepartment(department)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnelPerson.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnelPerson.cs
@@ -23,9 +23,19 @@ namespace Fusion.Resources.Api.Tests
 
     public class TestPersonPosition
     {
+        public Guid PositionId { get; set; }
+
         public DateTime AppliesFrom { get; set; }
         public DateTime AppliesTo { get; set; }
+        public bool HasChangeRequest { get; set; }
+        public TestRequestStatus ChangeRequestStatus { get; set; }
+    }
 
+    public class TestRequestStatus
+    {
+        public Guid Id { get; set; }
+        public string State { get; set; }
+        public bool IsDraft { get; set; }
     }
 
     public class Employmentstatus

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -703,7 +703,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
 
             var position = testProject.AddPosition()
-                .WithEnsuredFutureInstances()
+                .WithInstances(x => x.AddInstance(new DateTime(2000, 01, 01), TimeSpan.FromDays(365)))
                 .WithAssignedPerson(user);
 
             var instance = position.Instances.First();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -703,7 +703,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
 
             var position = testProject.AddPosition()
-                .WithEnsuredFutureInstances()
+                .WithInstances(x => x.AddInstance(new DateTime(2023,01,01), TimeSpan.FromDays(365)))
                 .WithAssignedPerson(user);
 
             var instance = position.Instances.First();
@@ -841,7 +841,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
             request = await Client.CreateDefaultRequestAsync(testProject, positionSetup: pos => pos.WithInstances(x =>
             {
-                x.AddInstance(new DateTime(2020, 03, 02), TimeSpan.FromDays(15));
+                x.AddInstance(new DateTime(2000, 01, 02), TimeSpan.FromDays(15));
             }));
             await Client.AssignDepartmentAsync(request.Id, user.FullDepartment);
             await Client.ProposePersonAsync(request.Id, user);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -703,7 +703,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
 
             var position = testProject.AddPosition()
-                .WithInstances(x => x.AddInstance(new DateTime(2023,01,01), TimeSpan.FromDays(365)))
+                .WithEnsuredFutureInstances()
                 .WithAssignedPerson(user);
 
             var instance = position.Instances.First();
@@ -841,7 +841,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
             request = await Client.CreateDefaultRequestAsync(testProject, positionSetup: pos => pos.WithInstances(x =>
             {
-                x.AddInstance(new DateTime(2000, 01, 02), TimeSpan.FromDays(15));
+                x.AddInstance(new DateTime(2020, 03, 02), TimeSpan.FromDays(15));
             }));
             await Client.AssignDepartmentAsync(request.Id, user.FullDepartment);
             await Client.ProposePersonAsync(request.Id, user);


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
[AB#24965](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/24965)
- Add `ChangeRequestStatus` property on personnel position classes to enable frontend to display different statuses differently


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

