### PR TITLE
 Flag deleted instances

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -67,6 +67,7 @@ namespace Fusion.Resources.Api.Controllers
             ProvisioningStatus = new ApiProvisioningStatus(query.ProvisioningStatus);
 
             CorrelationId = query.CorrelationId;
+            IsOrgInstanceDeleted = query.IsOrgInstanceDeleted;
         }
 
         public Guid Id { get; set; }
@@ -108,6 +109,8 @@ namespace Fusion.Resources.Api.Controllers
         public Guid? CorrelationId { get; }
         public List<ApiRequestAction>? Actions { get; }
         public List<ApiRequestConversationMessage>? Conversation { get; }
+
+        public bool IsOrgInstanceDeleted { get; }
 
         internal bool ShouldHideProposalsForProject
         {

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -135,6 +135,8 @@ namespace Fusion.Resources.Domain
         public List<QueryRequestAction>? Actions { get; set; }
         public List<QueryConversationMessage>? Conversation { get; set; }
 
+        public bool IsOrgInstanceDeleted => OrgPositionInstanceId.HasValue && OrgPositionInstance == null;
+
         internal QueryResourceAllocationRequest WithResolvedOriginalPosition(ApiPositionV2 position, Guid? positionInstanceId)
         {
             OrgPosition = position;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -257,6 +257,28 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task GetRequest_ShouldFlagDeletedInstances()
+        {
+            using var adminScope = fixture.AdminScope();
+            var fakeResourceOwner = fixture.AddResourceOwner("TPD PRD TST QWE");
+
+            var requestPosition = testProject.AddPosition().WithEnsuredFutureInstances();
+            var request = await Client.CreateRequestAsync(projectId, r => r.AsTypeNormal().WithPosition(requestPosition));
+            await Client.StartProjectRequestAsync(testProject, request.Id);
+
+            OrgServiceMock.RemoveInstance(request.OrgPositionId!.Value, request.OrgPositionInstanceId);
+
+            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}", new
+            {
+                isOrgInstanceDeleted = false
+            });
+
+
+            result.Should().BeSuccessfull();
+            result.Value.isOrgInstanceDeleted.Should().BeTrue();
+        }
+
+        [Fact]
         public async Task GetRequest_ShouldUseInstanceStartDate_WhenExpandTaskOwner()
         {
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -91,5 +91,11 @@ namespace Fusion.Testing.Mocks.OrgService
         {
             return projects.FirstOrDefault(p => p.ProjectId == id);
         }
+
+        public static void RemoveInstance(Guid orgPositionId,  Guid? orgPositionInstanceId)
+        {
+            var position = positions.FirstOrDefault(x => x.Id == orgPositionId);
+            position.Instances.RemoveAll(x => x.Id == orgPositionInstanceId);
+        }
     }
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
- [AB#26367](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/26367)

Sometimes a request is created for a position instance and then later the position instance is deleted in org.
This change should flag when that has happened.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

