### PR TITLE
Unable to remove resource allocation request when pro-org position instance is already deleted

### DIFF
--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -109,10 +109,21 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             using var adminScope = fixture.AdminScope();
 
             var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
+            // Ensure removal of request was successful and OrgPositionInstance is missing.
             response.Should().BeSuccessfull();
-            // Ensure OrgPositionInstance have property hasRequest=false
             var instance = OrgServiceMock.GetPosition(normalRequest.OrgPositionId!.Value).Instances.Single(x => x.Id == normalRequest.OrgPositionInstanceId);
             instance.Properties.Single(x => x.Key == "hasRequest").Value.Should().Be(false);
+        }
+
+        [Fact]
+        public async Task Delete_InternalRequest_ShouldNotUpdateOrgPositionInstanceWhenDeleted()
+        {
+            using var adminScope = fixture.AdminScope();
+            OrgServiceMock.RemoveInstance(normalRequest.OrgPositionInstanceId!.Value);
+            var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
+            response.Should().BeSuccessfull();
+            var instance = OrgServiceMock.GetPosition(normalRequest.OrgPositionId!.Value).Instances.SingleOrDefault(x => x.Id == normalRequest.OrgPositionInstanceId);
+            instance.Should().BeNull();
         }
 
         [Fact]

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -91,5 +91,12 @@ namespace Fusion.Testing.Mocks.OrgService
         {
             return projects.FirstOrDefault(p => p.ProjectId == id);
         }
+
+        public static void RemoveInstance(Guid id)
+        {
+            var instance = positions.SelectMany(x => x.Instances).FirstOrDefault(x => x.Id == id);
+            if(instance is null) return;
+            positions.FirstOrDefault(x => x.Id == instance.PositionId)?.Instances.Remove(instance);
+        }
     }
 }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When trying to delete a request where linked org position instance was deleted, request failed.
Should be allowed to remove request, even if linked org position instance doesn't exist anymore.

(Currently about 175 instances with requests has been deleted)

AB#29287

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

