### PR TITLE
Hide TBN positions when above department in line org

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
@@ -44,20 +44,20 @@ namespace Fusion.Resources.Domain.Queries
 
                 var tbnPositions = new List<QueryTbnPosition>();
 
-                var sourceDepartment = new DepartmentPath(request.Department);
+                var resourceOwnerDepartment = new DepartmentPath(request.Department);
 
                 foreach (var pos in positions)
                 {
                     foreach (var instance in pos.Instances)
                     {
                         if (instance.AssignedPerson is not null) continue;
-                        // This should be some sort of configuration in the future
-                        if (sourceDepartment.IsParent(pos.BasePosition.Department))
+                        if (instance.AppliesTo < DateTime.UtcNow) continue;
+
+                        if (resourceOwnerDepartment.IsParent(pos.BasePosition.Department))
                         {
                             tbnPositions.Add(new QueryTbnPosition(pos, instance));
                         }
                     }
-
                 }
 
                 return tbnPositions;

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
@@ -51,9 +51,8 @@ namespace Fusion.Resources.Domain.Queries
                     foreach (var instance in pos.Instances)
                     {
                         if (instance.AssignedPerson is not null) continue;
-
                         // This should be some sort of configuration in the future
-                        if (sourceDepartment.IsRelevant(pos.BasePosition.Department))
+                        if (sourceDepartment.IsParent(pos.BasePosition.Department))
                         {
                             tbnPositions.Add(new QueryTbnPosition(pos, instance));
                         }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -49,7 +49,7 @@ namespace Fusion.Resources.Api.Tests.Fixture
             return delegatedAdmin;
         }
 
-        internal void DisableMemoryCache() => ApiFactory.isMemorycacheDisabled = true;
+        internal void DisableMemoryCache() => ApiFactory.IsMemorycacheDisabled = true;
 
         public ResourceApiFixture()
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourcesApiWebAppFactory.cs
@@ -83,7 +83,7 @@ namespace Fusion.Resources.Api.Tests.Fixture
         }
 
         private static object locker = new object();
-        public bool isMemorycacheDisabled = false;
+        public bool IsMemorycacheDisabled { get; set; } = false;
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
@@ -105,7 +105,7 @@ namespace Fusion.Resources.Api.Tests.Fixture
                 services.TryRemoveImplementationService("ContextEventReceiver");
                 services.TryRemoveImplementationService<ICompanyResolver>();
 
-                if (isMemorycacheDisabled)
+                if (IsMemorycacheDisabled)
                 {
                     services.TryRemoveImplementationService<IMemoryCache>();
                     services.AddScoped<IMemoryCache, AlwaysEmptyCache>();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/GetTbnPositionTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/GetTbnPositionTests.cs
@@ -1,0 +1,104 @@
+﻿using FluentAssertions;
+using Fusion.Integration.Profile.ApiClient;
+using Fusion.Resources.Api.Tests.Fixture;
+using Fusion.Resources.Domain.Queries;
+using Fusion.Testing;
+using Fusion.Testing.Mocks.OrgService;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Fusion.Resources.Domain.Tests
+{
+    public class GetTbnPositionTests : IClassFixture<ResourceApiFixture>
+    {
+        private ResourceApiFixture fixture;
+        private TestLoggingScope loggingScope;
+        private FusionTestProjectBuilder testProject;
+        private ApiPersonProfileV3 resourceOwner;
+
+        public GetTbnPositionTests(ResourceApiFixture fixture, ITestOutputHelper output)
+        {
+            this.fixture = fixture;
+            fixture.ApiFactory.IsMemorycacheDisabled = true;
+
+            // Make the output channel available for TestLogger.TryLog and the TestClient* calls.
+            loggingScope = new TestLoggingScope(output);
+
+            // Generate random test user
+
+            testProject = new FusionTestProjectBuilder()
+                .WithPositions(10)
+                .AddToMockService();
+
+            resourceOwner = fixture.AddResourceOwner("PDP PRD FE SE");
+        }
+
+        [Fact]
+        public async Task GetTbn_ShouldIgnorePositionsAboveResourceOwner()
+        {
+            using var userScope = fixture.UserScope(resourceOwner);
+
+            var expectedTbnPosition = testProject.AddPosition()
+                .WithEnsuredFutureInstances()
+                .WithNoAssignedPerson();
+            expectedTbnPosition.BasePosition.Department = "PDP PRD FE SE L5";
+
+            var positionAboveLeader = testProject
+                .AddPosition()
+                .WithEnsuredFutureInstances()
+                .WithNoAssignedPerson();
+            positionAboveLeader.BasePosition.Department = "PDP PRD";
+
+            var client = fixture.ApiFactory.CreateClient();
+            var response = await client.TestClientGetAsync($"departments/{resourceOwner.FullDepartment}/resources/requests/tbn", new[]
+            {
+                new { PositionId = Guid.Empty, BasePosition = new { Department = "" } }
+            });
+
+            var tbns = response.Value;
+            tbns.Should().NotContain(x => x.PositionId == positionAboveLeader.Id);
+            tbns.Should().Contain(x => x.PositionId == expectedTbnPosition.Id);
+            tbns.Should().OnlyContain(x => x.BasePosition.Department.StartsWith(resourceOwner.FullDepartment));
+        }
+
+        [Fact]
+        public async Task GetTbn_ShouldIgnoreExpiredPositions()
+        {
+            using var userScope = fixture.UserScope(resourceOwner);
+
+            var expectedTbnPosition = testProject.AddPosition()
+                .WithEnsuredFutureInstances()
+                .WithNoAssignedPerson();
+            expectedTbnPosition.BasePosition.Department = "PDP PRD FE SE L5";
+
+            var expiredPosition = testProject
+                .AddPosition()
+                .WithInstances(x =>
+                {
+                    var expiredInstance = x.AddInstance(TimeSpan.Zero);
+                    expiredInstance.AppliesFrom = new DateTime(2020, 04, 01);
+                    expiredInstance.AppliesTo = new DateTime(2021, 04, 01);
+                    expiredInstance.AssignedPerson = null;
+                });
+                
+            expiredPosition.BasePosition.Department = "PDP PRD FE SE";
+
+            var client = fixture.ApiFactory.CreateClient();
+            var response = await client.TestClientGetAsync($"departments/{resourceOwner.FullDepartment}/resources/requests/tbn", new[]
+            {
+                new { PositionId = Guid.Empty, BasePosition = new { Department = "" } }
+            });
+
+            var tbns = response.Value;
+            tbns.Should().NotContain(x => x.PositionId == expiredPosition.Id);
+            tbns.Should().Contain(x => x.PositionId == expectedTbnPosition.Id);
+            tbns.Should().OnlyContain(x => x.BasePosition.Department.StartsWith(resourceOwner.FullDepartment));
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -265,6 +265,14 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
         }
 
         [MapToApiVersion("2.0")]
+        [HttpGet("/admin/positions/tbn")]
+        public ActionResult<List<ApiPositionV2>> GetTbnPositions()
+        {
+            var tbns = OrgServiceMock.positions.Where(x => x.Instances.All(x => x.AssignedPerson is null)).ToList();
+            return Ok(tbns);
+        }
+
+        [MapToApiVersion("2.0")]
         [HttpGet("/projects/{projectId}/positions/{positionId}/instances/{instanceId}/reports-to")]
         public ActionResult GetPositionReportsTo([FromRoute] ProjectIdentifier projectId, Guid positionId, Guid instanceId)
         {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
AB#29030

Ignore TBN positions that are above resource owner department in line org.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

