### PR TITLE
API - ContractPersonnel - Replace person

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/PersonnelController.cs
@@ -421,7 +421,10 @@ namespace Fusion.Resources.Api.Controllers
                     });
             });
 
-            return authResult.Unauthorized ? authResult.CreateForbiddenResponse() : Ok();
+            if (authResult.Success)
+                Response.Headers.Add("Allow", "POST");
+
+            return NoContent();
         }
 
         [HttpPost("/projects/{projectIdentifier}/contracts/{contractIdentifier}/resources/personnel/{personIdentifier}/replace")]

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/Requests/ReplaceContractPersonnelRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/Requests/ReplaceContractPersonnelRequest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentValidation;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ReplaceContractPersonnelRequest
+    {
+        public string UPN { get; set; } = null!;
+        public Guid AzureUniquePersonId { get; set; }
+
+        #region Validation
+
+        public class Validator : AbstractValidator<ReplaceContractPersonnelRequest>
+        {
+            public Validator()
+            {
+                RuleFor(x => x.UPN).NotEmpty();
+                RuleFor(x => x.UPN).NotContainScriptTag();
+                RuleFor(x => x.UPN).MaximumLength(200);
+
+                RuleFor(x => x.AzureUniquePersonId).NotEmpty();
+            }
+
+        }
+
+        #endregion
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/Requests/ReplaceContractPersonnelRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/Requests/ReplaceContractPersonnelRequest.cs
@@ -14,10 +14,7 @@ namespace Fusion.Resources.Api.Controllers
         {
             public Validator()
             {
-                RuleFor(x => x.UPN).NotEmpty();
-                RuleFor(x => x.UPN).NotContainScriptTag();
-                RuleFor(x => x.UPN).MaximumLength(200);
-
+                RuleFor(x => x.UPN).NotEmpty().NotContainScriptTag().MaximumLength(200);
                 RuleFor(x => x.AzureUniquePersonId).NotEmpty();
             }
 

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbContractPersonnelReplacement.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbContractPersonnelReplacement.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fusion.Resources.Database.Entities
+{
+    public class DbContractPersonnelReplacement
+    {
+        public Guid Id { get; set; }
+
+        public Guid ProjectId { get; set; }
+        public Guid ContractId { get; set; }
+        public string Message { get; set; } = null!;
+
+        [MaxLength(50)]
+        public string? ChangeType { get; set; }
+        [MaxLength(200)] 
+        public string? UPN { get; set; }
+        [MaxLength(200)] 
+        public string? FromPerson { get; set; }
+        [MaxLength(200)] 
+        public string? ToPerson { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+        [MaxLength(200)] 
+        public string? CreatedBy { get; set; }
+
+        public static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DbContractPersonnelReplacement>(x =>
+            {
+                x.HasIndex(e => new { e.ProjectId, e.ContractId }).IsClustered(false)
+                    .IncludeProperties(e => new
+                    {
+                        e.UPN,
+                        e.FromPerson,
+                        e.ToPerson,
+                        e.ChangeType,
+                        ReplacedTimestamp = e.Created,
+                        ReplacedBy = e.CreatedBy
+                    });
+            });
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
@@ -44,6 +44,8 @@ namespace Fusion.Resources.Database.Entities
         public DateTimeOffset? Deleted { get; set; }
         public ICollection<DbPersonnelDiscipline> Disciplines { get; set; } = null!;
 
+        public string? PersonIdReplacements { get; set; }
+
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<DbExternalPersonnelPerson>(entity =>

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbExternalPersonnelPerson.cs
@@ -44,6 +44,10 @@ namespace Fusion.Resources.Database.Entities
         public DateTimeOffset? Deleted { get; set; }
         public ICollection<DbPersonnelDiscipline> Disciplines { get; set; } = null!;
 
+        /// <summary>
+        /// This property is used for historic person identifiers.
+        /// Persons may be replaced multiple times, and can contain multiple personIds separated by comma
+        /// </summary>
         public string? PersonIdReplacements { get; set; }
 
         internal static void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20220127125233_ContractPersonnelReplacementAuditing.Designer.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20220127125233_ContractPersonnelReplacementAuditing.Designer.cs
@@ -4,14 +4,16 @@ using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Fusion.Resources.Database.Migrations
 {
     [DbContext(typeof(ResourcesDbContext))]
-    partial class ResourcesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220127125233_ContractPersonnelReplacementAuditing")]
+    partial class ContractPersonnelReplacementAuditing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/api/Fusion.Resources.Database/Migrations/20220127125233_ContractPersonnelReplacementAuditing.cs
+++ b/src/backend/api/Fusion.Resources.Database/Migrations/20220127125233_ContractPersonnelReplacementAuditing.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Fusion.Resources.Database.Migrations
+{
+    public partial class ContractPersonnelReplacementAuditing : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PersonIdReplacements",
+                table: "ExternalPersonnel",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ContractPersonnelReplacementChanges",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ProjectId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ContractId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ChangeType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    UPN = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    FromPerson = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    ToPerson = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ContractPersonnelReplacementChanges", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContractPersonnelReplacementChanges_ProjectId_ContractId",
+                table: "ContractPersonnelReplacementChanges",
+                columns: new[] { "ProjectId", "ContractId" })
+                .Annotation("SqlServer:Clustered", false)
+                .Annotation("SqlServer:Include", new[] { "UPN", "FromPerson", "ToPerson", "ChangeType", "Created", "CreatedBy" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ContractPersonnelReplacementChanges");
+
+            migrationBuilder.DropColumn(
+                name: "PersonIdReplacements",
+                table: "ExternalPersonnel");
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Database/ResourcesDbContext.cs
+++ b/src/backend/api/Fusion.Resources.Database/ResourcesDbContext.cs
@@ -46,6 +46,8 @@ namespace Fusion.Resources.Database
         public DbSet<DbRequestAction> RequestActions { get; set; }
         public DbSet<DbConversationMessage> RequestConversations { get; set; }
 
+        public DbSet<DbContractPersonnelReplacement> ContractPersonnelReplacementChanges { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             DbContractPersonnel.OnModelCreating(modelBuilder);
@@ -63,6 +65,7 @@ namespace Fusion.Resources.Database
             DbDepartmentResponsible.OnModelCreating(modelBuilder);
             DbRequestAction.OnModelCreating(modelBuilder);
             DbConversationMessage.OnModelCreating(modelBuilder);
+            DbContractPersonnelReplacement.OnModelCreating(modelBuilder);
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateContractPersonnelReplacementAudit.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/CreateContractPersonnelReplacementAudit.cs
@@ -1,0 +1,61 @@
+﻿using MediatR;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+
+namespace Fusion.Resources.Domain.Commands
+{
+
+    public class CreateContractPersonnelReplacementAudit : TrackableRequest
+    {
+
+        public CreateContractPersonnelReplacementAudit(Guid projectId, Guid contractId, string message, string editor)
+        {
+            ProjectId = projectId;
+            ContractId = contractId;
+            Message = message;
+            ReplacedBy = editor;
+        }
+        public Guid ProjectId { get; }
+        public Guid ContractId { get; }
+        public string Message { get; }
+        public string ReplacedBy { get; }
+        public string? ChangeType { get; set; }
+        public string? UPN { get; set; }
+        public string? FromPerson { get; set; }
+        public string? ToPerson { get; set; }
+
+        public class Handler : AsyncRequestHandler<CreateContractPersonnelReplacementAudit>
+        {
+            private readonly ResourcesDbContext db;
+
+            public Handler(ResourcesDbContext db)
+            {
+                this.db = db;
+            }
+
+            protected override async Task Handle(CreateContractPersonnelReplacementAudit request, CancellationToken cancellationToken)
+            {
+                var change = new DbContractPersonnelReplacement
+                {
+                    Id = Guid.NewGuid(),
+                    ProjectId = request.ProjectId,
+                    ContractId = request.ContractId,
+                    UPN = request.UPN,
+                    FromPerson = request.FromPerson,
+                    ToPerson = request.ToPerson,
+                    ChangeType = request.ChangeType,
+                    Message = request.Message,
+                    CreatedBy = request.ReplacedBy,
+                    Created = DateTimeOffset.UtcNow
+                };
+
+                db.Add(change);
+
+                await db.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
@@ -98,6 +98,9 @@ namespace Fusion.Resources.Domain.Commands
             {
                 try
                 {
+                    if (string.Equals(request.FromPerson.OriginalIdentifier, request.ToPerson.OriginalIdentifier, StringComparison.OrdinalIgnoreCase))
+                        throw new InvalidOperationException($"Cannot replace person using personnel identifier '{request.ToPerson.OriginalIdentifier}'. Subject identifier same as target identifer");
+
                     if (existingPerson?.Person is null)
                         throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.FromPerson.OriginalIdentifier}'");
                     if (existingPerson.Person.IsDeleted == false)

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Fusion.Resources.Database.Entities;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Fusion.Resources.Domain.Commands
 {
@@ -39,16 +41,20 @@ namespace Fusion.Resources.Domain.Commands
             private readonly ResourcesDbContext resourcesDb;
             private readonly IMediator mediator;
             private readonly IProfileService profileService;
+            private readonly TelemetryClient telemetryClient;
 
-            public Handler(ResourcesDbContext resourcesDb, IMediator mediator, IProfileService profileService)
+            public Handler(ResourcesDbContext resourcesDb, IMediator mediator, IProfileService profileService, TelemetryClient telemetryClient)
             {
                 this.resourcesDb = resourcesDb;
                 this.mediator = mediator;
                 this.profileService = profileService;
+                this.telemetryClient = telemetryClient;
             }
 
             public async Task<QueryContractPersonnel> Handle(ReplaceContractPersonnel request, CancellationToken cancellationToken)
             {
+                var startTime = DateTimeOffset.UtcNow;
+
                 var existingPerson = await resourcesDb.ContractPersonnel
                     .GetById(request.OrgContractId, request.FromPerson)
                     .Include(cp => cp.Person)
@@ -62,7 +68,7 @@ namespace Fusion.Resources.Domain.Commands
 
                 existingPerson.Updated = DateTimeOffset.UtcNow;
                 existingPerson.UpdatedBy = request.Editor.Person;
-                
+
                 await resourcesDb.SaveChangesAsync();
 
 
@@ -72,36 +78,50 @@ namespace Fusion.Resources.Domain.Commands
                     var mail = new List<(Guid personnelId, string? preferredMail)> { new(newPerson.Id, existingPersonPreferredContractMail) };
                     await mediator.Send(new UpdateContractPersonnelContactMail(request.OrgContractId, mail));
                 }
-                
+
                 var returnItem = await mediator.Send(new GetContractPersonnelItem(request.OrgContractId, request.ToPerson));
+
+                var props = new Dictionary<string, string>
+                {
+                    {"UPN", request.ToUpn },
+                    {"FromPerson", request.FromPerson.OriginalIdentifier },
+                    {"ToPerson", request.ToPerson.OriginalIdentifier },
+                    {"OperationDuration",$"{startTime-DateTimeOffset.UtcNow}"},
+                    {"Editor",request.Editor.Person.Name}
+                };
+                telemetryClient.TrackTrace($"Replaced contract personnel on contract {request.OrgContractId}", SeverityLevel.Information, props);
+
                 return returnItem;
             }
 
-            private async Task<DbExternalPersonnelPerson> ValidatePersonAsync(ReplaceContractPersonnel request, DbContractPersonnel existingPerson)
+            private async Task<DbExternalPersonnelPerson> ValidatePersonAsync(ReplaceContractPersonnel request, DbContractPersonnel? existingPerson)
             {
-                if (existingPerson is null)
-                    throw new InvalidOperationException(
-                        $"Cannot locate person using personnel identifier '{request.FromPerson.OriginalIdentifier}'");
-                if (existingPerson.Person.IsDeleted == false)
-                    throw new InvalidOperationException(
-                        $"Cannot replace person using personnel identifier '{request.FromPerson.OriginalIdentifier}' when account is not expired");
+                try
+                {
+                    if (existingPerson?.Person is null)
+                        throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.FromPerson.OriginalIdentifier}'");
+                    if (existingPerson.Person.IsDeleted == false)
+                        throw new InvalidOperationException($"Cannot replace person using personnel identifier '{request.FromPerson.OriginalIdentifier}' when account is not expired");
 
-                var newPerson = await profileService.EnsureExternalPersonnelAsync(request.ToUpn, request.ToPerson,
-                    existingPerson.Person.FirstName, existingPerson.Person.LastName);
-                if (existingPerson.Person.Id == newPerson.Id)
-                    throw new InvalidOperationException(
-                        $"Cannot replace person using personnel identifier '{request.FromPerson.OriginalIdentifier}'. New account identified as existing account");
+                    var newPerson = await profileService.EnsureExternalPersonnelAsync(request.ToUpn, request.ToPerson, existingPerson.Person.FirstName, existingPerson.Person.LastName);
 
-                if (newPerson is null)
-                    throw new InvalidOperationException(
-                        $"Cannot locate person using personnel identifier '{request.ToPerson.OriginalIdentifier}'");
+                    if (newPerson is null)
+                        throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.ToPerson.OriginalIdentifier}'");
 
-                if (!request.ForceUpdate)
-                    if (!string.Equals(existingPerson.Person.UPN, newPerson.UPN, StringComparison.OrdinalIgnoreCase))
-                        throw new InvalidOperationException(
-                            $"Cannot update person having different UPN. Existing:{existingPerson.Person.UPN}, New:{newPerson.UPN}");
+                    if (existingPerson.Person.Id == newPerson.Id)
+                        throw new InvalidOperationException($"Cannot replace person using personnel identifier '{request.FromPerson.OriginalIdentifier}'. New account identified as existing account");
 
-                return newPerson!;
+                    if (!request.ForceUpdate)
+                        if (!string.Equals(existingPerson.Person.UPN, newPerson.UPN, StringComparison.OrdinalIgnoreCase))
+                            throw new InvalidOperationException($"Cannot update person having different UPN. Existing:{existingPerson.Person.UPN}, New:{newPerson.UPN}");
+
+                    return newPerson!;
+                }
+                catch (InvalidOperationException ioe)
+                {
+                    telemetryClient.TrackTrace(ioe.Message, SeverityLevel.Error);
+                    throw;
+                }
             }
         }
     }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
@@ -50,6 +50,8 @@ namespace Fusion.Resources.Domain.Commands
 
                 if (existingPerson is null)
                     throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.FromPerson.OriginalIdentifier}'");
+                if (existingPerson.Person.IsDeleted == false)
+                    throw new InvalidOperationException($"Cannot replace person using personnel identifier '{request.FromPerson.OriginalIdentifier}' when account is not expired");
 
                 var newPerson = await resourcesDb.ExternalPersonnel.GetById(request.ToPerson).FirstOrDefaultAsync();
 

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
@@ -70,6 +70,9 @@ namespace Fusion.Resources.Domain.Commands
                 existingPerson.Updated = DateTimeOffset.UtcNow;
                 existingPerson.UpdatedBy = request.Editor.Person;
 
+                await mediator.Send(new ReplaceProjectPositionInstancesAssignedPerson(request.OrgProjectId,
+                    request.OrgContractId, request.FromPerson, request.ToPerson));
+
                 await resourcesDb.SaveChangesAsync();
 
 
@@ -90,7 +93,7 @@ namespace Fusion.Resources.Domain.Commands
                     {"OperationDuration",$"{startTime-DateTimeOffset.UtcNow}"},
                     {"Editor",request.Editor.Person.Name}
                 };
-                telemetryClient.TrackTrace($"Replaced contract personnel on contract {request.OrgContractId}", SeverityLevel.Information, props);
+                telemetryClient.TrackTrace($"Replaced contract personnel on contract {request.OrgContractId} on project {request.OrgProjectId}", SeverityLevel.Information, props);
 
                 return returnItem;
             }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceContractPersonnel.cs
@@ -1,0 +1,77 @@
+﻿using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Commands
+{
+    public class ReplaceContractPersonnel : TrackableRequest<QueryContractPersonnel>
+    {
+        public ReplaceContractPersonnel(Guid projectId, Guid contractIdentifier, PersonnelId fromPerson, string toUpn, PersonnelId toPerson)
+        {
+            OrgProjectId = projectId;
+            OrgContractId = contractIdentifier;
+            FromPerson = fromPerson;
+            ToPerson = toPerson;
+        }
+
+        public ReplaceContractPersonnel WithForce(bool force)
+        {
+            ForceUpdate = force;
+            return this;
+        }
+
+        public Guid OrgContractId { get; }
+        public Guid OrgProjectId { get; }
+        public PersonnelId FromPerson { get; }
+        public PersonnelId ToPerson { get; }
+        public bool ForceUpdate { get; private set; }
+
+
+        public class Handler : IRequestHandler<ReplaceContractPersonnel, QueryContractPersonnel>
+        {
+            private readonly ResourcesDbContext resourcesDb;
+            private readonly IMediator mediator;
+
+            public Handler(ResourcesDbContext resourcesDb, IMediator mediator)
+            {
+                this.resourcesDb = resourcesDb;
+                this.mediator = mediator;
+            }
+
+            public async Task<QueryContractPersonnel> Handle(ReplaceContractPersonnel request, CancellationToken cancellationToken)
+            {
+                var existingPerson = await resourcesDb.ContractPersonnel
+                    .GetById(request.OrgContractId, request.FromPerson)
+                    .Include(cp => cp.Person)
+                    .FirstOrDefaultAsync();
+
+                if (existingPerson is null)
+                    throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.FromPerson.OriginalIdentifier}'");
+
+                var newPerson = await resourcesDb.ExternalPersonnel.GetById(request.ToPerson).FirstOrDefaultAsync();
+
+                if (newPerson is null)
+                    throw new InvalidOperationException($"Cannot locate person using personnel identifier '{request.ToPerson.OriginalIdentifier}'");
+
+                if (!request.ForceUpdate)
+                    if (!string.Equals(existingPerson.Person.UPN, newPerson.UPN, StringComparison.OrdinalIgnoreCase))
+                        throw new InvalidOperationException($"Cannot update person having different UPN. Existing:{existingPerson.Person.UPN}, New:{newPerson.UPN}");
+
+                existingPerson.Person = newPerson;
+
+                existingPerson.Updated = DateTimeOffset.UtcNow;
+                existingPerson.UpdatedBy = request.Editor.Person;
+
+
+                await resourcesDb.SaveChangesAsync();
+
+                var returnItem = await mediator.Send(new GetContractPersonnelItem(request.OrgContractId, request.ToPerson));
+                return returnItem;
+            }
+
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceProjectPositionInstancesAssignedPerson.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Personnel/ReplaceProjectPositionInstancesAssignedPerson.cs
@@ -1,0 +1,75 @@
+﻿using MediatR;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.ApiClients.Org;
+
+namespace Fusion.Resources.Domain.Commands
+{
+    public class ReplaceProjectPositionInstancesAssignedPerson : TrackableRequest
+    {
+        public ReplaceProjectPositionInstancesAssignedPerson(Guid projectId, Guid contractIdentifier, PersonnelId fromPerson, PersonnelId toPerson)
+        {
+            OrgProjectId = projectId;
+            OrgContractId = contractIdentifier;
+            FromPerson = fromPerson;
+            ToPerson = toPerson;
+        }
+        public Guid OrgContractId { get; }
+        public Guid OrgProjectId { get; }
+        public PersonnelId FromPerson { get; }
+        public PersonnelId ToPerson { get; }
+        
+        public class Handler : AsyncRequestHandler<ReplaceProjectPositionInstancesAssignedPerson>
+        {
+            private readonly IOrgApiClient client;
+
+            public Handler(IOrgApiClientFactory orgApi)
+            {
+               
+                this.client = orgApi.CreateClient(ApiClientMode.Application);
+            }
+
+            protected override async Task Handle(ReplaceProjectPositionInstancesAssignedPerson request, CancellationToken cancellationToken)
+            {
+                var draft = await CreateProvisionDraftAsync(request);
+
+                var positions = await client.GetContractPositionsV2Async(request.OrgProjectId, request.OrgContractId);
+
+                await ReplaceAssignedPersonOnRelevantPositionInstancesInDraftAsync(request, draft, positions);
+
+                await client.PublishAndWaitAsync(draft);
+            }
+
+            private async Task<ApiDraftV2> CreateProvisionDraftAsync(ReplaceProjectPositionInstancesAssignedPerson request)
+            {
+                return await client.CreateProjectDraftAsync(request.OrgProjectId, $"Assigned Person Replacement",
+                    $"Replacing assigned person from person [{request.FromPerson.OriginalIdentifier} to person {request.ToPerson.OriginalIdentifier}] on position instances on project[{request.OrgProjectId}], contract[{request.OrgContractId}]");
+            }
+
+            private async Task ReplaceAssignedPersonOnRelevantPositionInstancesInDraftAsync(ReplaceProjectPositionInstancesAssignedPerson request, ApiDraftV2 draft, List<ApiPositionV2> positions)
+            {
+                if (request.FromPerson.UniqueId is null || request.ToPerson.UniqueId is null)
+                    throw new InvalidOperationException("Cannot update position instance without existing from-/to- person arguments.");
+
+                foreach (var position in positions)
+                {
+                    foreach (var instance in position.Instances.Where(y => y.AssignedPerson?.AzureUniqueId == request.FromPerson.UniqueId))
+                    {
+                        var instancePatchRequest = new JObject();
+                        instancePatchRequest.SetPropertyValue<ApiPositionInstanceV2>(i => i.AssignedPerson, new ApiPersonV2 { AzureUniqueId = request.ToPerson.UniqueId });
+
+                        var url = $"/projects/{request.OrgProjectId}/drafts/{draft.Id}/positions/{position.Id}/instances/{instance.Id}?api-version=2.0";
+                        var updateResp = await client.PatchAsync<ApiPositionInstanceV2>(url, instancePatchRequest);
+
+                        if (!updateResp.IsSuccessStatusCode)
+                            throw new OrgApiError(updateResp.Response, updateResp.Content);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
@@ -80,7 +80,7 @@ namespace Fusion.Resources
 
             return reportsTo.Value.ReportPositions != null && reportsTo.Value.Path != null
                 ? reportsTo.Value.ReportPositions
-                    .OrderBy(pos => Array.IndexOf((Array) reportsTo.Value.Path, pos.Id))
+                    .OrderBy(pos => Array.IndexOf((Array)reportsTo.Value.Path, pos.Id))
                     .ToList()
                 : new List<ApiPositionV2>();
         }
@@ -144,6 +144,15 @@ namespace Fusion.Resources
                 throw new OrgApiError(resp.Response, resp.Content);
 
             return resp.Value;
+        }
+
+        public static async Task DeleteProjectDraftAsync(this IOrgApiClient client, Guid projectId, ApiDraftV2 draft)
+        {
+            var resp = await client.DeleteAsync($"/projects/{projectId}/drafts/{draft.Id}?api-version=2.0");
+            var content = await resp.Content.ReadAsStringAsync();
+
+            if (!resp.IsSuccessStatusCode)
+                throw new OrgApiError(resp, content);
         }
 
         public static async Task<ApiDraftV2> PublishAndWaitAsync(this IOrgApiClient client, ApiDraftV2 draft)

--- a/src/backend/api/Fusion.Resources.Domain/Extensions/JsonNetExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/JsonNetExtensions.cs
@@ -1,0 +1,122 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Fusion.Resources
+{
+    public static class JObjectExtensions
+    {
+        public static void SetPropertyValue<T>(this JObject jObject, Expression<Func<T, object>> propertySelector, JToken propertyValue)
+        {
+            var prop = GetPropertyName<T, object>(propertySelector);
+
+            var property = jObject.Properties().FirstOrDefault(p => p.Name.EqualsIgnCase(prop.Name));
+
+            if (property == null)
+            {
+                var camelCasedPropertyName = CamelCaseProperty(prop.Name);
+                jObject.Add(camelCasedPropertyName, propertyValue);
+            }
+            else
+            {
+                jObject[property.Name] = propertyValue;
+            }
+        }
+
+        public static void RemoveProperty(this JObject jObject, params string[] propertyNames)
+        {
+            foreach (var prop in propertyNames)
+            {
+                var jProp = jObject.Property(prop, StringComparison.OrdinalIgnoreCase);
+                if (jProp is not null)
+                    jProp.Remove();
+            }
+        }
+
+        public static void SetPropertyValue<T>(this JObject jObject, Expression<Func<T, object>> propertySelector, object propertyValue)
+        {
+            var prop = GetPropertyName<T, object>(propertySelector);
+
+            var property = jObject.Properties().FirstOrDefault(p => p.Name.EqualsIgnCase(prop.Name));
+
+            var tempObject = JsonConvert.DeserializeObject<JObject>(JsonConvert.SerializeObject(new { prop = propertyValue }));
+
+            if (tempObject is null)
+                return;
+
+            if (property == null)
+            {
+                var camelCasedPropertyName = CamelCaseProperty(prop.Name);
+                jObject.Add(camelCasedPropertyName, tempObject.Property("prop")!.Value);
+            }
+            else
+            {
+                jObject[property.Name] = tempObject.Property("prop")!.Value;
+            }
+        }
+
+
+        public static JArray? GetPropertyCollection<T>(this JObject jObject, Expression<Func<T, object>> propertySelector)
+        {
+            var selectedPropertyMember = GetPropertyName<T, object>(propertySelector);
+            var property = jObject.Properties().FirstOrDefault(p => p.Name.EqualsIgnCase(selectedPropertyMember.Name));
+
+            if (property == null)
+            {
+                // Does not exist.. Create it
+                jObject[selectedPropertyMember.Name] = new JArray();
+                return jObject[selectedPropertyMember.Name] as JArray;
+            }
+
+            if (property.Value.Type == JTokenType.Null)
+                property.Value = new JArray();
+
+            return property.Value as JArray;
+        }
+        private static PropertyInfo GetPropertyName<T, TValue>(Expression<Func<T, TValue>> selector)
+        {
+            MemberExpression? body = selector.Body as MemberExpression;
+
+            if (body == null)
+            {
+                UnaryExpression ubody = (UnaryExpression)selector.Body;
+                body = ubody.Operand as MemberExpression;
+            }
+
+            return (PropertyInfo)body!.Member;
+
+        }
+
+        public static TValue GetPropertyValue<T, TValue>(this JObject jObject, Expression<Func<T, TValue>> propertySelector)
+        {
+            var selectedPropertyMember = GetPropertyName<T, TValue>(propertySelector);
+            var property = jObject.Properties().FirstOrDefault(p => p.Name.EqualsIgnCase(selectedPropertyMember.Name));
+
+            if (property != null)
+            {
+                return property.Value.ToObject<TValue>()!;
+            }
+
+            return default(TValue)!;
+        }
+
+        public static bool EqualsIgnCase(this string source, string query)
+        {
+            if (source == null)
+                return query == null;
+
+            return source.Equals(query, StringComparison.OrdinalIgnoreCase);
+        }
+        private static string CamelCaseProperty(string propertyName)
+        {
+            if (propertyName == null)
+                throw new ArgumentNullException("Property name cannot be null when converting to camelcase");
+
+            return Char.ToLowerInvariant(propertyName[0]) + propertyName.Substring(1);
+        }
+    }
+
+}

--- a/src/backend/api/Fusion.Resources.Domain/Services/IProfileServices.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/IProfileServices.cs
@@ -17,7 +17,7 @@ namespace Fusion.Resources.Domain
 
         Task<DbPerson?> EnsureApplicationAsync(Guid azureUniqueId);
 
-        Task<DbExternalPersonnelPerson> EnsureExternalPersonnelAsync(string? upn, string mail, string firstName, string lastName);
+        Task<DbExternalPersonnelPerson> EnsureExternalPersonnelAsync(string? upn, PersonId personIdentifier, string firstName, string lastName);
         Task<DbExternalPersonnelPerson?> ResolveExternalPersonnelAsync(PersonId personId);
         /// <summary>
         /// Resolves the fusion profile. Returns null if not found.

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -42,6 +42,17 @@ namespace Fusion.Resources.Api.Tests
             resp.Should().BeSuccessfull();
         }
 
+        public static async Task<TestClientHttpResponse<dynamic>> ReplaceContractPersonnelAsync(this HttpClient client, Guid projectId, Guid contractId, Guid fromPersonId, string toUpn, Guid toPersonId, bool force = false)
+        {
+            var resp = await client.TestClientPostAsync($"/projects/{projectId}/contracts/{contractId}/resources/personnel/{fromPersonId}/replace?force={force}", new
+            {
+                upn = toUpn,
+                azureUniquePersonId = toPersonId
+            });
+
+            return resp;
+        }
+
 
         public static async Task<TestApiInternalRequestModel> CreateRequestAsync(this HttpClient client, Guid projectId, Action<ApiCreateInternalRequestModel> setup)
         {
@@ -213,7 +224,7 @@ namespace Fusion.Resources.Api.Tests
             });
         }
 
-        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, Dictionary<string, object> props = null )
+        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, Dictionary<string, object> props = null)
         {
             var payload = new
             {
@@ -234,7 +245,7 @@ namespace Fusion.Resources.Api.Tests
             return result.Value;
         }
 
-        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, Action<TestCreateRequestAction> setup,  Dictionary<string, object> props = null)
+        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, Action<TestCreateRequestAction> setup, Dictionary<string, object> props = null)
         {
             var payload = new TestCreateRequestAction
             {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -42,9 +42,9 @@ namespace Fusion.Resources.Api.Tests
             resp.Should().BeSuccessfull();
         }
 
-        public static async Task<TestClientHttpResponse<dynamic>> ReplaceContractPersonnelAsync(this HttpClient client, Guid projectId, Guid contractId, Guid fromPersonId, string toUpn, Guid toPersonId, bool force = false)
+        public static async Task<TestClientHttpResponse<TestApiPersonnel>> ReplaceContractPersonnelAsync(this HttpClient client, Guid projectId, Guid contractId, Guid fromPersonId, string toUpn, Guid toPersonId, bool force = false)
         {
-            var resp = await client.TestClientPostAsync($"/projects/{projectId}/contracts/{contractId}/resources/personnel/{fromPersonId}/replace?force={force}", new
+            var resp = await client.TestClientPostAsync<TestApiPersonnel>($"/projects/{projectId}/contracts/{contractId}/resources/personnel/{fromPersonId}/replace?force={force}", new
             {
                 upn = toUpn,
                 azureUniquePersonId = toPersonId

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnel.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Rsponses/TestApiPersonnel.cs
@@ -6,6 +6,7 @@ namespace Fusion.Resources.Api.Tests
     {
         public Guid PersonnelId { get; set; }
         public Guid? AzureUniquePersonId { get; set; }
+        public string UPN { get; set; }
 
         public string Mail { get; set; }
         public string FirstName { get; set; }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
@@ -118,6 +118,14 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1Expired.AzureUniqueId!.Value, testUserA1Expired.UPN, testUserA1Expired.AzureUniqueId!.Value);
             resp.Should().BeBadRequest();
         }
+        [Fact]
+        public async Task ReplacePersonnel_ShouldFail_WhenSubjectNotExists()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, Guid.NewGuid(), testUser.UPN, testUser.AzureUniqueId!.Value);
+            resp.Should().BeBadRequest();
+        }
 
         public async Task InitializeAsync()
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
@@ -1,0 +1,165 @@
+﻿using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Testing;
+using Fusion.Testing.Authentication.User;
+using Fusion.Testing.Mocks.OrgService;
+using Fusion.Testing.Mocks.ProfileService;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Fusion.Resources.Api.Tests.IntegrationTests
+{
+    public class ContractPersonnelReplacementTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
+    {
+        private readonly ResourceApiFixture fixture;
+        private readonly TestLoggingScope loggingScope;
+        /// <summary>
+        /// Will be generated new for each test
+        /// </summary>
+        private readonly ApiPersonProfileV3 testUserA1;
+        private readonly ApiPersonProfileV3 testUserA2;
+        private readonly ApiPersonProfileV3 testUser;
+
+
+        // Created by the async lifetime
+        private FusionTestProjectBuilder testProject = null;
+        private Guid projectId => testProject.Project.ProjectId;
+        private Guid contractId => testProject.ContractsWithPositions.First().Item1.Id;
+
+        private HttpClient client => fixture.ApiFactory.CreateClient();
+
+        public ContractPersonnelReplacementTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+
+            // Generate random test user
+            testUserA1 = fixture.AddProfile(FusionAccountType.External);
+            var profileB = PeopleServiceMock.AddTestProfile()
+                .WithAccountType(FusionAccountType.External)
+                .WithUpn(testUserA1.UPN);
+            testUserA2 = profileB.SaveProfile();
+
+            testUser = fixture.AddProfile(FusionAccountType.External);
+
+        }
+
+        [Fact]
+        public async Task ReplacePersonnel_ShouldUpdateSuccessfully_WhenUpnMatch()
+        {
+
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1.AzureUniqueId.Value, testUserA2.UPN, testUserA2.AzureUniqueId.Value);
+            resp.Should().BeSuccessfull();
+        }
+        [Fact]
+        public async Task ReplacePersonnel_ShouldUpdateSuccessfully_WhenUpnMisMatchAndForced()
+        {
+
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1.AzureUniqueId.Value, testUser.UPN, testUser.AzureUniqueId.Value, true);
+            resp.Should().BeSuccessfull();
+        }
+
+        [Fact]
+        public async Task ReplacePersonnel_ShouldFail_WhenUpnMismatch()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1.AzureUniqueId.Value, testUser.UPN, testUser.AzureUniqueId.Value);
+            resp.Should().BeBadRequest();
+        }
+
+        [Fact]
+        public async Task ReplacePersonnel_ShouldFail_WhenInvalidAzureUniqueIdArgument()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1.AzureUniqueId.Value, testUser.UPN, Guid.Empty);
+            resp.Should().BeBadRequest();
+        }
+
+        [Fact]
+        public async Task ReplacePersonnel_ShouldFail_WhenInvalidUpnArgument()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1.AzureUniqueId.Value, string.Empty, testUser.AzureUniqueId.Value);
+            resp.Should().BeBadRequest();
+        }
+
+        public async Task InitializeAsync()
+        {
+
+            testProject = new FusionTestProjectBuilder()
+               .WithContractAndPositions()
+               .WithPositions()
+               .AddToMockService();
+
+            fixture.ContextResolver
+                .AddContext(testProject.Project);
+
+            var client = fixture.ApiFactory.CreateClient()
+                .WithTestUser(fixture.AdminUser)
+                .AddTestAuthToken();
+
+            (var contract, var positions) = testProject.ContractsWithPositions.First();
+
+
+
+            // Make the company available in the ppl service
+            if (contract.Company != null)
+                Testing.Mocks.ProfileService.PeopleServiceMock.AddCompany(contract.Company.Id, contract.Company.Name);
+
+            var response = await client.PostAsJsonAsync($"/projects/{testProject.Project.ProjectId}/contracts", new
+            {
+                ContractNumber = contract.ContractNumber,
+                Name = contract.Name,
+                Description = contract.Description,
+                StartDate = contract.StartDate,
+                EndDate = contract.EndDate,
+                Company = new { id = contract.Company.Id },
+                CompanyRepPositionId = testProject.Positions.Skip(1).First().Id,
+                ExternalCompanyRepPositionId = positions.First().Id
+            });
+
+            var content = await response.Content.ReadAsStringAsync();
+            response.EnsureSuccessStatusCode();
+
+            // To make sure all test users are available for contract personnel
+            await EnsureContractPersonAsync(testUser);
+            await EnsureContractPersonAsync(testUserA2);
+            await EnsureContractPersonAsync(testUserA1);
+
+        }
+        private async Task EnsureContractPersonAsync(ApiPersonProfileV3 profile)
+        {
+            using var adminScope = fixture.AdminScope();
+            var createResp = await client.TestClientPostAsync(
+                $"/projects/{projectId}/contracts/{contractId}/resources/personnel", new
+                {
+                    Mail = profile.Mail,
+                    FirstName = profile.Name,
+                    LastName = profile.Name,
+                    PhoneNumber = profile.MobilePhone
+                });
+            createResp.Should().BeSuccessfull();
+        }
+
+        public Task DisposeAsync()
+        {
+            loggingScope.Dispose();
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ContractPersonnelReplacementTests.cs
@@ -110,6 +110,15 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             resp.Should().BeBadRequest();
         }
 
+        [Fact]
+        public async Task ReplacePersonnel_ShouldFail_WhenSubjectEqualsTarget()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var resp = await client.ReplaceContractPersonnelAsync(projectId, contractId, testUserA1Expired.AzureUniqueId!.Value, testUserA1Expired.UPN, testUserA1Expired.AzureUniqueId!.Value);
+            resp.Should().BeBadRequest();
+        }
+
         public async Task InitializeAsync()
         {
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -78,6 +78,11 @@ namespace Fusion.Testing.Mocks.OrgService
             taskOwnerMapping.TryAdd(position, taskOwnerPosition);
         }
 
+        public static List<ApiPositionV2> GetContractPositions()
+        {
+            return contractPositions.Select(contractPosition => contractPosition.Value).ToList();
+        }
+
         public static ApiPositionV2 GetPosition(Guid id)
         {
             return positions.FirstOrDefault(p => p.Id == id);
@@ -86,9 +91,5 @@ namespace Fusion.Testing.Mocks.OrgService
         {
             return projects.FirstOrDefault(p => p.ProjectId == id);
         }
-        //public static ApiPositionV2 ResolveContractPosition(Guid position)
-        //{
-
-        //}
     }
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -52,6 +52,11 @@ namespace Fusion.Testing.Mocks.ProfileService
             profile.UPN = upn;
             return this;
         }
+        public FusionTestUserBuilder WithPreferredContactMail(string mail)
+        {
+            profile.PreferredContactMail = mail;
+            return this;
+        }
 
         public FusionTestUserBuilder WithAccountType(FusionAccountType type)
         {

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -47,6 +47,12 @@ namespace Fusion.Testing.Mocks.ProfileService
             profile = FusionTestProfiles.CreateTestUser(type, classification);
         }
 
+        public FusionTestUserBuilder WithUpn(string upn)
+        {
+            profile.UPN = upn;
+            return this;
+        }
+
         public FusionTestUserBuilder WithAccountType(FusionAccountType type)
         {
             profile.AccountType = type;


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
The admins for a contract should have an option to "replace" the account with a new one.

[AB#25134](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/25134)

[DOCS link](https://docs.fusion-dev.net/pr-163/domain/services/resources/tech-specs/replace-expired-accounts/)

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

To be able to test, we require new and old accounts.
I can see MARTIN.SANDEN@AIBEL.COM to exist in CI with expired and new account.
The old account is used in Oseberg Gas Capacity Upgrade (OGP) project on the Aibel OGP EPCI contract
and Query test project on the Test contract


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

