### PR TITLE
INFRA - Get-AzKeyVaultSecret - breaking change in latest version

### DIFF
--- a/pipelines/templates/grant-database-app-access.yml
+++ b/pipelines/templates/grant-database-app-access.yml
@@ -52,7 +52,7 @@ steps:
             return "0x" + $byteGuid
         }
 
-        $sqlpasswordSecret = Get-AzKeyVaultSecret -VaultName $sqlPasswordKeyVault -Name fusion-sql-password
+        $sqlpasswordSecret = Get-AzKeyVaultSecret -VaultName $sqlPasswordKeyVault -Name fusion-sql-password -AsPlainText
 
         $sqlServer = Get-SqlServer 
         $sp = Get-AzADApplication -ApplicationId $clientId
@@ -63,6 +63,6 @@ steps:
         Invoke-Sqlcmd -ServerInstance $sqlServer.FullyQualifiedDomainName `
                 -Database $sqlDatabaseName `
                 -Username $sqlServer.SqlAdministratorLogin `
-                -Password $sqlpasswordSecret.SecretValueText `
+                -Password $sqlpasswordSecret `
                 -Query $sql `
                 -ConnectionTimeout 120

--- a/src/backend/api/Fusion.Resources.Api/Deployment/deploy-webapp.ps1
+++ b/src/backend/api/Fusion.Resources.Api/Deployment/deploy-webapp.ps1
@@ -44,7 +44,7 @@ $hostingPlan = New-HostingResource
 Write-Host "Using resource group $resourceGroup"
 
 $adClientSecret = Get-AzKeyVaultSecret -VaultName $envKeyVault -Name "AzureAd--ClientSecret"
-$acrPullToken = Get-AzKeyVaultSecret -VaultName $envKeyVault -Name "ACR-PullToken"
+$acrPullToken = Get-AzKeyVaultSecret -VaultName $envKeyVault -Name "ACR-PullToken" -AsPlainText
 
 ## 
 ## ACR Pull secret
@@ -52,7 +52,7 @@ $acrPullToken = Get-AzKeyVaultSecret -VaultName $envKeyVault -Name "ACR-PullToke
 ## The ACR password must be generated on the fusioncr resource and added to the env key vault. 
 ## No automatic generation of this for now.
 
-$dockerCredentials = @{ username="Resources-fprd-pull"; password=$acrPullToken.SecretValueText }
+$dockerCredentials = @{ username="Resources-fprd-pull"; password=$acrPullToken }
 $dockerInfo = @{
     url = "https://fusioncr.azurecr.io"
     image = $imageName

--- a/src/backend/infrastructure/grant-adapp-sql-access.ps1
+++ b/src/backend/infrastructure/grant-adapp-sql-access.ps1
@@ -32,7 +32,7 @@ function ConvertTo-Sid {
     return "0x" + $byteGuid
 }
 
-$sqlpasswordSecret = Get-AzKeyVaultSecret -VaultName $sqlPasswordKeyVault -Name fusion-sql-password
+$sqlpasswordSecret = Get-AzKeyVaultSecret -VaultName $sqlPasswordKeyVault -Name fusion-sql-password -AsPlainText
 
 $sqlServer = Get-SqlServer 
 $sp = Get-AzADApplication -ApplicationId $clientId
@@ -48,6 +48,6 @@ END
 Invoke-Sqlcmd -ServerInstance $sqlServer.FullyQualifiedDomainName `
         -Database $sqlDatabaseName `
         -Username $sqlServer.SqlAdministratorLogin `
-        -Password $sqlpasswordSecret.SecretValueText `
+        -Password $sqlpasswordSecret `
         -Query $sql `
         -ConnectionTimeout 120


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
Current pipeline is using Get-AzKeyVaultSecret
Assigning to variable and try to use .SecretValueText doesn't work anymore.

Could use -AsPlainText to get the value directly and assign to variable.

* File [grant-database-app-access.yml](https://github.com/equinor/fusion-app-resources/pull/471/files#diff-71de94f9506b85399113638e3b207a37ded9c6b8363684c6f3a78dde4d9b0298) seems to be left in code for historic reason. Decided to update anyway.
* File [deploy-webapp.ps1](https://github.com/equinor/fusion-app-resources/pull/471/files#diff-30d4d099f72f4e92e4c2a89823a2273362edcaf62138215920a7faa4a87445db) is used for deploy to PROD (currently using webapp and not cluster)
* File [grant-adapp-sql-access.ps1](https://github.com/equinor/fusion-app-resources/pull/471/files#diff-d04331d05e214af53ab027d4a0be981ed2ed8269234184d60f55037ce662a3f9) is used when executing **"Resources Environments "** pipeline

**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

