### PR TITLE
Querying delegated department responsibles doesnt consider valid dateframe

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentHandlerBase.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentHandlerBase.cs
@@ -41,7 +41,8 @@ namespace Fusion.Resources.Domain
             var departmentIds = departments.Select(x => x.DepartmentId).ToArray();
 
             var query = await db.DelegatedDepartmentResponsibles
-                .Where(r => departmentIds.Contains(r.DepartmentId))
+                .Where(r => departmentIds.Contains(r.DepartmentId) &&
+                r.DateTo >= DateTime.Today && r.DateFrom <= DateTime.Today)
                 .ToListAsync(cancellationToken);
 
             var delegatedMap = query.ToLookup(x => x.DepartmentId);

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentHandlerBase.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentHandlerBase.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Fusion.Resources.Database.Entities;
+using System;
 
 namespace Fusion.Resources.Domain
 {
@@ -28,7 +29,8 @@ namespace Fusion.Resources.Domain
         internal async Task ExpandDelegatedResourceOwner(QueryDepartment department, CancellationToken cancellationToken)
         {
             var delegatedResourceOwners = await db.DelegatedDepartmentResponsibles
-                .Where(r => r.DepartmentId == department.DepartmentId)
+                .Where(r => r.DepartmentId == department.DepartmentId &&
+                r.DateTo >= DateTime.Today && r.DateFrom <= DateTime.Today)
                 .ToListAsync(cancellationToken);
 
             await ResolveDelegatedOwners(department, delegatedResourceOwners);
@@ -51,7 +53,7 @@ namespace Fusion.Resources.Domain
             }
         }
 
-        private async Task ResolveDelegatedOwners(QueryDepartment department,  IEnumerable<DbDelegatedDepartmentResponsible>? delegatedResourceOwners)
+        private async Task ResolveDelegatedOwners(QueryDepartment department, IEnumerable<DbDelegatedDepartmentResponsible>? delegatedResourceOwners)
         {
             if (delegatedResourceOwners is null) return;
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDelegatedDepartmentResponsibles.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDelegatedDepartmentResponsibles.cs
@@ -44,7 +44,8 @@ namespace Fusion.Resources.Domain
                     return returnModel;
 
                 var delegatedResourceOwners = await db.DelegatedDepartmentResponsibles
-                    .Where(r => r.DepartmentId == request.DepartmentId)
+                    .Where(r => r.DepartmentId == request.DepartmentId &&
+                r.DateTo >= DateTime.Today && r.DateFrom <= DateTime.Today)
                     .ToListAsync(cancellationToken);
 
                 foreach (var m in delegatedResourceOwners)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fixture/ResourceApiFixture.cs
@@ -83,10 +83,12 @@ namespace Fusion.Resources.Api.Tests.Fixture
             return resourceOwner;
         }
 
-        internal void EnsureDepartment(string departmentId, string sectorId = null, ApiPersonProfileV3 defactoResponsible = null)
+        internal void EnsureDepartment(string departmentId, string sectorId = null, ApiPersonProfileV3 defactoResponsible = null, int daysFrom = -1, int daysTo = 1)
         {
             using var scope = ApiFactory.Services.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ResourcesDbContext>();
+
+            
 
             LineOrgServiceMock.AddDepartment(departmentId);
 
@@ -94,8 +96,8 @@ namespace Fusion.Resources.Api.Tests.Fixture
             {
                 db.DelegatedDepartmentResponsibles.Add(new Database.Entities.DbDelegatedDepartmentResponsible()
                 {
-                    DateFrom = DateTime.Today.AddDays(-1),
-                    DateTo = DateTime.Today.AddDays(1),
+                    DateFrom = DateTime.Today.AddDays(daysFrom),
+                    DateTo = DateTime.Today.AddDays(daysTo),
                     DepartmentId = departmentId,
                     ResponsibleAzureObjectId = defactoResponsible.AzureUniqueId.GetValueOrDefault(),
                     Reason = "Just for testing"

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -125,6 +125,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             mainResourceOwner.FullDepartment = $"AAA BBB CCC DDD EE FFF";
             var delegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var secondDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
+            var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
             await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
             {
@@ -144,18 +146,37 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 Source = source
             });
 
+            await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            {
+                Identifier = $"{Guid.NewGuid()}",
+                RoleName = AccessRoles.ResourceOwner,
+                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+                ValidTo = DateTime.UtcNow.AddDays(1),
+                Source = source
+            });
+            await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            {
+                Identifier = $"{Guid.NewGuid()}",
+                RoleName = AccessRoles.ResourceOwner,
+                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+                ValidTo = DateTime.UtcNow.AddDays(1),
+                Source = source
+            });
+
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();
 
             fixture.EnsureDepartment(delegatedDepartment, null, delegatedResourceOwner);
             fixture.EnsureDepartment(delegatedDepartment, null, secondDelegatedResourceOwner);
+            fixture.EnsureDepartment(delegatedDepartment, null, expiredDelegatedResourceOwner, -2, -1);
+            fixture.EnsureDepartment(delegatedDepartment, null, notStartedDelegatedResourceOwner, +2, +5);
 
             var resp = await Client.TestClientGetAsync<TestDepartment>($"/departments/{delegatedDepartment}");
             TestLogger.TryLogObject(resp);
             resp.Response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             resp.Value.Name.Should().Contain(delegatedDepartment);
-            resp.Value.DelegatedResponsibles.Should().HaveCountGreaterOrEqualTo(2);
+            resp.Value.DelegatedResponsibles.Should().HaveCount(2);
             resp.Value.DelegatedResponsibles.Should().Contain(d => d.AzureUniquePersonId.Equals(delegatedResourceOwner.AzureUniqueId));
             resp.Value.DelegatedResponsibles.Should().Contain(d => d.AzureUniquePersonId.Equals(secondDelegatedResourceOwner.AzureUniqueId));
         }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -159,6 +159,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
 
+
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -186,7 +186,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             var source = $"Department.Test";
             var delegatedDepartment = "AAA BBB CCC DDD";
-            var secondDepartment = "AAA BBB CCC EEE";
             var mainResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             mainResourceOwner.FullDepartment = $"AAA BBB CCC DDD EE FFF";
             var delegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -128,40 +128,40 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
-            await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
-            await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
-            await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
-            await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
+            //await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();
@@ -193,40 +193,40 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
-            await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
-            await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
-            await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
-            await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            {
-                Identifier = $"{Guid.NewGuid()}",
-                RoleName = AccessRoles.ResourceOwner,
-                Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-                ValidTo = DateTime.UtcNow.AddDays(1),
-                Source = source
-            });
+            //await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
+            //await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
+            //{
+            //    Identifier = $"{Guid.NewGuid()}",
+            //    RoleName = AccessRoles.ResourceOwner,
+            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
+            //    ValidTo = DateTime.UtcNow.AddDays(1),
+            //    Source = source
+            //});
 
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -150,9 +150,9 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task GetDepartments_Should_GetDelegatedResponsibles_FromGetDepartmentsQueryString()
         {
             var source = $"Department.Test";
-            var delegatedDepartment = "AAA BBB CCC DDD";
+            var delegatedDepartment = "BBB CCC DDD EEE";
             var mainResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
-            mainResourceOwner.FullDepartment = $"AAA BBB CCC DDD EE FFF";
+            mainResourceOwner.FullDepartment = $"BBB CCC DDD EEE FFF GGG";
             var delegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var secondDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -158,40 +158,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
-            //await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-
-            //await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-
-            //await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-            //await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
 
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -128,41 +128,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var expiredDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
             var notStartedDelegatedResourceOwner = fixture.AddProfile(FusionAccountType.Employee);
 
-            //await RolesClientMock.AddPersonRole(delegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-
-            //await RolesClientMock.AddPersonRole(secondDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-
-            //await RolesClientMock.AddPersonRole(expiredDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-            //await RolesClientMock.AddPersonRole(notStartedDelegatedResourceOwner.AzureUniqueId!.Value, new Fusion.Integration.Roles.RoleAssignment
-            //{
-            //    Identifier = $"{Guid.NewGuid()}",
-            //    RoleName = AccessRoles.ResourceOwner,
-            //    Scope = new Fusion.Integration.Roles.RoleAssignment.RoleScope("OrgUnit", delegatedDepartment),
-            //    ValidTo = DateTime.UtcNow.AddDays(1),
-            //    Source = source
-            //});
-
             LineOrgServiceMock.AddTestUser().MergeWithProfile(mainResourceOwner).AsResourceOwner().WithFullDepartment(delegatedDepartment).SaveProfile();
             using var adminScope = fixture.AdminScope();
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Updated ExpandDelegatedResoureOwner to use DateTo and DateFrom in query parameters to filter out expired or future positions.
There have also been created tests that check for the DateTo and From,  som code have been cheng in relation to that to help facilitate the test. wihtout breakting eksisting functionality


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Can be tested by running a get request against the endpoint /delegated-resource-owners, where there is a user that have a future or expired delegation.  one way is to delegate a user acces today with expiration today, and wait unitl tomorrow. 



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

[AB#35362](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/35362)
