### PR TITLE
Pro-Org - Positions having allocation request missing in org-chart histogram

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -89,7 +89,6 @@ namespace Fusion.Resources.Api.Controllers
                         ProposedPersonAzureUniqueId = request.ProposedPersonAzureUniqueId
                     });
                 }
-                await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
 
                 await transaction.CommitAsync();
 
@@ -172,8 +171,7 @@ namespace Fusion.Resources.Api.Controllers
                             ProposedPersonAzureUniqueId = request.ProposedPersonAzureUniqueId
                         });
                     }
-                    await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
-
+                    
                     var newRequestQuery = new GetResourceAllocationRequestItem(newRequest.RequestId)
                         .ExpandDepartmentDetails()
                         .ExpandResourceOwner()
@@ -269,7 +267,6 @@ namespace Fusion.Resources.Api.Controllers
                         ProposalChangeType = request.ProposalParameters?.Type
                     });
                 }
-                await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
 
                 await transaction.CommitAsync();
                 var query = new GetResourceAllocationRequestItem(newRequest.RequestId)
@@ -818,7 +815,6 @@ namespace Fusion.Resources.Api.Controllers
 
 
             await using var transaction = await BeginTransactionAsync();
-            await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(requestId, false));
             await DispatchAsync(new DeleteInternalRequest(requestId));
 
             await transaction.CommitAsync();

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -89,6 +89,7 @@ namespace Fusion.Resources.Api.Controllers
                         ProposedPersonAzureUniqueId = request.ProposedPersonAzureUniqueId
                     });
                 }
+                await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
 
                 await transaction.CommitAsync();
 
@@ -171,7 +172,8 @@ namespace Fusion.Resources.Api.Controllers
                             ProposedPersonAzureUniqueId = request.ProposedPersonAzureUniqueId
                         });
                     }
-                    
+                    await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
+
                     var newRequestQuery = new GetResourceAllocationRequestItem(newRequest.RequestId)
                         .ExpandDepartmentDetails()
                         .ExpandResourceOwner()
@@ -267,6 +269,7 @@ namespace Fusion.Resources.Api.Controllers
                         ProposalChangeType = request.ProposalParameters?.Type
                     });
                 }
+                await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(newRequest.RequestId, true));
 
                 await transaction.CommitAsync();
                 var query = new GetResourceAllocationRequestItem(newRequest.RequestId)
@@ -815,6 +818,7 @@ namespace Fusion.Resources.Api.Controllers
 
 
             await using var transaction = await BeginTransactionAsync();
+            await DispatchAsync(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(requestId, false));
             await DispatchAsync(new DeleteInternalRequest(requestId));
 
             await transaction.CommitAsync();

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/Handlers/InternalRequests/UpdateOrgPositionInstanceHaveRequestHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/Handlers/InternalRequests/UpdateOrgPositionInstanceHaveRequestHandler.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Resources.Domain.Notifications.InternalRequests;
+using Fusion.Resources.Domain.Queries;
+using MediatR;
+
+namespace Fusion.Resources.Api.FusionEvents.Handlers.InternalRequests
+{
+    public class UpdateOrgPositionInstanceHaveRequestHandler : INotificationHandler<InternalRequestCreated>, INotificationHandler<InternalRequestDeleted>
+    {
+        private readonly IMediator mediator;
+
+        public UpdateOrgPositionInstanceHaveRequestHandler(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+        public async Task Handle(InternalRequestCreated notification, CancellationToken cancellationToken)
+        {
+            var request = await mediator.Send(new GetResourceAllocationRequestItem(notification.RequestId));
+            if (request is null)
+                return;
+
+            await mediator.Send(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(request.Project.OrgProjectId, request.OrgPosition!.Id, request.OrgPositionInstance!.Id, true));
+        }
+
+        public async Task Handle(InternalRequestDeleted notification, CancellationToken cancellationToken)
+        {
+            await mediator.Send(new Logic.Commands.UpdateOrgPositionInstanceHaveRequest(notification.OrgProjectId, notification.OrgPositionId!.Value, notification.PositionInstanceId!.Value, false));
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/UpdateOrgPositionInstanceHaveRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/UpdateOrgPositionInstanceHaveRequest.cs
@@ -1,0 +1,73 @@
+﻿using Fusion.ApiClients.Org;
+using MediatR;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Resources.Domain.Queries;
+
+namespace Fusion.Resources.Logic.Commands
+{
+    public class UpdateOrgPositionInstanceHaveRequest : IRequest
+    {
+        public UpdateOrgPositionInstanceHaveRequest(Guid requestId, bool haveRequest)
+        {
+            RequestId = requestId;
+            HaveRequest = haveRequest;
+        }
+
+        public Guid RequestId { get; }
+        public bool HaveRequest { get; }
+
+        public class Handler : AsyncRequestHandler<UpdateOrgPositionInstanceHaveRequest>
+        {
+            private readonly IMediator mediator;
+            private readonly IOrgApiClient client;
+
+            public Handler(IOrgApiClientFactory orgApiClientFactory, IMediator mediator)
+            {
+                this.mediator = mediator;
+                this.client = orgApiClientFactory.CreateClient(ApiClientMode.Application);
+            }
+
+            protected override async Task Handle(UpdateOrgPositionInstanceHaveRequest request, CancellationToken cancellationToken)
+            {
+
+                var item = await mediator.Send(new GetResourceAllocationRequestItem(request.RequestId));
+                if (item is null)
+                    throw new InvalidOperationException($"Request with id{request.RequestId} not found");
+
+                var position = await client.GetPositionV2Async(item.Project.OrgProjectId, item.OrgPosition!.Id);
+
+                var instance = position?.Instances.FirstOrDefault(i => i.Id == item.OrgPositionInstance!.Id);
+                if (instance is null)
+                    throw new InvalidOperationException($"Could not locate instance {item.OrgPositionInstance!.Id} on the position {item.OrgPosition!.Id} for project {item.Project.OrgProjectId}.");
+
+                var instancePatchRequest = new JObject();
+                instance.Properties = EnsureHasRequestProperty(instance.Properties, request.HaveRequest);
+                instancePatchRequest.SetPropertyValue<ApiPositionInstanceV2>(i => i.Properties, instance.Properties);
+
+                var url = $"/projects/{item.Project.OrgProjectId}/positions/{item.OrgPosition!.Id}/instances/{item.OrgPositionInstance!.Id}?api-version=2.0";
+                var updateResp = await client.PatchAsync<ApiPositionInstanceV2>(url, instancePatchRequest);
+
+                if (!updateResp.IsSuccessStatusCode)
+                    throw new OrgApiError(updateResp.Response, updateResp.Content);
+            }
+
+            private static ApiPropertiesCollectionV2 EnsureHasRequestProperty(ApiPropertiesCollectionV2? properties, bool value)
+            {
+                properties ??= new ApiPropertiesCollectionV2();
+                if (properties.ContainsKey("hasRequest", true))
+                {
+                    properties["hasRequest"] = value;
+                }
+                else
+                {
+                    properties.Add("hasRequest", value);
+                }
+                return properties;
+            }
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -104,6 +104,18 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task Delete_InternalRequest_ShouldUpdateOrgPositionInstanceHasRequest()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
+            response.Should().BeSuccessfull();
+            // Ensure OrgPositionInstance have property hasRequest=false
+            var instance = OrgServiceMock.GetPosition(normalRequest.OrgPositionId!.Value).Instances.Single(x => x.Id == normalRequest.OrgPositionInstanceId);
+            instance.Properties.Single(x => x.Key == "hasRequest").Value.Should().Be(false);
+        }
+
+        [Fact]
         public async Task Delete_InternalRequest_ShouldSendSubscriptionEvent()
         {
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Fusion.ApiClients.Org;
-using System.Threading.Tasks;
-using System.Net.Http;
 
 namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
 {
@@ -145,6 +143,30 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
                     AzureUniqueId = request.AssignedPerson.Value.AzureUniqueId,
                     Mail = request.AssignedPerson.Value.Mail
                 };
+            }
+
+            if (request.Properties.HasValue)
+            {
+                if (request.Properties.Value is null)
+                {
+                    instance.Properties = null;
+                }
+                else
+                {
+                    instance.Properties ??= new ApiPropertiesCollectionV2();
+                    foreach (var (key, value) in request.Properties.Value)
+                    {
+                        var existingProp = instance.Properties.FirstOrDefault(x => x.Key == key);
+                        if (existingProp.Key is null)
+                        {
+                            instance.Properties.Add(key, value);
+                        }
+                        else
+                        {
+                            instance.Properties[key] = value;
+                        }
+                    }
+                }
             }
 
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When creating or deleting request, logic should update hasRequest property on pro-org position instance.
true if request is created
false if request is deleted

Property does not exist if no request exists. Property may exist on older instances created based on PIMS as source.
(Previously requests where handled in PIMS)

AB#28770


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Should be able to verify using histograms in Pro-Org app.
Creating request, should tag instance. Should reflect in historgram's.


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

