### PR TITLE
API - Internal Requests - Update authorization rule on delete endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -678,10 +678,10 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
+                    or.BeRequestCreator(requestId);
+
                     if (result.Type == InternalRequestType.Allocation)
                     {
-                        or.BeRequestCreator(requestId);
-
                         if (result.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                     }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -115,6 +115,14 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task Delete_InternalRequest_ShouldBeUnauthorized_WhenNotRequestCreator()
+        {
+            using var adminScope = fixture.UserScope(testUser);
+            var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
+            response.Should().BeUnauthorized();
+        }
+
+        [Fact]
         public async Task Delete_InternalRequest_NonExistingRequest_ShouldBeNotFound()
         {
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -117,7 +117,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task Delete_InternalRequest_ShouldBeUnauthorized_WhenNotRequestCreator()
         {
-            using var adminScope = fixture.UserScope(testUser);
+            using var userScope = fixture.UserScope(testUser);
             var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
             response.Should().BeUnauthorized();
         }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Current implementation does only allow the creator of a request to delete it only if the request is of type Allocation. An issue occurred where the creator of a change request wanted to delete it, but did not have authorization. The proposed change is to allow the creator of requests, regardless of request type, to have authorization to delete the created request.

[AB#27424](https://dev.azure.com/statoil-proview/Fusion/_workitems/edit/27424)

**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

