### PR TITLE
Delete actions when request is provisioned

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
@@ -24,6 +24,9 @@ namespace Fusion.Resources.Api.Controllers.Requests
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
 
+            if (requestItem.IsCompleted)
+                return FusionApiError.InvalidOperation("ActionsDisabled", "Cannot add action on closed request");
+
             #region Authorization
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {

--- a/src/backend/api/Fusion.Resources.Logic/DeleteActionsHandler.cs
+++ b/src/backend/api/Fusion.Resources.Logic/DeleteActionsHandler.cs
@@ -1,0 +1,29 @@
+﻿using Fusion.Resources.Database;
+using Fusion.Resources.Logic.Events;
+using MediatR;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class DeleteActionsHandler : INotificationHandler<RequestProvisioned>
+{
+    private readonly ResourcesDbContext resourcesDb;
+
+    public DeleteActionsHandler(ResourcesDbContext resourcesDb)
+    {
+        this.resourcesDb = resourcesDb;
+    }
+    public async Task Handle(RequestProvisioned notification, CancellationToken cancellationToken)
+    {
+        await DeleteActions(notification.RequestId, cancellationToken);
+    }
+
+    private Task DeleteActions(Guid requestId, CancellationToken cancellationToken)
+    {
+        resourcesDb.RequestActions.RemoveRange(
+            resourcesDb.RequestActions.Where(c => c.RequestId == requestId)
+        );
+        return resourcesDb.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestActionTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestActionTests.cs
@@ -155,7 +155,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             fixture.EnsureDepartment(testDepartment);
             var request = await adminClient.CreateDefaultRequestAsync(testProject, x => x.WithAssignedDepartment(testDepartment));
             await adminClient.StartProjectRequestAsync(testProject, request.Id);
-            //await adminClient.ResourceOwnerApproveAsync(normalRequest.AssignedDepartment, request.Id);
             await adminClient.TaskOwnerApproveAsync(testProject, request.Id);
             await adminClient.ProvisionRequestAsync(request.Id);
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
[AB#25080](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/25080)

Implement same functionality for follow-up actions as notes.
- Actions are cleared when request is completed.
- Adding new actions after completion is no longer permitted.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

