### PR TITLE
ProfileSync - No cache scope

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/ProfileServices.cs
@@ -45,6 +45,8 @@ namespace Fusion.Resources.Domain.Services
 
         public async Task<DbExternalPersonnelPerson> RefreshExternalPersonnelAsync(PersonId personId, bool considerRemovedProfile = false)
         {
+            // Make sure we don't get fooled by cached profiles.
+            using var noCacheScope = new NoProfileCacheScope();
             var profile = await ResolveProfileAsync(personId);
 
             if (profile == null && !considerRemovedProfile) //early check for null to avoid hitting DB unnecessary


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Initialize NoProfileCacheScope before resolving profile during refresh.
Should ensure that a fresh profile is resolved before matcing with external personnel entry


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

