### PR TITLE
Reject direct requests when assignedDeparment != proposedPerson.department

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/CreateResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/CreateResourceAllocationRequest.cs
@@ -121,12 +121,16 @@ namespace Fusion.Resources.Api.Controllers
                 RuleFor(x => x)
                     .MustAsync(async (rq, ct) =>
                     {
-                        var id = rq.ProposedPersonAzureUniqueId;
+                        var id = rq.ProposedPersonAzureUniqueId!;
                         var profile = await profileResolver.ResolvePersonBasicProfileAsync(id);
 
-                        return profile!.FullDepartment == rq.AssignedDepartment;
+
+                        bool isAssignedDepartmentLegal = rq.AssignedDepartment == profile!.FullDepartment
+                            || new DepartmentPath(rq.AssignedDepartment).IsParent(profile!.FullDepartment);
+
+                        return isAssignedDepartmentLegal;
                     })
-                    .WithMessage("Assigned department cannot be different from the proposed persons department. Either avoid assigning department or assign it to the proposed persons department.")
+                    .WithMessage("Assigned department cannot be different from the proposed persons department. Either avoid assigning department or assign it to the proposed persons sector or department.")
                     .When(x => x.ProposedPersonAzureUniqueId.HasValue && !string.IsNullOrEmpty(x.AssignedDepartment));
             }
         }

--- a/src/backend/api/Fusion.Resources.Domain/Utils/DepartmentPath.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/DepartmentPath.cs
@@ -14,7 +14,7 @@ namespace Fusion.Resources.Domain
         private readonly string[] path;
         private readonly string fullDepartmentPath;
 
-        public DepartmentPath(string fullDepartmentPath)
+        public DepartmentPath(string? fullDepartmentPath)
         {
             var trimedPath = (fullDepartmentPath ?? "").Trim();
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -249,6 +249,36 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeBadRequest();
         }
 
+
+        [Fact]
+        public async Task DirectRequest_Create_ShouldBeAllowedWhenProposedPersonIsInSector()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var position = testProject.AddPosition();
+            var proposedPerson = fixture.AddProfile(FusionAccountType.Employee);
+
+            fixture.EnsureDepartment("PDP PRD PCM QRI");
+            fixture.EnsureDepartment("PDP PRD PCM QRI QRM2");
+
+
+            proposedPerson.FullDepartment = "PDP PRD PCM QRI QRM2";
+            proposedPerson.Department = "PCM QRI QRM2";
+
+            var response = await Client.TestClientPostAsync($"/projects/{projectId}/requests", new
+            {
+                type = "normal",
+                subType = "direct",
+                orgPositionId = position.Id,
+                orgPositionInstanceId = position.Instances.Last().Id,
+                proposedPersonAzureUniqueId = proposedPerson.AzureUniqueId,
+                assignedDepartment = "PDP PRD PCM QRI"
+            }, new { assignedDepartment = "" });
+
+            response.Should().BeSuccessfull();
+            response.Value.assignedDepartment.Should().Be("PDP PRD PCM QRI");
+        }
+
         #endregion
 
         #region Request flow tests


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
[AB#26101](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/26101)

It should not be possible to assign a direct request to a different department than the one the proposed person is in.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

