### PR TITLE
Open up request conversations/actions for task owners when they are the recipient

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Fusion.Resources.Api.Authorization;
 using Fusion.Resources.Api.Authorization.Requirements;
 using Fusion.Resources.Domain;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using System;
 using System.Linq;
 
@@ -58,6 +59,15 @@ namespace Fusion.Resources.Api.Controllers
         public static IAuthorizationRequirementRule OrgChartWriteAccess(this IAuthorizationRequirementRule builder, Guid orgProjectId)
         {
             return builder.AddRule(OrgProjectAccessRequirement.OrgWrite(orgProjectId));
+        }
+
+        public static IAuthorizationRequirementRule RequireConversationForTaskOwner(this IAuthorizationRequirementRule builder, QueryMessageRecipient recipient)
+        {
+            return builder.AddRule(new AssertionRequirement(_ => recipient == QueryMessageRecipient.TaskOwner));
+        }
+        public static IAuthorizationRequirementRule RequireConversationForResourceOwner(this IAuthorizationRequirementRule builder, QueryMessageRecipient recipient)
+        {
+            return builder.AddRule(new AssertionRequirement(_ => recipient == QueryMessageRecipient.ResourceOwner));
         }
 
         /// <summary>

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiActionCount.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiActionCount.cs
@@ -1,0 +1,18 @@
+﻿using Fusion.Resources.Domain;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class ApiActionCount
+    {
+        public ApiActionCount(QueryActionCounts actionCount)
+        {
+            Total = actionCount.TotalCount;
+            Resolved = actionCount.ResolvedCount;
+            Unresolved = actionCount.UnresolvedCount;
+        }
+
+        public int Total { get; }
+        public int Resolved { get; }
+        public int Unresolved { get; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -67,7 +67,7 @@ namespace Fusion.Resources.Api.Controllers
             ProvisioningStatus = new ApiProvisioningStatus(query.ProvisioningStatus);
 
             CorrelationId = query.CorrelationId;
-            ActionCount = query.ActionCount;
+            ActionCount = query.ActionCount is not null ? new ApiActionCount(query.ActionCount) : null;
         }
 
         public Guid Id { get; set; }
@@ -107,7 +107,7 @@ namespace Fusion.Resources.Api.Controllers
         public bool IsDraft { get; set; }
         public ApiProvisioningStatus ProvisioningStatus { get; set; }
         public Guid? CorrelationId { get; }
-        public int ActionCount { get; }
+        public ApiActionCount? ActionCount { get; }
         public List<ApiRequestAction>? Actions { get; }
         public List<ApiRequestConversationMessage>? Conversation { get; }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ApiModels/ApiResourceAllocationRequest.cs
@@ -67,6 +67,7 @@ namespace Fusion.Resources.Api.Controllers
             ProvisioningStatus = new ApiProvisioningStatus(query.ProvisioningStatus);
 
             CorrelationId = query.CorrelationId;
+            ActionCount = query.ActionCount;
         }
 
         public Guid Id { get; set; }
@@ -106,6 +107,7 @@ namespace Fusion.Resources.Api.Controllers
         public bool IsDraft { get; set; }
         public ApiProvisioningStatus ProvisioningStatus { get; set; }
         public Guid? CorrelationId { get; }
+        public int ActionCount { get; }
         public List<ApiRequestAction>? Actions { get; }
         public List<ApiRequestConversationMessage>? Conversation { get; }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
@@ -185,7 +185,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.Must(and =>
                 {
-                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.TaskOwner));
+                    and.RequireConversationForTaskOwner(conversation.Recipient);
                     if (requestItem.OrgPositionId.HasValue)
                         and.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
                 });
@@ -214,7 +214,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.Must(and =>
                 {
-                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.ResourceOwner));
+                    and.RequireConversationForResourceOwner(conversation.Recipient);
                     if (requestItem.AssignedDepartment is not null)
                     {
                         and.BeResourceOwner(
@@ -253,7 +253,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.Must(and =>
                 {
-                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.TaskOwner));
+                    and.RequireConversationForTaskOwner(conversation.Recipient);
                     if (requestItem.OrgPositionId.HasValue)
                         and.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
                 });
@@ -292,7 +292,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
                 r.Must(and =>
                 {
-                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.ResourceOwner));
+                    and.RequireConversationForResourceOwner(conversation.Recipient);
                     if (requestItem.AssignedDepartment is not null)
                     {
                         and.BeResourceOwner(

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
@@ -77,13 +77,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
-                r.LimitedAccessWhen(or =>
-                {
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                    or.BeRequestCreator(requestId);
-                });
-
+                
                 r.AnyOf(or =>
                 {
                     if (requestItem.AssignedDepartment is not null)
@@ -94,10 +88,13 @@ namespace Fusion.Resources.Api.Controllers.Requests
                             includeDescendants: true
                         );
                     }
-                    else
-                    {
-                        or.BeResourceOwner();
-                    }
+                    or.BeResourceOwner();
+                });
+
+                r.LimitedAccessWhen(or =>
+                {
+                    if (requestItem.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
                 });
             });
 
@@ -107,8 +104,8 @@ namespace Fusion.Resources.Api.Controllers.Requests
             #endregion
 
             var recipient = QueryMessageRecipient.TaskOwner;
-            if(!authResult.LimitedAuth)
-                recipient = QueryMessageRecipient.ResourceOwner;    
+            if (!authResult.LimitedAuth)
+                recipient = QueryMessageRecipient.ResourceOwner;
 
             var conversation = await DispatchAsync(new GetRequestConversation(requestId, recipient));
             return Ok(conversation.Select(x => new ApiRequestConversationMessage(x)));
@@ -125,7 +122,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
             var conversation = await DispatchAsync(new GetRequestConversationMessage(requestId, messageId));
             if (conversation is null) return FusionApiError.NotFound(messageId, $"Message with id '{messageId}' was not found.");
-          
+
             #region Authorization
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
@@ -136,7 +133,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     {
                         if (requestItem.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                        or.BeRequestCreator(requestId);
                     }
                     if (conversation.Recipient == QueryMessageRecipient.ResourceOwner)
                     {
@@ -173,7 +169,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
 
             var conversation = await DispatchAsync(new GetRequestConversationMessage(requestId, messageId));
-            if(conversation is null) return FusionApiError.NotFound(messageId, $"Message with id '{messageId}' was not found.");
+            if (conversation is null) return FusionApiError.NotFound(messageId, $"Message with id '{messageId}' was not found.");
 
             #region Authorization
 
@@ -188,7 +184,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                         {
                             if (requestItem.OrgPositionId.HasValue)
                                 or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                            or.BeRequestCreator(requestId);
                         }
                         if (conversation.Recipient == QueryMessageRecipient.ResourceOwner)
                         {

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
@@ -5,6 +5,7 @@ using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Commands.Conversations;
 using Fusion.Resources.Domain.Queries;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Linq;
@@ -17,9 +18,51 @@ namespace Fusion.Resources.Api.Controllers.Requests
     [ApiVersion("1.0")]
     public class ConversationsController : ResourceControllerBase
     {
-        [HttpPost("/requests/internal/{requestId}/conversation")]
         [HttpPost("/projects/{projectIdentifier}/requests/{requestId}/conversation")]
         [HttpPost("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation")]
+        public async Task<ActionResult> AddConversationMessage([FromRoute] Guid requestId, string? departmentString, [FromBody] AddRequestConversationMessageRequest request)
+        {
+            var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+            if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal();
+                r.AnyOf(or =>
+                {
+                    if (requestItem.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwner(
+                            new DepartmentPath(requestItem.AssignedDepartment).GoToLevel(2),
+                            includeParents: false,
+                            includeDescendants: true
+                        );
+                    }
+                    else
+                    {
+                        or.BeResourceOwner();
+                    }
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+            #endregion
+
+            var recipientType = request.Recipient.ToDomain();
+
+            var command = new AddRequestConversationMessage(requestId, request.Title, request.Body, request.Category, recipientType)
+            {
+                Properties = request.Properties
+            };
+
+            var created = await DispatchAsync(command);
+            return CreatedAtAction(nameof(GetRequestConversation), new { requestId, messageId = created.Id }, new ApiRequestConversationMessage(created));
+        }
+
+        [HttpPost("/requests/internal/{requestId}/conversation")]
         [HttpPost("/departments/{departmentString}/resources/requests/{requestId}/conversation")]
         public async Task<ActionResult> AddConversationMessage([FromRoute] Guid requestId, Guid? projectIdentifier, string? departmentString, [FromBody] AddRequestConversationMessageRequest request)
         {
@@ -63,11 +106,9 @@ namespace Fusion.Resources.Api.Controllers.Requests
             return CreatedAtAction(nameof(GetRequestConversation), new { requestId, messageId = created.Id }, new ApiRequestConversationMessage(created));
         }
 
-        [HttpGet("/requests/internal/{requestId}/conversation")]
         [HttpGet("/projects/{projectIdentifier}/requests/{requestId}/conversation")]
         [HttpGet("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation")]
-        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation")]
-        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid? projectIdentifier, string? departmentString)
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid? projectIdentifier)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -77,7 +118,35 @@ namespace Fusion.Resources.Api.Controllers.Requests
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
-                
+                r.AnyOf(or =>
+                {
+                    if (requestItem.OrgPositionId.HasValue)
+                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var conversation = await DispatchAsync(new GetRequestConversation(requestId, QueryMessageRecipient.TaskOwner));
+            return Ok(conversation.Select(x => new ApiRequestConversationMessage(x)));
+        }
+
+        [HttpGet("/requests/internal/{requestId}/conversation")]
+        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation")]
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, string? departmentString)
+        {
+            var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+            if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
+
                 r.AnyOf(or =>
                 {
                     if (requestItem.AssignedDepartment is not null)
@@ -90,12 +159,6 @@ namespace Fusion.Resources.Api.Controllers.Requests
                     }
                     or.BeResourceOwner();
                 });
-
-                r.LimitedAccessWhen(or =>
-                {
-                    if (requestItem.OrgPositionId.HasValue)
-                        or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                });
             });
 
             if (authResult.Unauthorized)
@@ -103,19 +166,12 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
             #endregion
 
-            var recipient = QueryMessageRecipient.TaskOwner;
-            if (!authResult.LimitedAuth)
-                recipient = QueryMessageRecipient.ResourceOwner;
-
-            var conversation = await DispatchAsync(new GetRequestConversation(requestId, recipient));
+            var conversation = await DispatchAsync(new GetRequestConversation(requestId, QueryMessageRecipient.ResourceOwner));
             return Ok(conversation.Select(x => new ApiRequestConversationMessage(x)));
         }
-
-        [HttpGet("/requests/internal/{requestId}/conversation/{messageId}")]
         [HttpGet("/projects/{projectIdentifier}/requests/{requestId}/conversation/{messageId}")]
         [HttpGet("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation/{messageId}")]
-        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
-        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid messageId, Guid? projectIdentifier, string? departmentString)
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid messageId, Guid? projectIdentifier)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -127,28 +183,11 @@ namespace Fusion.Resources.Api.Controllers.Requests
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
-                r.AnyOf(or =>
+                r.Must(and =>
                 {
-                    if (conversation.Recipient == QueryMessageRecipient.TaskOwner)
-                    {
-                        if (requestItem.OrgPositionId.HasValue)
-                            or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                    }
-                    if (conversation.Recipient == QueryMessageRecipient.ResourceOwner)
-                    {
-                        if (requestItem.AssignedDepartment is not null)
-                        {
-                            or.BeResourceOwner(
-                                new DepartmentPath(requestItem.AssignedDepartment).GoToLevel(2),
-                                includeParents: false,
-                                includeDescendants: true
-                            );
-                        }
-                        else
-                        {
-                            or.BeResourceOwner();
-                        }
-                    }
+                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.TaskOwner));
+                    if (requestItem.OrgPositionId.HasValue)
+                        and.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
                 });
             });
 
@@ -159,10 +198,46 @@ namespace Fusion.Resources.Api.Controllers.Requests
             return Ok(new ApiRequestConversationMessage(conversation));
         }
 
-        [HttpPut("/requests/internal/{requestId}/conversation/{messageId}")]
+        [HttpGet("/requests/internal/{requestId}/conversation/{messageId}")]
+        [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid messageId, string? departmentString)
+        {
+            var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+            if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
+
+            var conversation = await DispatchAsync(new GetRequestConversationMessage(requestId, messageId));
+            if (conversation is null) return FusionApiError.NotFound(messageId, $"Message with id '{messageId}' was not found.");
+
+            #region Authorization
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
+                r.Must(and =>
+                {
+                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.ResourceOwner));
+                    if (requestItem.AssignedDepartment is not null)
+                    {
+                        and.BeResourceOwner(
+                            new DepartmentPath(requestItem.AssignedDepartment).GoToLevel(2),
+                            includeParents: false,
+                            includeDescendants: true
+                        );
+                    }
+                    else
+                    {
+                        and.BeResourceOwner();
+                    }
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+            #endregion
+
+            return Ok(new ApiRequestConversationMessage(conversation));
+        }
         [HttpPut("/projects/{projectIdentifier}/requests/{requestId}/conversation/{messageId}")]
         [HttpPut("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation/{messageId}")]
-        [HttpPut("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
         public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, Guid? projectIdentifier, string? departmentString, [FromBody] UpdateRequestConversationMessageRequest request)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
@@ -175,32 +250,61 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
-                r.AlwaysAccessWhen().FullControl().FullControlInternal();
-                r.AnyOf(or =>
+                r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
+                r.Must(and =>
                 {
-                    r.AnyOf(or =>
+                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.TaskOwner));
+                    if (requestItem.OrgPositionId.HasValue)
+                        and.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+            #endregion
+
+            var recipientType = request.Recipient.ToDomain();
+
+            var command = new UpdateRequestConversationMessage(requestId, messageId, request.Title, request.Body, request.Category, recipientType)
+            {
+                Properties = request.Properties
+            };
+
+            var updated = await DispatchAsync(command);
+
+            return Ok(new ApiRequestConversationMessage(updated!));
+        }
+
+        [HttpPut("/requests/internal/{requestId}/conversation/{messageId}")]
+        [HttpPut("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
+        public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, string? departmentString, [FromBody] UpdateRequestConversationMessageRequest request)
+        {
+            var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
+            if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
+
+            var conversation = await DispatchAsync(new GetRequestConversationMessage(requestId, messageId));
+            if (conversation is null) return FusionApiError.NotFound(messageId, $"Message with id '{messageId}' was not found.");
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal().BeTrustedApplication();
+                r.Must(and =>
+                {
+                    and.AddRule(new AssertionRequirement(_ => conversation.Recipient == QueryMessageRecipient.ResourceOwner));
+                    if (requestItem.AssignedDepartment is not null)
                     {
-                        if (conversation.Recipient == QueryMessageRecipient.TaskOwner)
-                        {
-                            if (requestItem.OrgPositionId.HasValue)
-                                or.OrgChartPositionWriteAccess(requestItem.Project.OrgProjectId, requestItem.OrgPositionId.Value);
-                        }
-                        if (conversation.Recipient == QueryMessageRecipient.ResourceOwner)
-                        {
-                            if (requestItem.AssignedDepartment is not null)
-                            {
-                                or.BeResourceOwner(
-                                    new DepartmentPath(requestItem.AssignedDepartment).GoToLevel(2),
-                                    includeParents: false,
-                                    includeDescendants: true
-                                );
-                            }
-                            else
-                            {
-                                or.BeResourceOwner();
-                            }
-                        }
-                    });
+                        and.BeResourceOwner(
+                            new DepartmentPath(requestItem.AssignedDepartment).GoToLevel(2),
+                            includeParents: false,
+                            includeDescendants: true
+                        );
+                    }
+                    else
+                    {
+                        and.BeResourceOwner();
+                    }
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -525,7 +525,7 @@ namespace Fusion.Resources.Api.Controllers
 
             requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId).WithQuery(query));
 
-            var apiModel = new ApiResourceAllocationRequest(requestItem);
+            var apiModel = new ApiResourceAllocationRequest(requestItem!);
 
             if (projectIdentifier is null)
                 return apiModel;

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -511,7 +511,8 @@ namespace Fusion.Resources.Api.Controllers
 
             var requestCommand = new GetResourceAllocationRequests(query)
                 .ForTaskOwners()
-                .WithProjectId(projectIdentifier.ProjectId);
+                .WithProjectId(projectIdentifier.ProjectId)
+                .WithActionCount();
 
             var result = await DispatchAsync(requestCommand);
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -287,8 +287,6 @@ namespace Fusion.Resources.Api.Controllers
                 {
                     if (item.OrgPositionId.HasValue)
                         or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 
@@ -365,8 +363,6 @@ namespace Fusion.Resources.Api.Controllers
                     {
                         or.BeResourceOwner();
                     }
-
-                    or.BeRequestCreator(requestId);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/RequestActionsController.cs
@@ -120,6 +120,9 @@ namespace Fusion.Resources.Api.Controllers.Requests
                 return authResult.CreateForbiddenResponse();
             #endregion
 
+            // Actions have to be filtered based on who is responsible. In the list endpoint
+            // we use limited auth to flag that the current user is a task owner and filter
+            // actions accordingly.
             var responsible = QueryTaskResponsible.TaskOwner;
             if (!authResult.LimitedAuth)
                 responsible = QueryTaskResponsible.ResourceOwner;

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Conversations/GetRequestConversation.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Conversations/GetRequestConversation.cs
@@ -1,4 +1,5 @@
 ﻿using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -12,10 +13,12 @@ namespace Fusion.Resources.Domain.Commands.Conversations
     public class GetRequestConversation : IRequest<List<QueryConversationMessage>>
     {
         private Guid requestId;
+        private readonly DbMessageRecipient recipient;
 
-        public GetRequestConversation(Guid requestId)
+        public GetRequestConversation(Guid requestId, QueryMessageRecipient recipient)
         {
             this.requestId = requestId;
+            this.recipient = recipient.MapToDatabase();
         }
 
         public class Handler : IRequestHandler<GetRequestConversation, List<QueryConversationMessage>>
@@ -31,7 +34,7 @@ namespace Fusion.Resources.Domain.Commands.Conversations
             {
                 var conversation = await db.RequestConversations
                     .Include(m => m.Sender)
-                    .Where(m => m.RequestId == request.requestId)
+                    .Where(m => m.RequestId == request.requestId && m.Recpient == request.recipient)
                     .ToListAsync(cancellationToken);
 
                 return conversation.Select(m => new QueryConversationMessage(m)).ToList();

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/CountActionsForRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/CountActionsForRequests.cs
@@ -13,7 +13,8 @@ using System.Threading.Tasks;
 namespace Fusion.Resources.Domain
 {
     /// <summary>
-    /// Get all tasks for multiple requests, specified with request ids.
+    /// Count resolved, unresolved, and total tasks per recipient for given request ids without 
+    /// retrieving all actions from the database.
     /// </summary>
     public class CountActionsForRequests : IRequest<IDictionary<Guid, QueryActionCounts>>
     {

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/CountActionsForRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/CountActionsForRequests.cs
@@ -1,0 +1,46 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Integration;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Commands.Tasks
+{
+    /// <summary>
+    /// Get all tasks for multiple requests, specified with request ids.
+    /// </summary>
+    public class CountActionsForRequests : IRequest<IDictionary<Guid, int>>
+    {
+        private IEnumerable<Guid> requestId;
+
+        public CountActionsForRequests(IEnumerable<Guid> requestId)
+        {
+            this.requestId = requestId;
+        }
+
+        public class Handler : IRequestHandler<CountActionsForRequests, IDictionary<Guid, int>>
+        {
+            private readonly ResourcesDbContext db;
+            private readonly IFusionProfileResolver profileResolver;
+
+            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver)
+            {
+                this.db = db;
+                this.profileResolver = profileResolver;
+            }
+
+            public async Task<IDictionary<Guid, int>> Handle(CountActionsForRequests request, CancellationToken cancellationToken)
+            {
+                return await db.RequestActions
+                    .Where(t => request.requestId.Contains(t.RequestId))
+                    .GroupBy(t => t.RequestId)
+                    .ToDictionaryAsync(g => g.Key, g => g.Count(), cancellationToken);
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetActionsForRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetActionsForRequests.cs
@@ -1,0 +1,56 @@
+﻿using Fusion.ApiClients.Org;
+using Fusion.Integration;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Commands.Tasks
+{
+    /// <summary>
+    /// Get all tasks for multiple requests, specified with request ids.
+    /// </summary>
+    public class GetActionsForRequests : IRequest<ILookup<Guid, QueryRequestAction>>
+    {
+        private readonly DbTaskResponsible responsible;
+        private readonly Guid[] requestId;
+
+        public GetActionsForRequests(IEnumerable<Guid> requestId, QueryTaskResponsible responsible)
+        {
+            this.requestId = requestId.ToArray();
+            this.responsible = responsible.MapToDatabase();
+        }
+
+        public class Handler : IRequestHandler<GetActionsForRequests, ILookup<Guid, QueryRequestAction>>
+        {
+            private readonly ResourcesDbContext db;
+            private readonly IFusionProfileResolver profileResolver;
+
+            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver)
+            {
+                this.db = db;
+                this.profileResolver = profileResolver;
+            }
+
+            public async Task<ILookup<Guid, QueryRequestAction>> Handle(GetActionsForRequests request, CancellationToken cancellationToken)
+            {
+                var result = await db.RequestActions
+                    .Include(t => t.ResolvedBy)
+                    .Include(t => t.AssignedTo)
+                    .Include(t => t.SentBy)
+                    .Where(t => request.requestId.Contains(t.RequestId))
+                    .Where(t => t.Responsible == request.responsible || t.Responsible == DbTaskResponsible.Both)
+                    .ToListAsync(cancellationToken);
+
+                var actions = await result.AsQueryRequestActionsAsync(profileResolver);
+
+                return actions.ToLookup(x => x.RequestId);
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetRequestAction.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetRequestAction.cs
@@ -39,7 +39,7 @@ namespace Fusion.Resources.Domain.Commands.Tasks
                     .Include(t => t.SentBy)
                     .SingleOrDefaultAsync(t => t.RequestId == request.requestId && t.Id == request.taskId, cancellationToken);
 
-                return await action.AsQueryRequestActionAsync(profileResolver);
+                return action is not null ? await action.AsQueryRequestActionAsync(profileResolver) : null;
             }
         }
     }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetRequestActions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/GetRequestActions.cs
@@ -1,6 +1,7 @@
 ﻿using Fusion.AspNetCore.OData;
 using Fusion.Integration;
 using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -15,10 +16,12 @@ namespace Fusion.Resources.Domain.Commands.Tasks
     {
         private Guid requestId;
         private ODataQueryParams? query;
+        private DbTaskResponsible responsible;
 
-        public GetRequestActions(Guid requestId)
+        public GetRequestActions(Guid requestId, QueryTaskResponsible responsible)
         {
             this.requestId = requestId;
+            this.responsible = responsible.MapToDatabase();
         }
 
         public GetRequestActions WithQuery(ODataQueryParams query)
@@ -54,6 +57,9 @@ namespace Fusion.Resources.Domain.Commands.Tasks
                         opts.MapField("responsible", x => x.Responsible);
                     });
                 }
+
+                // Filter 
+                query = query.Where(t => t.Responsible == request.responsible || t.Responsible == DbTaskResponsible.Both);
 
                 var result = await query.ToListAsync(cancellationToken);
 

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/QueryTaskSource.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Tasks/QueryTaskSource.cs
@@ -1,14 +1,18 @@
-﻿namespace Fusion.Resources.Domain
+﻿using System;
+
+namespace Fusion.Resources.Domain
 {
     public enum QueryTaskSource
     {
         ResourceOwner,
         TaskOwner
     }
+
+    [Flags]
     public enum QueryTaskResponsible
     {
-        ResourceOwner,
-        TaskOwner,
-        Both
+        ResourceOwner = 0b01,
+        TaskOwner     = 0b10,
+        Both          = 0b11
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -135,12 +135,13 @@ namespace Fusion.Resources.Domain
         public List<QueryConversationMessage>? Conversation { get; set; }
 
         private int actionCount = 0;
-        public int ActionCount { 
+        public int ActionCount 
+        { 
             get 
-            { 
-                if(Actions is not null) return Actions.Count;
-
-                return actionCount;
+            {
+                if (Actions is null) return actionCount;
+                
+                return Actions.Count;
             } 
             set 
             { 

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -28,7 +28,6 @@ namespace Fusion.Resources.Domain
 
     public class QueryResourceAllocationRequest
     {
-
         public QueryResourceAllocationRequest(DbResourceAllocationRequest entity, QueryWorkflow? workflow = null)
         {
             RequestId = entity.Id;
@@ -134,6 +133,20 @@ namespace Fusion.Resources.Domain
         public QueryTaskOwner? TaskOwner { get; set; }
         public List<QueryRequestAction>? Actions { get; set; }
         public List<QueryConversationMessage>? Conversation { get; set; }
+
+        private int actionCount = 0;
+        public int ActionCount { 
+            get 
+            { 
+                if(Actions is not null) return Actions.Count;
+
+                return actionCount;
+            } 
+            set 
+            { 
+                actionCount = value;
+            }
+        }
 
         internal QueryResourceAllocationRequest WithResolvedOriginalPosition(ApiPositionV2 position, Guid? positionInstanceId)
         {

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryResourceAllocationRequest.cs
@@ -134,14 +134,14 @@ namespace Fusion.Resources.Domain
         public List<QueryRequestAction>? Actions { get; set; }
         public List<QueryConversationMessage>? Conversation { get; set; }
 
-        private int actionCount = 0;
-        public int ActionCount 
+        private QueryActionCounts? actionCount;
+        public QueryActionCounts? ActionCount 
         { 
             get 
             {
                 if (Actions is null) return actionCount;
                 
-                return Actions.Count;
+                return new QueryActionCounts(Actions.Count(x => x.IsResolved), Actions.Count(x => !x.IsResolved));
             } 
             set 
             { 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -11,6 +11,7 @@ using Fusion.Integration.Org;
 using Fusion.Resources.Domain.Commands.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Fusion.Resources.Domain.Commands.Conversations;
 
 namespace Fusion.Resources.Domain.Queries
 {
@@ -35,15 +36,6 @@ namespace Fusion.Resources.Domain.Queries
             {
                 Expands |= ExpandProperties.DepartmentDetails;
             }
-            //if(query.ShouldExpand("actions"))
-            //{
-            //    Expands |= ExpandProperties.Actions;
-            //}
-            //if(query.ShouldExpand("conversation"))
-            //{
-            //    Expands |= ExpandProperties.Conversation;
-            //}
-
 
             return this;
         }
@@ -62,7 +54,6 @@ namespace Fusion.Resources.Domain.Queries
             Expands |= ExpandProperties.TaskOwner;
             return this;
         }
-
 
         [Flags]
         public enum ExpandProperties
@@ -136,21 +127,6 @@ namespace Fusion.Resources.Domain.Queries
       
                 return requestItem;
             }
-
-            private async Task ExpandConversation(QueryResourceAllocationRequest requestItem)
-            {
-                requestItem.Conversation = await db.RequestConversations
-                                                   .Include(x => x.Sender)
-                                                   .Where(x => x.RequestId == requestItem.RequestId)
-                                                   .Select(x => new QueryConversationMessage(x))
-                                                   .ToListAsync();
-            }
-
-            //private async Task ExpandActions(QueryResourceAllocationRequest request)
-            //{
-            //    var actions = await mediator.Send(new GetActionsForRequests(new[] { request.RequestId }));
-            //    request.Actions = actions[request.RequestId].ToList();
-            //}
 
             private async Task ExpandDepartmentDetails(QueryResourceAllocationRequest requestItem)
             {

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequestItem.cs
@@ -122,7 +122,6 @@ namespace Fusion.Resources.Domain.Queries
                     .Include(r => r.ProposedPerson)
                     .FirstOrDefaultAsync(c => c.Id == request.RequestId);
 
-
                 if (row is null)
                     return null;
 
@@ -162,7 +161,6 @@ namespace Fusion.Resources.Domain.Queries
                 }
                 return requestItem;
             }
-
 
             private async Task ExpandDepartmentDetails(QueryResourceAllocationRequest requestItem)
             {
@@ -233,7 +231,5 @@ namespace Fusion.Resources.Domain.Queries
                 request.Actions = actions.ToList();
             }
         }
-
-
     }
 }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -89,11 +89,15 @@ namespace Fusion.Resources.Domain.Queries
         public GetResourceAllocationRequests ForResourceOwners()
         {
             Owner = DbInternalRequestOwner.ResourceOwner;
+            Recipient = QueryMessageRecipient.ResourceOwner;
+            Responsible = QueryTaskResponsible.ResourceOwner;
             return this;
         }
         public GetResourceAllocationRequests ForTaskOwners()
         {
             Owner = DbInternalRequestOwner.Project;
+            Recipient = QueryMessageRecipient.TaskOwner;
+            Responsible = QueryTaskResponsible.TaskOwner;
             return this;
         }
 
@@ -107,7 +111,13 @@ namespace Fusion.Resources.Domain.Queries
         {
             ExcludeWithoutProposedPerson = true;
             return this;
-    }
+        }
+
+        public GetResourceAllocationRequests WithActionCount()
+        {
+            Expands |= ExpandFields.ActionCount;
+            return this;
+        }
 
         public Guid? ProjectId { get; private set; }
         public string? DepartmentString { get; private set; }
@@ -116,7 +126,8 @@ namespace Fusion.Resources.Domain.Queries
         public bool? ExcludeCompleted { get; private set; }
 
         private DbInternalRequestOwner? Owner { get; set; }
-
+        public QueryMessageRecipient Recipient { get; private set; }
+        public QueryTaskResponsible Responsible { get; private set; }
         private ODataQueryParams Query { get; set; }
         private ExpandFields Expands { get; set; }
 
@@ -125,7 +136,7 @@ namespace Fusion.Resources.Domain.Queries
         /// </summary>
         public bool? ShouldIncludeAllRequests { get; private set; }
         public bool ExcludeWithoutProposedPerson { get; private set; }
-        
+
         /// <summary>
         /// Use <see cref="WithPositionId(Guid)"/>
         /// </summary>
@@ -138,6 +149,7 @@ namespace Fusion.Resources.Domain.Queries
             OrgPosition = 1 << 0,
             OrgPositionInstance = 1 << 1,
             DepartmentDetails = 1 << 2,
+            ActionCount = 1 << 3
         }
 
         public class Validator : AbstractValidator<GetResourceAllocationRequests>
@@ -147,12 +159,12 @@ namespace Fusion.Resources.Domain.Queries
                 RuleFor(x => x.Owner)
                     .Must(o => o.HasValue).When(x => !x.ShouldIncludeAllRequests.HasValue)
                     .WithMessage("GetResourceAllocationRequests must be scoped with either `ForAll()`, `ForResourceOwner`, or `ForTaskOwner()`");
-                
+
                 RuleFor(x => x.ShouldIncludeAllRequests)
                     .Must(o => o.HasValue).When(x => !x.Owner.HasValue)
                     .WithMessage("GetResourceAllocationRequests must be scoped with either `ForAll()`, `ForResourceOwner`, or `ForTaskOwner()`");
             }
-        }      
+        }
 
         public class Handler : IRequestHandler<GetResourceAllocationRequests, QueryRangedList<QueryResourceAllocationRequest>>
         {
@@ -182,7 +194,7 @@ namespace Fusion.Resources.Domain.Queries
                     .AsQueryable();
 
                 query = ApplySorting(query, request.Query);
-                
+
                 if (request.Owner is not null)
                     query = query.Where(r => r.IsDraft == false || r.RequestOwner == request.Owner);
 
@@ -228,7 +240,7 @@ namespace Fusion.Resources.Domain.Queries
                 var countOnly = request.OnlyCount;
 
                 var pagedQuery = await QueryRangedList.FromQueryAsync(query.Select(x => new QueryResourceAllocationRequest(x, null)), skip, take, countOnly);
-                
+
 
                 if (!countOnly)
                 {
@@ -236,9 +248,22 @@ namespace Fusion.Resources.Domain.Queries
                     await AddProposedPersons(pagedQuery);
                     await AddOrgPositions(pagedQuery, request.Expands);
                     await AddDepartmentDetails(pagedQuery, request.Expands);
+                    await AddActionCount(pagedQuery, request);
                 }
 
                 return pagedQuery;
+            }
+
+            private async Task AddActionCount(QueryRangedList<QueryResourceAllocationRequest> pagedQuery, GetResourceAllocationRequests request)
+            {
+                if (!request.Expands.HasFlag(ExpandFields.ActionCount)) return;
+
+                var actionCounts = await mediator.Send(new CountActionsForRequests(pagedQuery.Select(x => x.RequestId), request.Responsible));
+                foreach (var rq in pagedQuery)
+                {
+                    if (actionCounts.TryGetValue(rq.RequestId, out var count))
+                        rq.ActionCount = count;
+                }
             }
 
             private IQueryable<DbResourceAllocationRequest> ApplySorting(IQueryable<DbResourceAllocationRequest> query, ODataQueryParams odataQuery)
@@ -343,13 +368,14 @@ namespace Fusion.Resources.Domain.Queries
 
                 var profiles = await mediator.Send(new GetPersonProfiles(ids));
 
-                foreach(var request in requestItems)
+                foreach (var request in requestItems)
                 {
                     var id = request.ProposedPerson?.AzureUniqueId;
                     if (id is not null && profiles.ContainsKey(id.Value))
                         request.ProposedPerson!.Person = profiles[id.Value];
                 }
             }
-        }       
+        }
+
     }
 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -100,7 +100,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, false)]
         [InlineData("resourceOwner", ParentDepartment, false)]
         [InlineData("resourceOwner", SameL2Department, false)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanDeleteRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();
@@ -119,8 +118,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
         [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
-
         public async Task CanReadRequestsAssignedToDepartment(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();
@@ -139,8 +136,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
         [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
-
         public async Task CanEditGeneralOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();
@@ -193,7 +188,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
         [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanReassignDepartmentOnRequest(string role, string department, bool shouldBeAllowed)
         {
             const string changedDepartment = "TPD UPD ASD";
@@ -230,7 +224,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", ParentDepartment, true)]
         [InlineData("resourceOwner", SameL2Department, true)]
         [InlineData("resourceOwner", "PDP PRD FE ANE ANE5", true)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanAssignDepartmentOnUnassignedRequest(string role, string department, bool shouldBeAllowed)
         {
             const string changedDepartment = "TDI UPD QWE RTY1";
@@ -302,7 +295,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, false)]
         [InlineData("resourceOwner", ParentDepartment, false)]
         [InlineData("resourceOwner", SameL2Department, false)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanStartNormalRequest(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateRequest();
@@ -347,7 +339,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, true)]
         [InlineData("resourceOwner", ParentDepartment, true)]
         [InlineData("resourceOwner", SameL2Department, true)]
-        [InlineData("creator", "TPD RND WQE FQE", false)]
         [InlineData("taskOwner", TestDepartment, false)]
 
         public async Task CanProposeNormalRequest(string role, string department, bool shouldBeAllowed)
@@ -383,7 +374,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, false)]
         [InlineData("resourceOwner", ParentDepartment, false)]
         [InlineData("resourceOwner", SameL2Department, false)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         [InlineData("taskOwner", TestDepartment, true)]
         public async Task CanAcceptNormalRequest(string role, string department, bool shouldBeAllowed)
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -128,7 +128,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             using var userScope = fixture.UserScope(Users[role]);
 
             var client = fixture.ApiFactory.CreateClient();
-            var result = await client.TestClientGetAsync<TestApiInternalRequestModel>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
+            var result = await client.TestClientGetAsync<TestApiInternalRequestModel>($"/departments/{request.AssignedDepartment}/resources/requests/{request.Id}");
 
             if (shouldBeAllowed) result.Should().BeSuccessfull();
             else result.Should().BeUnauthorized();
@@ -149,7 +149,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var client = fixture.ApiFactory.CreateClient();
             var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
-                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                $"/departments/{request.AssignedDepartment}/resources/requests/{request.Id}",
                 new
                 {
                     proposedChanges = new
@@ -205,7 +205,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             {
                 var client = fixture.ApiFactory.CreateClient();
                 var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
-                    $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                    $"/departments/{request.AssignedDepartment}/resources/requests/{request.Id}",
                     new { assignedDepartment = TestDepartment }
                 );
                 result.Should().BeSuccessfull();
@@ -215,7 +215,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             {
                 var client = fixture.ApiFactory.CreateClient();
                 var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
-                    $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                    $"/departments/{request.AssignedDepartment}/resources/requests/{request.Id}",
                     new { assignedDepartment = changedDepartment }
                 );
 
@@ -249,7 +249,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var client = fixture.ApiFactory.CreateClient();
             var result = await client.TestClientPatchAsync<TestApiInternalRequestModel>(
-                $"/projects/{testProject.Project.ProjectId}/requests/{request.Id}",
+                $"/resources/requests/internal/{request.Id}",
                 new { assignedDepartment = changedDepartment }
             );
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -163,7 +163,6 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SiblingDepartment, false)]
         [InlineData("resourceOwner", ParentDepartment, false)]
         [InlineData("resourceOwner", SameL2Department, false)]
-        [InlineData("creator", "TPD RND WQE FQE", true)]
         public async Task CanEditAdditionalCommentOnRequestAssignedToDepartment(string role, string department, bool shouldBeAllowed)
         {
             var request = await CreateAndStartRequest();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -224,7 +224,7 @@ namespace Fusion.Resources.Api.Tests
             });
         }
 
-        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, Dictionary<string, object> props = null)
+        public static async Task<TestApiRequestAction> AddRequestActionAsync(this HttpClient client, Guid requestId, string responsible = "TaskOwner", Dictionary<string, object> props = null)
         {
             var payload = new
             {
@@ -233,7 +233,7 @@ namespace Fusion.Resources.Api.Tests
                 type = "test",
                 subType = "Test Test",
                 source = "ResourceOwner",
-                responsible = "TaskOwner",
+                responsible = responsible,
                 Properties = props
             };
 
@@ -267,7 +267,7 @@ namespace Fusion.Resources.Api.Tests
             return result.Value;
         }
 
-        public static Task<TestApiRequestMessage> AddRequestMessage(this HttpClient client, Guid requestId, Dictionary<string, object> props = null)
+        public static Task<TestApiRequestMessage> AddRequestMessage(this HttpClient client, Guid requestId, string recipient = "TaskOwner", Dictionary<string, object> props = null)
         {
             return AddRequestMessage(client, requestId,
                 new
@@ -275,7 +275,7 @@ namespace Fusion.Resources.Api.Tests
                     title = "Hello, world!",
                     body = "Goodbye, world!",
                     category = "world",
-                    recipient = "TaskOwner",
+                    recipient = recipient,
                     properties = props
                 }
             );

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -259,7 +259,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             await Client.StartProjectRequestAsync(testProject, normalRequest.Id);
             var assignedRequest = await Client.AssignRandomDepartmentAsync(normalRequest.Id);
             await Client.ProposePersonAsync(normalRequest.Id, testPerson);
-            await Client.AddRequestActionAsync(normalRequest.Id, x => x.isRequired = true);
+            await Client.AddRequestActionAsync(normalRequest.Id, x => {
+                x.isRequired = true;
+                x.responsible = "ResourceOwner";
+            });
 
             var resp = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{assignedRequest.AssignedDepartment}/requests/{normalRequest.Id}/approve", null);
             resp.Should().BeBadRequest();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -80,8 +80,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var assignedPerson = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile();
             // Create adjustment request on a position instance currently active
             adjustmentRequest = await adminClient.CreateDefaultResourceOwnerRequestAsync(
-                testDepartment, testProject, 
-                r => r.AsTypeResourceOwner(SUBTYPE_ADJUST), 
+                testDepartment, testProject,
+                r => r.AsTypeResourceOwner(SUBTYPE_ADJUST),
                 p => p.WithAssignedPerson(assignedPerson)
             );
         }
@@ -113,7 +113,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             var position = testProject.AddPosition();
 
-            var response = await Client.TestClientPostAsync($"/departments/{testDepartment}/resources/requests", new 
+            var response = await Client.TestClientPostAsync($"/departments/{testDepartment}/resources/requests", new
             {
                 type = type,
                 orgPositionId = position.Id,
@@ -212,7 +212,11 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             await Client.ProposeChangesAsync(adjustmentRequest.Id, new { workload = 50 });
             await Client.SetChangeParamsAsync(adjustmentRequest.Id, DateTime.Today.AddDays(1));
-            await Client.AddRequestActionAsync(adjustmentRequest.Id, x => x.isRequired = true);
+            await Client.AddRequestActionAsync(adjustmentRequest.Id, x =>
+            {
+                x.isRequired = true;
+                x.responsible = "ResourceOwner";
+            });
 
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests/{adjustmentRequest.Id}/start", null);
             response.Should().BeBadRequest();
@@ -258,9 +262,9 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task ChangeResourceRequest_Start_ShouldBeBadRequest_WhenMissingProposedPerson()
         {
             using var adminScope = fixture.AdminScope();
-            
-            var oldUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile();;
-            var newUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile();;
+
+            var oldUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile(); ;
+            var newUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile(); ;
 
             var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, r => r.AsTypeResourceOwner(SUBTYPE_CHANGE), p => p.WithAssignedPerson(oldUser));
 
@@ -277,8 +281,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             using var adminScope = fixture.AdminScope();
 
-            var oldUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile();;
-            var newUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile();;
+            var oldUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile(); ;
+            var newUser = PeopleServiceMock.AddTestProfile().WithAccountType(FusionAccountType.Employee).WithFullDepartment(testDepartment).WithDepartment(testDepartment).SaveProfile(); ;
 
             var request = await Client.CreateDefaultResourceOwnerRequestAsync(testDepartment, testProject, r => r.AsTypeResourceOwner(SUBTYPE_CHANGE), p => p.WithAssignedPerson(oldUser));
 
@@ -302,7 +306,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests/{request.Id}/start", null);
             response.Should().BeSuccessfull();
         }
-        
+
         [Fact]
         public async Task CreatRequestForUnassignedPositionInstance_ShouldGiveBadRequest()
         {
@@ -321,7 +325,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var newRequestResponse = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/departments/{testDepartment}/resources/requests", requestModel);
             newRequestResponse.Should().BeBadRequest();
         }
-        
+
         // Is this still relevant? i.e could a position instance become unassigned between change 
         // request is created and when it is started?
         //[Fact]
@@ -421,7 +425,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
 
             var response = await Client.TestClientOptionsAsync($"/projects/{position.ProjectId}/positions/{position.Id}/instances/{instance.Id}/resources/requests?requestType=resourceOwnerChange");
-            
+
             response.Should().BeSuccessfull();
             response.Should().HaveAllowHeaders(HttpMethod.Post);
         }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -413,71 +413,71 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             updated.Value.Workflow.Should().BeNull();
         }
 
-        //[Fact]
-        //public async Task GetRequest_ShouldIncludeTasks_WhenExpanded()
-        //{
-        //    using var adminScope = fixture.AdminScope();
+        [Fact]
+        public async Task GetRequest_ShouldIncludeTasks_WhenExpanded()
+        {
+            using var adminScope = fixture.AdminScope();
 
-        //    var request = await Client.CreateDefaultRequestAsync(testProject);
-        //    var task = await Client.AddRequestActionAsync(request.Id);
+            var request = await Client.CreateDefaultRequestAsync(testProject);
+            var task = await Client.AddRequestActionAsync(request.Id, responsible: "ResourceOwner");
 
-        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
-        //    {
-        //        actions = new[] { new { id = Guid.Empty } }
-        //    });
+            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
+            {
+                actions = new[] { new { id = Guid.Empty } }
+            });
 
-        //    result.Should().BeSuccessfull();
-        //    result.Value.actions.Should().Contain(t => t.id == task.id);
-        //}
+            result.Should().BeSuccessfull();
+            result.Value.actions.Should().Contain(t => t.id == task.id);
+        }
 
-        //[Fact]
-        //public async Task GetRequest_ShouldNotFailToExpandTasks_WhenNoTasksExist()
-        //{
-        //    using var adminScope = fixture.AdminScope();
+        [Fact]
+        public async Task GetRequest_ShouldNotFailToExpandTasks_WhenNoTasksExist()
+        {
+            using var adminScope = fixture.AdminScope();
 
-        //    var request = await Client.CreateDefaultRequestAsync(testProject);
+            var request = await Client.CreateDefaultRequestAsync(testProject);
 
-        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
-        //    {
-        //        actions = new[] { new { id = Guid.Empty } }
-        //    });
+            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=actions", new
+            {
+                actions = new[] { new { id = Guid.Empty } }
+            });
 
-        //    result.Should().BeSuccessfull();
-        //    result.Value.actions.Should().BeEmpty();
-        //}
+            result.Should().BeSuccessfull();
+            result.Value.actions.Should().BeEmpty();
+        }
 
-        //[Fact]
-        //public async Task GetRequest_ShouldIncludeConversation_WhenExpanded()
-        //{
-        //    using var adminScope = fixture.AdminScope();
+        [Fact]
+        public async Task GetRequest_ShouldIncludeConversation_WhenExpanded()
+        {
+            using var adminScope = fixture.AdminScope();
 
-        //    var request = await Client.CreateDefaultRequestAsync(testProject);
-        //    var message = await Client.AddRequestMessage(request.Id);
+            var request = await Client.CreateDefaultRequestAsync(testProject);
+            var message = await Client.AddRequestMessage(request.Id, recipient: "ResourceOwner");
 
-        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
-        //    {
-        //        conversation = new[] { new { id = Guid.Empty } }
-        //    });
+            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
+            {
+                conversation = new[] { new { id = Guid.Empty } }
+            });
 
-        //    result.Should().BeSuccessfull();
-        //    result.Value.conversation.Should().Contain(m => m.id == message.Id);
-        //}
+            result.Should().BeSuccessfull();
+            result.Value.conversation.Should().Contain(m => m.id == message.Id);
+        }
 
-        //[Fact]
-        //public async Task GetRequest_ShouldNotFailToExpandConversation_WhenNoMessagesExist()
-        //{
-        //    using var adminScope = fixture.AdminScope();
+        [Fact]
+        public async Task GetRequest_ShouldNotFailToExpandConversation_WhenNoMessagesExist()
+        {
+            using var adminScope = fixture.AdminScope();
 
-        //    var request = await Client.CreateDefaultRequestAsync(testProject);
+            var request = await Client.CreateDefaultRequestAsync(testProject);
 
-        //    var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
-        //    {
-        //        conversation = new[] { new { id = Guid.Empty } }
-        //    });
+            var result = await Client.TestClientGetAsync($"/resources/requests/internal/{request.Id}?$expand=conversation", new
+            {
+                conversation = new[] { new { id = Guid.Empty } }
+            });
 
-        //    result.Should().BeSuccessfull();
-        //    result.Value.conversation.Should().BeEmpty();
-        //}
+            result.Should().BeSuccessfull();
+            result.Value.conversation.Should().BeEmpty();
+        }
 
         //[Fact]
         //public async Task GetProjectsRequests_ShouldExpandActions()

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -710,7 +710,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             payload.Add(property, JToken.FromObject(value));
 
 
-            var response = await Client.TestClientPatchAsync<JObject>($"/resources/requests/internal/{request.Id}", payload);
+            var response = await Client.TestClientPatchAsync<JObject>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}", payload);
             response.Should().BeSuccessfull();
 
             var updatedProp = response.Value.Property(property)?.ToObject(value.GetType());

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
@@ -20,7 +20,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
     {
         private ResourceApiFixture fixture;
         private TestLoggingScope loggingScope;
-        private ApiPersonProfileV3 testUser;
+        private ApiPersonProfileV3 resourceOwner;
         private FusionTestProjectBuilder testProject;
         private TestApiInternalRequestModel normalRequest;
 
@@ -53,15 +53,15 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             normalRequest = await adminClient.CreateDefaultRequestAsync(testProject);
 
             // Generate random test user
-            testUser = fixture.AddProfile(FusionAccountType.Employee);
-            testUser.IsResourceOwner = true;
-            testUser.FullDepartment = normalRequest.AssignedDepartment ?? "PDP TST DPT";
+            resourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            resourceOwner.IsResourceOwner = true;
+            resourceOwner.FullDepartment = normalRequest.AssignedDepartment ?? "PDP TST DPT";
         }
 
         [Fact]
         public async Task AddMessage_Should_SetSenderMeta()
         {
-            using var scope = fixture.UserScope(testUser);
+            using var scope = fixture.UserScope(resourceOwner);
             var client = fixture.ApiFactory.CreateClient();
 
             var payload = new
@@ -84,7 +84,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             result.Body.Should().Be(payload.body);
             result.Recipient.Should().Be(payload.recipient);
 
-            result.Sender.AzureUniquePersonId.Should().Be(testUser.AzureUniqueId.GetValueOrDefault());
+            result.Sender.AzureUniquePersonId.Should().Be(resourceOwner.AzureUniqueId.GetValueOrDefault());
             result.Sent.Should().BeCloseTo(DateTimeOffset.UtcNow, 5000);
 
             result.Properties["customProp1"].Should().Be(payload.properties.customProp1);
@@ -94,7 +94,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task AddMessage_ShouldGiveNotFound_WhenRequestDoesNotExist()
         {
-            using var scope = fixture.UserScope(testUser);
+            using var scope = fixture.UserScope(resourceOwner);
             var client = fixture.ApiFactory.CreateClient();
 
             var payload = new
@@ -117,7 +117,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task UpdateMessage_Should_NotChangeSenderMeta()
         {
-            using var scope = fixture.UserScope(testUser);
+            using var scope = fixture.UserScope(resourceOwner);
             var client = fixture.ApiFactory.CreateClient();
             var message = await client.AddRequestMessage(normalRequest.Id, new Dictionary<string, object>
             {
@@ -146,7 +146,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             result.Value.Body.Should().Be(payload.body);
             result.Value.Recipient.Should().Be(payload.recipient);
 
-            result.Value.Sender.AzureUniquePersonId.Should().Be(testUser.AzureUniqueId.GetValueOrDefault());
+            result.Value.Sender.AzureUniquePersonId.Should().Be(resourceOwner.AzureUniqueId.GetValueOrDefault());
             result.Value.Sent.Should().Be(message.Sent);
 
             result.Value.Properties["customProp1"].Should().Be(payload.properties.customProp1);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
@@ -255,7 +255,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                .WithTestUser(fixture.AdminUser)
                .AddTestAuthToken();
 
-            var message = await adminClient.AddRequestMessage(normalRequest.Id, recipient);
+            var message = await adminClient.AddRequestMessage(normalRequest.Id, recipient: recipient);
 
             await ExecuteAsRole(role, async http =>
             {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
Proper fix for AB#27683

- Split request endpoints into two areas: `/project/{projectId}` and `/departments/{departmentId}`
    - This allows us to simplify access control for endpoints, because only task owners need access to the /project/ area, while only resource owners need access to the /departments area.
    - It also makes it possible to query actions and conversations by recipient/responsible without checking user information in the domain handlers.
- Add actionCount to request list endpoint to enable showing unresolved action count in list view without expanding all action data.
**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

