### PR TITLE
Resource owners should not be notfied on auto approved direct requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Initialize.cs
@@ -49,17 +49,24 @@ namespace Fusion.Resources.Logic.Commands
 
                     await mediator.Publish(new RequestInitialized(dbRequest.Id, dbRequest.Type, dbRequest.SubType, request.Editor.Person));
 
-                    if (ShouldDispatchNotification(dbRequest))
+                    if (await ShouldDispatchNotification(dbRequest))
                     {
                         await mediator.Publish(new InternalRequestNotifications.AssignedDepartment(dbRequest.Id));
                     }
                 }
 
-                private static bool ShouldDispatchNotification(DbResourceAllocationRequest dbRequest)
+                private async Task<bool> ShouldDispatchNotification(DbResourceAllocationRequest dbRequest)
                 {
                     // Should not notify for enterprise requests
                     if (string.Equals(dbRequest.SubType, AllocationEnterpriseWorkflowV1.SUBTYPE, StringComparison.OrdinalIgnoreCase))
                         return false;
+
+                    //Should not notify for direct requests if the request may be to auto approved
+                    if (string.Equals(dbRequest.SubType, AllocationDirectWorkflowV1.SUBTYPE, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var autoApprovalEnabledForResource = await mediator.Send(new Domain.Queries.GetPersonAutoApprovalStatus(dbRequest.ProposedPerson.AzureUniqueId!.Value));
+                        return !autoApprovalEnabledForResource.HasValue;
+                    }
 
                     return true;
                 }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Fusion.Integration.Profile;
 using Fusion.Integration.Profile.ApiClient;
 using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Resources.Api.Tests.FusionMocks;
 using Fusion.Resources.Integration.Models.Queue;
 using Fusion.Testing;
 using Fusion.Testing.Authentication.User;
@@ -561,6 +562,33 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             resp.Value.workflow.Should().NotBeNull();
             resp.Value.workflow.Steps.Should().Contain(s => s.Id == "proposal" && s.IsCompleted && s.State == "Skipped");
             resp.Value.workflow.Steps.Should().Contain(s => s.Id == "approval" && s.IsCompleted && s.State == "Skipped");
+        }
+
+
+        [Fact]
+        public async Task DirectRequest_AutoApproval_ShouldNotSendNotification_WhenAutoApprove()
+        {
+            var proposedPerson = PeopleServiceMock
+                .AddTestProfile()
+                .WithAccountType(FusionAccountType.Consultant)
+                .WithFullDepartment("PDP PRD FE TST XN ASD")
+                .SaveProfile();
+
+            using var adminScope = fixture.AdminScope();
+
+            var testRequest = await Client.CreateDefaultRequestAsync(testProject, r => r
+                .AsTypeDirect()
+                .WithAssignedDepartment("PDP PRD FE TST XN ASD")
+                .WithProposedPerson(proposedPerson));
+            
+            await Client.StartProjectRequestAsync(testProject, testRequest.Id);
+
+            NotificationClientMock.SentMessages.Clear();
+
+            var resp = await Client.TestClientGetAsync($"/projects/{projectId}/requests/{testRequest.Id}", new { workflow = new TestApiWorkflow() });
+            resp.Should().BeSuccessfull();
+
+            NotificationClientMock.SentMessages.Count.Should().Be(0);
         }
 
         #endregion


### PR DESCRIPTION
- [ ] ~~New feature~~
- [x] Bug fix
- [ ] ~~High impact~~

**Description of work:**


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

