### PR TITLE
API - Exception when trying to remove request where position in ORG is already deleted

### DIFF
--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -95,13 +95,31 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
         #region delete tests
         [Fact]
-        public async Task Delete_InternalRequest_ShouldBeSuccessfull()
+        public async Task Delete_InternalRequest_ShouldBeSuccessful()
         {
             using var adminScope = fixture.AdminScope();
 
             var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{normalRequest.Id}");
             response.Should().BeSuccessfull();
         }
+
+        [Fact]
+        public async Task Delete_InternalRequest_OrgPositionMissing_ShouldBeSuccessful()
+        {
+            using var adminScope = fixture.AdminScope();
+            var adminClient = fixture.ApiFactory.CreateClient()
+                .WithTestUser(fixture.AdminUser)
+                .AddTestAuthToken();
+
+            var requestWithoutPosition = await adminClient.CreateDefaultRequestAsync(testProject);
+
+            OrgServiceMock.RemovePosition(requestWithoutPosition.OrgPositionId!.Value);
+
+            var response = await Client.TestClientDeleteAsync($"/resources/requests/internal/{requestWithoutPosition.Id}");
+            // Ensure removal of request was successful even if Org Position is missing.
+            response.Should().BeSuccessfull();
+        }
+
 
         [Fact]
         public async Task Delete_InternalRequest_ShouldUpdateOrgPositionInstanceHasRequest()

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/OrgServiceMock.cs
@@ -2,14 +2,11 @@
 using Fusion.Testing.Mocks.OrgService.Api;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 
 namespace Fusion.Testing.Mocks.OrgService
 {
@@ -92,10 +89,15 @@ namespace Fusion.Testing.Mocks.OrgService
             return projects.FirstOrDefault(p => p.ProjectId == id);
         }
 
+        public static void RemovePosition(Guid id)
+        {
+            var newPositions = positions.Where(x => x.Id != id);
+            positions = new ConcurrentBag<ApiPositionV2>(newPositions);
+        }
         public static void RemoveInstance(Guid id)
         {
             var instance = positions.SelectMany(x => x.Instances).FirstOrDefault(x => x.Id == id);
-            if(instance is null) return;
+            if (instance is null) return;
             positions.FirstOrDefault(x => x.Id == instance.PositionId)?.Instances.Remove(instance);
         }
     }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When trying to delete a request, where the ORG Project Position is already removed, you will receive an error.
Make sure we are able to delete an internal resource allocation request even if ORG position is deleted.

[AB#30371](https://dev.azure.com/statoil-proview/Fusion/_workitems/edit/30371)

**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

Tried to remove locally connecting a request to a non existing position guid

In CI you can verify this by trying to delete requests missing positions found [here](https://pro-s-portal-ci.azurewebsites.net/apps/org-admin/29ddab36-e7a9-418b-a9e4-8cfbc9591274/open-requests)
![image](https://user-images.githubusercontent.com/2544455/177936233-4bd57ae5-1127-4876-b43a-b8a98a1f03f7.png)


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

