### PR TITLE
Key rotation pipeline update

### DIFF
--- a/pipelines/secret-rotation-pipeline.yml
+++ b/pipelines/secret-rotation-pipeline.yml
@@ -26,7 +26,7 @@ schedules:
 # The pipeline will run twice a month to ensure it is running successfully.
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: "windows-latest"
 
 variables:
   subscriptionService: 'PROJECT_PORTAL (63b791ae-b2bc-41a1-ac66-806c4e69bffe)'  

--- a/pipelines/secret-rotation-pipeline.yml
+++ b/pipelines/secret-rotation-pipeline.yml
@@ -72,7 +72,7 @@ stages:
           vaultName: 'kv-fap-resources-pr'
           aadApplicationId: '5a842df8-3238-415d-b168-9f16a6a6031b'
         steps:
-        - task: AzurePowerShell@5    
+        - task: AzurePowerShell@5
           displayName: Update client secret
           
           inputs:

--- a/pipelines/secret-rotation-pipeline.yml
+++ b/pipelines/secret-rotation-pipeline.yml
@@ -48,7 +48,8 @@ stages:
             azureSubscription: $(subscriptionService)
             ScriptType: FilePath
             FailOnStandardError: true
-            azurePowerShellVersion: 'LatestVersion'
+            azurePowerShellVersion: 'OtherVersion'
+            preferredAzurePowerShellVersion: '7.2.0'
             ScriptPath: src/backend/infrastructure/generate-secret.ps1
             ScriptArguments: -applicationId $(aadApplicationId) -keyVaultName $(vaultName)
 
@@ -79,7 +80,8 @@ stages:
             azureSubscription: $(subscriptionService)
             ScriptType: FilePath
             FailOnStandardError: true
-            azurePowerShellVersion: 'LatestVersion'
+            azurePowerShellVersion: 'OtherVersion'
+            preferredAzurePowerShellVersion: '7.2.0'
             ScriptPath: src/backend/infrastructure/generate-secret.ps1
             ScriptArguments: -applicationId $(aadApplicationId) -keyVaultName $(vaultName)
 
@@ -111,7 +113,8 @@ stages:
             azureSubscription: $(subscriptionService)
             ScriptType: FilePath
             FailOnStandardError: true
-            azurePowerShellVersion: 'LatestVersion'
+            azurePowerShellVersion: 'OtherVersion'
+            preferredAzurePowerShellVersion: '7.2.0'
             ScriptPath: src/backend/infrastructure/generate-secret.ps1
             ScriptArguments: -applicationId $(aadApplicationId) -keyVaultName $(vaultName)
 
@@ -144,7 +147,8 @@ stages:
             azureSubscription: $(subscriptionService)
             ScriptType: FilePath
             FailOnStandardError: true
-            azurePowerShellVersion: 'LatestVersion'
+            azurePowerShellVersion: 'OtherVersion'
+            preferredAzurePowerShellVersion: '7.2.0'
             ScriptPath: src/backend/infrastructure/generate-secret.ps1
             ScriptArguments: -applicationId $(aadApplicationId) -keyVaultName $(vaultName)
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -49,7 +49,7 @@ $credential = @{
 
 Get-Command -Name "New-AzADAppCredential"
 
-$app = Get-AzADAppCredential -ApplicationId $AAD_APP_ID
+$app = Get-AzADApplication -ApplicationId $AAD_APP_ID
 $app
 $newSecret = New-AzADAppCredential -ApplicationObject $app -PasswordCredentials $credential
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -48,6 +48,7 @@ $credential = @{
 }
 
 Get-Command -Name "New-AzADAppCredential"
+get-module -name Az.Resources
 
 $app = Get-AzADApplication -ApplicationId $AAD_APP_ID
 $app

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -48,7 +48,16 @@ $credential = @{
 }
 
 $app = Get-AzADApplication -ApplicationId $AAD_APP_ID
-$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $credential
+
+$name = "Resources - $keyVaultName"
+$creds = New-Object `
+             -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential" `
+             -Property @{ 'DisplayName' = $name; 'StartDateTime' = $startDate; 'EndDateTime' = $endDate }
+
+$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $creds
+
+
+#$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -39,12 +39,11 @@ if (-not $generateNew) {
 $startDate = Get-Date
 $endDate = $startDate.AddMonths(6)
 
-$credential = New-Object -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential" `
-                                 -Property @{ `
-                                 'DisplayName' = "Resources - $keyVaultName"; `
-                                 'StartDateTime' = $startDate; `
-                                 'EndDateTime' = $endDate `
-                                 }
+$credential = @{
+    DisplayName = "Resources - $keyVaultName"
+    StartDateTime = $startDate
+    EndDateTime = $endDate
+}
 
 $newSecret = New-AzADAppCredential -PasswordCredentials $credential -ApplicationId $AAD_APP_ID
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -47,12 +47,8 @@ $credential = @{
     EndDateTime = $endDate
 }
 
-Get-Command -Name "New-AzADAppCredential"
-get-module -name Az.Resources
-
 $app = Get-AzADApplication -ApplicationId $AAD_APP_ID
-$app
-$newSecret = New-AzADAppCredential -ApplicationObject $app -PasswordCredentials $credential
+$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -7,6 +7,8 @@ $SECRET_NAME = "AzureAd--ClientSecret"
 $AAD_APP_ID = $applicationId
 $SECRETVAULTNAME = $keyVaultName
 
+Write-Host "Application ID: $AAD_APP_ID"
+Write-Host "Key vault: $SECRETVAULTNAME"
 
 $secret = Get-AzKeyVaultSecret -VaultName $SECRETVAULTNAME -Name $SECRET_NAME
 
@@ -45,7 +47,7 @@ $credential = @{
     EndDateTime = $endDate
 }
 
-$newSecret = New-AzADAppCredential -PasswordCredentials $credential -ApplicationId $AAD_APP_ID
+$newSecret = New-AzADAppCredential -ApplicationId $AAD_APP_ID -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -49,7 +49,9 @@ $credential = @{
 
 Get-Command -Name "New-AzADAppCredential"
 
-$newSecret = New-AzADAppCredential -ApplicationId $AAD_APP_ID -PasswordCredentials $credential
+$app = Get-AzADAppCredential -ApplicationId $AAD_APP_ID
+$app
+$newSecret = New-AzADAppCredential -ApplicationObject $app -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -37,6 +37,8 @@ if (-not $generateNew) {
     Write-Host "Generating new secret..."
 }
 
+Get-Command -Name "New-AzADAppCredential"
+Get-Module -Name Az.Resources
 ## Generate secret on aad app
 $startDate = Get-Date
 $endDate = $startDate.AddMonths(6)

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -37,8 +37,6 @@ if (-not $generateNew) {
     Write-Host "Generating new secret..."
 }
 
-Get-Command -Name "New-AzADAppCredential"
-Get-Module -Name Az.Resources
 ## Generate secret on aad app
 $startDate = Get-Date
 $endDate = $startDate.AddMonths(6)
@@ -49,17 +47,7 @@ $credential = @{
     EndDateTime = $endDate
 }
 
-$app = Get-AzADApplication -ApplicationId $AAD_APP_ID
-
-$name = "Resources - $keyVaultName"
-$creds = New-Object `
-             -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential" `
-             -Property @{ 'DisplayName' = $name; 'StartDateTime' = $startDate; 'EndDateTime' = $endDate }
-
-$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $creds
-
-
-#$newSecret = New-AzADAppCredential -ObjectId $app.Id -PasswordCredentials $credential
+$newSecret = New-AzADAppCredential -ApplicationId $AAD_APP_ID -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"
 

--- a/src/backend/infrastructure/generate-secret.ps1
+++ b/src/backend/infrastructure/generate-secret.ps1
@@ -47,6 +47,8 @@ $credential = @{
     EndDateTime = $endDate
 }
 
+Get-Command -Name "New-AzADAppCredential"
+
 $newSecret = New-AzADAppCredential -ApplicationId $AAD_APP_ID -PasswordCredentials $credential
 
 Write-Host "New secret [$($newSecret.Hint)************] generated with expiration date $endDate, key id [$($newSecret.KeyId)]"


### PR DESCRIPTION
Updated the pipeline to use latest version of powershell, which allows setting a display name for the secrets generated. This leads to improved visibility when inspecting expiring secrets etc.

Issues encountered due to bugs in the PS module at version 7.1.0, which is default on hosted agents. Resolved this by forcing 7.2.0 version which is normally pre-installed on the agents.