### PR TITLE
Manager info on the person allocation status endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAllocationRequestStatus.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAllocationRequestStatus.cs
@@ -3,5 +3,6 @@
     public class ApiPersonAllocationRequestStatus
     {
         public bool AutoApproval { get; set; }
+        public ApiPerson? Manager { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -278,10 +278,12 @@ namespace Fusion.Resources.Api.Controllers
 
 
             var autoApproval = await DispatchAsync(new Domain.Queries.GetPersonAutoApprovalStatus(user.azureId));
+            var manager = await DispatchAsync(new Domain.Queries.GetResourceOwner(user.azureId));
 
             return new ApiPersonAllocationRequestStatus
             {
-                AutoApproval = autoApproval.GetValueOrDefault(false)
+                AutoApproval = autoApproval.GetValueOrDefault(false),
+                Manager = manager is not null ? new ApiPerson(manager) : null
             };
         }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -80,6 +80,14 @@ namespace Fusion.Resources.Api.Tests.Fixture
             return account;
         }
 
+        internal ApiPersonProfileV3 AddProfile(Action<Testing.Mocks.ProfileService.FusionTestUserBuilder> setup)
+        {
+            var account = PeopleServiceMock.AddTestProfile();
+            setup(account);
+            var profile = account.SaveProfile();
+            return profile;
+        }
+
         internal ApiPersonProfileV3 AddResourceOwner(string department)
         {
             var resourceOwner = this.AddProfile(FusionAccountType.Employee);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -139,6 +139,33 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task AllocationRequestStatus_ShouldIncludeManager()
+        {
+            var manager = fixture.AddProfile(FusionAccountType.Employee);
+            var testUser = fixture.AddProfile(s => s
+                .WithAccountType(FusionAccountType.Employee)
+                .WithManager(manager));
+
+            using var userScope = fixture.AdminScope();
+
+            var client = fixture.ApiFactory.CreateClient();
+            var resp = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/resources/allocation-request-status",
+                new
+                {
+                    manager = new
+                    {
+                        azureUniquePersonId = Guid.Empty
+                    }
+
+                }
+            );
+
+            resp.Should().BeSuccessfull();
+            resp.Value.manager.Should().NotBeNull();
+            resp.Value.manager.azureUniquePersonId.Should().Be(manager.AzureUniqueId.Value);
+        }
+
+        [Fact]
         public async Task AllocationRequestStatus_ShouldBeUnauthorized_WhenExternal()
         {
             var testUser = fixture.AddProfile(FusionAccountType.Consultant);

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/PeopleServiceMock.cs
@@ -65,6 +65,18 @@ namespace Fusion.Testing.Mocks.ProfileService
             return this;
         }
 
+
+        public FusionTestUserBuilder WithManager(Guid? azureUniqueId)
+        {
+            profile.ManagerAzureUniqueId = azureUniqueId;
+            return this;
+        }
+        public FusionTestUserBuilder WithManager(ApiPersonProfileV3 person)
+        {
+            profile.ManagerAzureUniqueId = person.AzureUniqueId;
+            return this;
+        }
+
         public FusionTestUserBuilder WithFullDepartment(string fullDepartment)
         {
             profile.FullDepartment = fullDepartment;


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added manager object to the endpoint listing allocation status for a person.

This allows to frontend to get all relevant info in one go.

Updated the query that use uncached request to lineorg to resolve manager, to use the profile instead, as the property is now included her.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Added test to verify manager is populated.


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

