### PR TITLE
Avoid removing comments when request is completed

### DIFF
--- a/src/backend/api/Fusion.Resources.Logic/CloseSecondOpinionsHandler.cs
+++ b/src/backend/api/Fusion.Resources.Logic/CloseSecondOpinionsHandler.cs
@@ -28,8 +28,6 @@ namespace Fusion.Resources.Logic
             {
                 if(response.State != DbSecondOpinionResponseStates.Published)
                     response.State = DbSecondOpinionResponseStates.Closed;
-                
-                response.Comment = "Comments are hidden when request is closed.";
             }
 
             await db.SaveChangesAsync(ct);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SecondOpinionTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SecondOpinionTests.cs
@@ -375,7 +375,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
 
         [Fact]
-        public async Task ClosingRequest_ShouldHidePublishedSecondOpinions()
+        public async Task ClosingRequest_ShouldNotHidePublishedSecondOpinions()
         {
             using var adminScope = fixture.AdminScope();
             var request = await Client.CreateDefaultRequestAsync(testProject);
@@ -396,8 +396,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var prompt = result.Value.First();
 
             prompt.Responses
-                .All(x => x.Comment == "Comments are hidden when request is closed.")
-                .Should().BeTrue();
+                .Should()
+                .NotContain(x => x.Comment == "Comments are hidden when request is closed.");
         }
 
         [Fact]


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**

Prevent second opinions from being hidden after request completion.

AB#30775

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

