### PR TITLE
Auto approval for direct requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAutoApprovalStatus.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAutoApprovalStatus.cs
@@ -1,0 +1,46 @@
+﻿using Fusion.Integration.Profile;
+using MediatR;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Queries
+{
+    /// <summary>
+    /// Check if the user should be auto approved or not.
+    /// Returns null if the user does not exist.
+    /// </summary>
+    public class GetPersonAutoApprovalStatus : IRequest<bool?>
+    {
+        public GetPersonAutoApprovalStatus(Guid personAzureUniqueId)
+        {
+            PersonId = new PersonId(personAzureUniqueId);
+        }
+
+        public PersonId PersonId { get; }
+
+        public class Handler : IRequestHandler<GetPersonAutoApprovalStatus, bool?>
+        {
+            private readonly IMediator mediator;
+
+            public Handler(IMediator mediator)
+            {
+                this.mediator = mediator;
+            }
+            public async Task<bool?> Handle(GetPersonAutoApprovalStatus request, CancellationToken cancellationToken)
+            {
+                // Request requires azure unique id, so this should be ok.
+                var profile = await mediator.Send(new GetPersonProfile(request.PersonId.UniqueId!.Value));
+
+                if (profile is null)
+                    return null;
+
+                // Requirement right now is to check the account type
+                if (profile.AccountType != FusionAccountType.Employee)
+                    return true;
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Workflows/Base/WorkflowDefinition.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Workflows/Base/WorkflowDefinition.cs
@@ -96,6 +96,15 @@ namespace Fusion.Resources.Logic.Workflows
             }
         }
 
+        public WorkflowStep AutoComplete()
+        {
+            return Step(APPROVAL)
+                .SetName("Approved")
+                .SetDescription($"Specified resource resulted in auto approval of request.")
+                .Skip()
+                .StartNext().Current;
+        }
+
         public DbWorkflow CreateDatabaseEntity(Guid requestId, DbRequestType type)
         {
             dbWorkflow = new DbWorkflow()

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -119,7 +119,40 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             resp.Should().BeNotFound();
         }
 
+        [Fact]
+        public async Task AllocationRequestStatus_ShouldBeAutoApproval_WhenAccountTypeIsContractor()
+        {
+            var testUser = fixture.AddProfile(FusionAccountType.Consultant);
 
+            using var userScope = fixture.AdminScope();
+            
+            var client = fixture.ApiFactory.CreateClient();
+            var resp = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/resources/allocation-request-status",
+                new
+                {
+                    autoApproval = false
+                }
+            );
+
+            resp.Should().BeSuccessfull();
+            resp.Value.autoApproval.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task AllocationRequestStatus_ShouldBeUnauthorized_WhenExternal()
+        {
+            var testUser = fixture.AddProfile(FusionAccountType.Consultant);
+            var externalUser = fixture.AddProfile(FusionAccountType.External);
+
+            using var userScope = fixture.UserScope(externalUser);
+
+            var client = fixture.ApiFactory.CreateClient();
+            var resp = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/resources/allocation-request-status",
+                new { autoApproval = false }
+            );
+
+            resp.Should().BeUnauthorized();
+        }
 
         public Task InitializeAsync() => Task.CompletedTask;
         public Task DisposeAsync()


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When contractors and externals are specified as resources for direct requests, these accounts will not typically have any managers that will process the requests.

This feature should allow these requests to be auto approved so they can be added to the org chart. 

AB#26989


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Created tests that verifies endpoint that checks auto approval status for user.
Created tests for confirming requests are auto approved when started.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

