### PR TITLE
GetPositionDepartments needed to also return ExpandedDelegatedDepartments

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
@@ -123,7 +123,7 @@ namespace Fusion.Resources.Api.Controllers
             var routedDepartment = await requestRouter.RouteAsync(position, instanceId, cancellationToken);
             if (string.IsNullOrWhiteSpace(routedDepartment)) return result;
 
-            var department = await DispatchAsync(new GetDepartment(routedDepartment));
+            var department = await DispatchAsync(new GetDepartment(routedDepartment).ExpandDelegatedResourceOwners());
             var related = await DispatchAsync(new GetRelatedDepartments(position.BasePosition.Department));
 
             if (related is not null)


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
GetPositionDepartments needed to also return ExpandedDelegatedDepartments, the api suggested it already did, but the expanded method was not added to actualy return the data. 

[AB#33250](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/33250)

**Testing:**
- [X] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Have tested localy and it now returns expandedDelegatedResouceOwners


**Checklist:**
- [X] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [ ] Considered security
- [X] Performed developer testing
- [x] Checklist finalized / ready for review

