### PR TITLE
Fix inconsistent Allow header in OPTIONS for completed rquests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/SecondOpinionController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/SecondOpinionController.cs
@@ -50,7 +50,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
             if (authResult.Success)
             {
                 allowed.Add("GET");
-                if (!authResult.LimitedAuth) allowed.Add("POST");
+                if (!authResult.LimitedAuth && !requestItem.IsCompleted) allowed.Add("POST");
             }
 
             Response.Headers.Add("Allow", string.Join(',', allowed));


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**

AB#30955

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

