### PR TITLE
Add v2 of person absence analytics endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
@@ -70,6 +70,33 @@ namespace Fusion.Resources.Api.Controllers
             return collection;
         }
 
+        [MapToApiVersion("2.0")]
+        [HttpGet("/analytics/absence/internal")]
+        public async Task<ActionResult<ApiCollection<ApiPersonAbsenceForAnalyticsV2>>> GetPersonsAbsenceV2([FromQuery] ODataQueryParams query)
+        {
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AlwaysAccessWhen().FullControl().FullControlInternal();
+                r.AnyOf(or =>
+                {
+                    or.GlobalRoleAccess("Fusion.Analytics.Requests");
+                });
+
+            });
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var allAbsenceQuery = await DispatchAsync(new GetPersonsAbsenceForAnalytics(query));
+            var apiModel = allAbsenceQuery.Select(ApiPersonAbsenceForAnalyticsV2.CreateWithoutConfidentialTaskInfoForAnalytics);
+
+            var collection = new ApiCollection<ApiPersonAbsenceForAnalyticsV2>(apiModel) { TotalCount = allAbsenceQuery.TotalCount };
+            return collection;
+        }
+
         #region Analytics Api Models
         public class ApiPersonAbsenceForAnalytics
         {
@@ -104,6 +131,44 @@ namespace Fusion.Resources.Api.Controllers
             public ApiTaskDetails? TaskDetails { get; set; }
             public DateTimeOffset AppliesFrom { get; set; }
             public DateTimeOffset? AppliesTo { get; set; }
+            public ApiPersonAbsence.ApiAbsenceType Type { get; set; }
+            public double? AbsencePercentage { get; set; }
+        }
+
+        public class ApiPersonAbsenceForAnalyticsV2
+        {
+
+            private ApiPersonAbsenceForAnalyticsV2(QueryPersonAbsenceBasic absence)
+            {
+                Id = absence.Id;
+                AppliesFrom = absence.AppliesFrom;
+                AppliesTo = absence.AppliesTo;
+                Type = Enum.Parse<ApiPersonAbsence.ApiAbsenceType>($"{absence.Type}", true);
+                AbsencePercentage = absence.AbsencePercentage;
+
+                IsPrivate = absence.IsPrivate;
+                Comment = absence.Comment;
+                TaskDetails = (absence.TaskDetails != null) ? new ApiTaskDetails(absence.TaskDetails) : null;
+
+                if (absence.Person is not null) Person = new ApiPerson(absence.Person);
+
+                if (absence.IsPrivate || absence.Type == QueryAbsenceType.Absence)
+                {
+                    Comment = "Not disclosed.";
+                    TaskDetails = (absence.TaskDetails != null) ? ApiTaskDetails.Hidden : null;
+                }
+            }
+
+            public static ApiPersonAbsenceForAnalyticsV2 CreateWithoutConfidentialTaskInfoForAnalytics(QueryPersonAbsenceBasic absence) => new(absence);
+
+            public Guid Id { get; set; }
+            public bool IsPrivate { get; set; }
+            public string? Comment { get; set; }
+            public ApiPerson? Person { get; set; }
+            public ApiTaskDetails? TaskDetails { get; set; }
+            public DateTimeOffset AppliesFrom { get; set; }
+            public DateTimeOffset? AppliesTo { get; set; }
+            [JsonConverter(typeof(JsonStringEnumConverter))]
             public ApiPersonAbsence.ApiAbsenceType Type { get; set; }
             public double? AbsencePercentage { get; set; }
         }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -203,6 +203,29 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var response = await Client.TestClientGetAsync<object>($"/analytics/requests/internal");
             response.Should().BeSuccessfull();
         }
+
+        [Fact]
+        public async Task Get_AnalyticsRequestsInternalV1_ShouldNotHaveReadableTypeNames()
+        {
+            using var adminScope = fixture.AdminScope();
+            var absentee = fixture.AddProfile(FusionAccountType.Employee);
+            await Client.AddAbsence(absentee, x => x.Type = "OtherTasks");
+            var response = await Client.TestClientGetAsync($"/analytics/absence/internal", new { value = new[] { new { type = default(int) } } });
+            response.Should().BeSuccessfull();
+            response.Value.value.Single().type.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task Get_AnalyticsRequestsInternalV2_ShouldHaveReadableTypeNames()
+        {
+            using var adminScope = fixture.AdminScope();
+            var absentee = fixture.AddProfile(FusionAccountType.Employee);
+            await Client.AddAbsence(absentee, x => x.Type = "OtherTasks");
+            var response = await Client.TestClientGetAsync($"/analytics/absence/internal?api-version=2.0", new { value = new[] { new { type = default(string) } } });
+            response.Should().BeSuccessfull();
+            response.Value.value.Single().type.Should().Be("OtherTasks");
+        }
+
         [Fact]
         public async Task Get_AnalyticsPersonsAbsenceInternal_ShouldBeSuccessfull_WhenAdmin()
         {


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Add new version of person absence analytics endpoint with enum values for type serialized as string instead of internal int value.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

