### PR TITLE
Restrict access to request notes

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
@@ -33,9 +33,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-
                     if (requestItem.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -48,8 +45,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -84,13 +79,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.AnyOf(or =>
                 {
-                    or.BeRequestCreator(requestId);
-                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(requestItem.Project.OrgProjectId));
-                    or.OrgChartReadAccess(requestItem.Project.OrgProjectId);
-
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionReadAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-
                     if (requestItem.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -131,13 +119,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.AnyOf(or =>
                 {
-                    or.BeRequestCreator(requestId);
-                    or.HaveOrgchartPosition(ProjectOrganisationIdentifier.FromOrgChartId(requestItem.Project.OrgProjectId));
-                    or.OrgChartReadAccess(requestItem.Project.OrgProjectId);
-
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionReadAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-
                     if (requestItem.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -181,9 +162,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-
                     if (requestItem.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -196,8 +174,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
@@ -96,9 +96,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (request.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(request.Project.OrgProjectId, request.OrgPositionId.Value);
-
                     if (request.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -111,8 +108,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -138,9 +133,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (request.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(request.Project.OrgProjectId, request.OrgPositionId.Value);
-
                     if (request.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -153,8 +145,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -181,9 +171,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (request.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(request.Project.OrgProjectId, request.OrgPositionId.Value);
-
                     if (request.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -196,8 +183,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -240,9 +225,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    if (request.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(request.Project.OrgProjectId, request.OrgPositionId.Value);
-
                     if (request.AssignedDepartment is not null)
                     {
                         or.BeResourceOwner(
@@ -255,8 +237,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -35,14 +35,14 @@ namespace Fusion.Resources.Domain.Queries
             {
                 Expands |= ExpandProperties.DepartmentDetails;
             }
-            if(query.ShouldExpand("actions"))
-            {
-                Expands |= ExpandProperties.Actions;
-            }
-            if(query.ShouldExpand("conversation"))
-            {
-                Expands |= ExpandProperties.Conversation;
-            }
+            //if(query.ShouldExpand("actions"))
+            //{
+            //    Expands |= ExpandProperties.Actions;
+            //}
+            //if(query.ShouldExpand("conversation"))
+            //{
+            //    Expands |= ExpandProperties.Conversation;
+            //}
 
 
             return this;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -413,71 +413,71 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             updated.Value.Workflow.Should().BeNull();
         }
 
-        [Fact]
-        public async Task GetRequest_ShouldIncludeTasks_WhenExpanded()
-        {
-            using var adminScope = fixture.AdminScope();
+        //[Fact]
+        //public async Task GetRequest_ShouldIncludeTasks_WhenExpanded()
+        //{
+        //    using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultRequestAsync(testProject);
-            var task = await Client.AddRequestActionAsync(request.Id);
+        //    var request = await Client.CreateDefaultRequestAsync(testProject);
+        //    var task = await Client.AddRequestActionAsync(request.Id);
 
-            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
-            {
-                actions = new[] { new { id = Guid.Empty } }
-            });
+        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
+        //    {
+        //        actions = new[] { new { id = Guid.Empty } }
+        //    });
 
-            result.Should().BeSuccessfull();
-            result.Value.actions.Should().Contain(t => t.id == task.id);
-        }
+        //    result.Should().BeSuccessfull();
+        //    result.Value.actions.Should().Contain(t => t.id == task.id);
+        //}
 
-        [Fact]
-        public async Task GetRequest_ShouldNotFailToExpandTasks_WhenNoTasksExist()
-        {
-            using var adminScope = fixture.AdminScope();
+        //[Fact]
+        //public async Task GetRequest_ShouldNotFailToExpandTasks_WhenNoTasksExist()
+        //{
+        //    using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultRequestAsync(testProject);
+        //    var request = await Client.CreateDefaultRequestAsync(testProject);
 
-            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
-            {
-                actions = new[] { new { id = Guid.Empty } }
-            });
+        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
+        //    {
+        //        actions = new[] { new { id = Guid.Empty } }
+        //    });
 
-            result.Should().BeSuccessfull();
-            result.Value.actions.Should().BeEmpty();
-        }
+        //    result.Should().BeSuccessfull();
+        //    result.Value.actions.Should().BeEmpty();
+        //}
 
-        [Fact]
-        public async Task GetRequest_ShouldIncludeConversation_WhenExpanded()
-        {
-            using var adminScope = fixture.AdminScope();
+        //[Fact]
+        //public async Task GetRequest_ShouldIncludeConversation_WhenExpanded()
+        //{
+        //    using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultRequestAsync(testProject);
-            var message = await Client.AddRequestMessage(request.Id);
+        //    var request = await Client.CreateDefaultRequestAsync(testProject);
+        //    var message = await Client.AddRequestMessage(request.Id);
 
-            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
-            {
-                conversation = new[] { new { id = Guid.Empty } }
-            });
+        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
+        //    {
+        //        conversation = new[] { new { id = Guid.Empty } }
+        //    });
 
-            result.Should().BeSuccessfull();
-            result.Value.conversation.Should().Contain(m => m.id == message.Id);
-        }
+        //    result.Should().BeSuccessfull();
+        //    result.Value.conversation.Should().Contain(m => m.id == message.Id);
+        //}
 
-        [Fact]
-        public async Task GetRequest_ShouldNotFailToExpandConversation_WhenNoMessagesExist()
-        {
-            using var adminScope = fixture.AdminScope();
+        //[Fact]
+        //public async Task GetRequest_ShouldNotFailToExpandConversation_WhenNoMessagesExist()
+        //{
+        //    using var adminScope = fixture.AdminScope();
 
-            var request = await Client.CreateDefaultRequestAsync(testProject);
+        //    var request = await Client.CreateDefaultRequestAsync(testProject);
 
-            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
-            {
-                conversation = new[] { new { id = Guid.Empty } }
-            });
+        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
+        //    {
+        //        conversation = new[] { new { id = Guid.Empty } }
+        //    });
 
-            result.Should().BeSuccessfull();
-            result.Value.conversation.Should().BeEmpty();
-        }
+        //    result.Should().BeSuccessfull();
+        //    result.Value.conversation.Should().BeEmpty();
+        //}
 
         [Fact]
         public async Task GetProjectsRequests_ShouldExpandActions()
@@ -506,25 +506,25 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             result.Value.value.First(x => x.id == requestB.Id).actions[0].sentBy.Should().NotBeNull();
         }
 
-        [Fact]
-        public async Task GetResourcesRequests_ShouldExpandActions_SentByShouldNotBeNull()
-        {
-            using var adminScope = fixture.AdminScope();
+        //[Fact]
+        //public async Task GetResourcesRequests_ShouldExpandActions_SentByShouldNotBeNull()
+        //{
+        //    using var adminScope = fixture.AdminScope();
 
-            var requestA = await Client.CreateDefaultRequestAsync(testProject);
-            var taskA = await Client.AddRequestActionAsync(requestA.Id);
+        //    var requestA = await Client.CreateDefaultRequestAsync(testProject);
+        //    var taskA = await Client.AddRequestActionAsync(requestA.Id);
 
-            var result = await Client.TestClientGetAsync($"/projects/{testProject.Project.ProjectId}/resources/requests/{requestA.Id}/?$expand=actions",
-                                                         new
-                                                         {
-                                                             id = Guid.Empty,
-                                                             actions = new[] { new { requestId = Guid.Empty, id = Guid.Empty, sentBy = new { } } }
-                                                         });
+        //    var result = await Client.TestClientGetAsync($"/projects/{testProject.Project.ProjectId}/resources/requests/{requestA.Id}/?$expand=actions",
+        //                                                 new
+        //                                                 {
+        //                                                     id = Guid.Empty,
+        //                                                     actions = new[] { new { requestId = Guid.Empty, id = Guid.Empty, sentBy = new { } } }
+        //                                                 });
 
-            result.Should().BeSuccessfull();
-            result.Value.actions[0].id.Should().Be(taskA.id);
-            result.Value.actions[0].sentBy.Should().NotBeNull();
-        }
+        //    result.Should().BeSuccessfull();
+        //    result.Value.actions[0].id.Should().Be(taskA.id);
+        //    result.Value.actions[0].sentBy.Should().NotBeNull();
+        //}
 
         [Fact]
         public async Task ListRequests_ShouldOrderRequests_WhenNumberSpecified()


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
AB#27683

Elin reported that request actions and notes should never be visible to task owners. This PR is a temporary fix to remove access to request notes for for anyone not a resource owner.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

