### PR TITLE
When a profile is updated, updated users may still remain in cache.

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ProfileUpdatedHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/NotificationHandlers/ProfileUpdatedHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Fusion.Integration.Diagnostics;
 using Fusion.Integration.Profile;
+using Fusion.Integration.Profile.Internal;
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using MediatR;
@@ -16,11 +17,13 @@ namespace Fusion.Resources.Domain.Notifications
         {
             private readonly ResourcesDbContext dbContext;
             private readonly IFusionLogger<ProfileUpdatedHandler> logger;
+            private readonly IProfileCache fusionProfileResolverCache;
 
-            public ProfileUpdatedHandler(ResourcesDbContext dbContext, IFusionLogger<ProfileUpdatedHandler> logger)
+            public ProfileUpdatedHandler(ResourcesDbContext dbContext, IFusionLogger<ProfileUpdatedHandler> logger, IProfileCache fusionProfileResolverCache)
             {
                 this.dbContext = dbContext;
                 this.logger = logger;
+                this.fusionProfileResolverCache = fusionProfileResolverCache;
             }
 
             public async Task Handle(ProfileUpdated notification, CancellationToken cancellationToken)
@@ -48,7 +51,11 @@ namespace Fusion.Resources.Domain.Notifications
 
                     await dbContext.SaveChangesAsync();
                     logger.LogInformation("Updated profile for {UPN} ({UniqueId})", notification.Profile.UPN, notification.Profile.AzureUniqueId);
+
                 }
+
+                // Received profile updated event. Remove from profile resolver cache to get a fresh profile in next request.
+                await fusionProfileResolverCache.RemoveAsync(notification.Profile.Identifier);
             }
 
             private async Task<DbPerson?> ResolveDbPersonAsync(FusionPersonProfile profile)


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When backend receives a ProfileUpdated event, we ensure local profile is updated.
However we don't flush the fusion profile resolver cache.

Ensure updated user is removed from cache during ProfileUpdatedHandler

[AB#31121](https://dev.azure.com/statoil-proview/Fusion/_workitems/edit/32121)


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

