### PR TITLE
Context issue when trying to initiate workflow

### DIFF
--- a/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
+++ b/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
@@ -13,7 +13,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fusion.Integration.Abstractions" Version="6.0.8" />
+    <PackageReference Include="Fusion.Integration.Abstractions" Version="6.0.9" />
     <PackageReference Include="Fusion.Integration.Authorization" Version="6.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="34.0.2" />
-		<PackageReference Include="Fusion.Integration" Version="6.0.8" />
+		<PackageReference Include="Fusion.Integration" Version="6.0.9" />
 		<PackageReference Include="Fusion.Events.Server" Version="3.0.0" />
 		<PackageReference Include="Fusion.Integration.Authorization" Version="6.0.9" />
 

--- a/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
+++ b/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fusion.Integration.LineOrg" Version="6.0.5" />
-    <PackageReference Include="Fusion.Integration.Profile" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Fusion.AspNetCore" Version="6.0.3" />
     <PackageReference Include="Fusion.Threading" Version="3.1.5" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.7" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.6" />
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="6.0.1" />
     <PackageReference Include="Fusion.Integration.Roles.Abstractions" Version="6.1.5" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />

--- a/src/backend/function/Fusion.Resources.Functions/Fusion.Resources.Functions.csproj
+++ b/src/backend/function/Fusion.Resources.Functions/Fusion.Resources.Functions.csproj
@@ -5,7 +5,7 @@
 	  <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.6" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.7" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />

--- a/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
+++ b/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.6" />
     <PackageReference Include="Fusion.ApiClients.People" Version="2.0.0-preview-1" />
     <PackageReference Include="Fusion.Infrastructure.Authentication" Version="6.0.0" />
 

--- a/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
+++ b/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.6" />
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fusion.AspNetCore" Version="6.0.3" />
-    <PackageReference Include="Fusion.Integration.Context" Version="6.0.3" />
+    <PackageReference Include="Fusion.Integration.Context" Version="6.0.4" />
     <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="6.0.2" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.7" />
 

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.5" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="6.0.6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
When trying to initiate workflow when context-cache in integration library contains multiple cache items of same id, backend endpoint crashed.

Fixed by adding duplicate-check in integration library.

Solved here by upgrading nuget packages, referencing newer versions of fusion packages.

AB#32221

**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

