### PR TITLE
Direct request only option on base position

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Extensions/OrgApiModelExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/OrgApiModelExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Fusion.ApiClients.Org;
+using System;
+using System.Linq;
+
+namespace Fusion.Resources.Domain
+{
+    public static class OrgApiModelExtensions
+    {
+        public static T TryGetSettingOrDefault<T>(this ApiBasePositionV2 basePosition, string settingsKey, T defaultValue)
+        {
+            if (basePosition.Settings is null || !basePosition.Settings.Keys.Any(k => string.Equals(settingsKey, k, StringComparison.OrdinalIgnoreCase)))
+                return defaultValue;
+
+            var kv = basePosition.Settings.First(kv => string.Equals(kv.Key, settingsKey, StringComparison.OrdinalIgnoreCase));
+
+            try
+            {
+                return (T)kv.Value;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// The base position has the 'requireDirectRequest' setting set to true.
+        /// </summary>
+        public static bool RequiresDirectRequest(this ApiBasePositionV2 basePosition)
+        {
+            return basePosition?.TryGetSettingOrDefault<bool?>("requireDirectRequest", null) == true;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResolveSubType.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResolveSubType.cs
@@ -49,13 +49,7 @@ namespace Fusion.Resources.Logic.Commands
                         else if (string.Equals(position?.Properties?.GetProperty<string>("resourceType", "normal"), "enterprise", StringComparison.OrdinalIgnoreCase))
                             return AllocationEnterpriseWorkflowV1.SUBTYPE;
                         else
-                        {
-                            // Check if the base position requires direct request.
-                            if (basePosition?.RequiresDirectRequest() == true)
-                                return AllocationDirectWorkflowV1.SUBTYPE;
-
                             return AllocationNormalWorkflowV1.SUBTYPE;
-                        }
                     }
                 }
             }

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResolveSubType.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResolveSubType.cs
@@ -1,11 +1,8 @@
 ﻿using Fusion.Integration.Org;
-using Fusion.Resources.Database;
-using Fusion.Resources.Database.Entities;
+using Fusion.Resources.Domain;
 using Fusion.Resources.Logic.Workflows;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -42,7 +39,8 @@ namespace Fusion.Resources.Logic.Commands
                     var basePosition = await orgResolver.ResolveBasePositionAsync(position.BasePosition.Id);
                     var bpSettings = basePosition?.GetTypedSettings();
 
-                    if (bpSettings is not null && bpSettings.DirectAssignmentEnabled.GetValueOrDefault(false))
+
+                    if (bpSettings is not null && bpSettings.DirectAssignmentEnabled.GetValueOrDefault(false) )
                         return AllocationDirectWorkflowV1.SUBTYPE;
                     else
                     {
@@ -51,7 +49,13 @@ namespace Fusion.Resources.Logic.Commands
                         else if (string.Equals(position?.Properties?.GetProperty<string>("resourceType", "normal"), "enterprise", StringComparison.OrdinalIgnoreCase))
                             return AllocationEnterpriseWorkflowV1.SUBTYPE;
                         else
+                        {
+                            // Check if the base position requires direct request.
+                            if (basePosition?.RequiresDirectRequest() == true)
+                                return AllocationDirectWorkflowV1.SUBTYPE;
+
                             return AllocationNormalWorkflowV1.SUBTYPE;
+                        }
                     }
                 }
             }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Responses/TestApiInternalRequestModel.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Responses/TestApiInternalRequestModel.cs
@@ -19,6 +19,7 @@ namespace Fusion.Testing.Mocks
         /// <para>Check valid values used in request model <see cref="ApiAllocationRequestType"/> for information.</para>
         /// </summary>
         public string Type { get; set; } = null!;
+        public string SubType { get; set; } = null!;
         public TestApiProjectReference Project { get; set; } = null!;
         public ApiPositionV2? OrgPosition { get; set; }
         public Guid? OrgPositionId { get; set; }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -176,28 +176,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
-        public async Task DirectRequest_Create_ShouldDefaultToDirectRequestSubType_WhenDirectRequestRequired()
-        {
-            using var adminScope = fixture.AdminScope();
-            var directRequestBasePosition = testProject.AddBasePosition($"Direct request test {Guid.NewGuid()}", s =>
-            {
-                s.Settings["requireDirectRequest"] = true;
-            });
-
-            var position = testProject.AddPosition(p => p.BasePosition = directRequestBasePosition);
-            var proposedPerson = fixture.AddProfile(FusionAccountType.Employee);
-
-            var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests", new
-            {
-                type = "normal",
-                orgPositionId = position.Id,
-                orgPositionInstanceId = position.Instances.Last().Id,
-            });
-            response.Should().BeSuccessfull();
-            response.Value.SubType.Should().Be("direct");
-        }
-
-        [Fact]
         public async Task DirectRequest_Create_ShouldHaveIsDraftTrue()
         {
             using var adminScope = fixture.AdminScope();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -250,6 +250,32 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Value.ProposedPerson?.Person.Mail.Should().Be(proposedPerson.Mail);
         }
 
+        /// <summary>
+        /// When the base position flags that a direct request is required, it should return bad request when a normal request is created.
+        /// The request type should be direct.
+        /// </summary>
+        [Fact]
+        public async Task NormalRequest_Create_ShouldBeBadRequest_WhenDirectRequestRequired()
+        {
+            using var adminScope = fixture.AdminScope();
+            var directRequestBasePosition = testProject.AddBasePosition("Direct request test", s =>
+            {
+                s.Settings["requireDirectRequest"] = true;
+            });
+
+            var position = testProject.AddPosition(p => p.BasePosition = directRequestBasePosition);
+            var proposedPerson = fixture.AddProfile(FusionAccountType.Employee);
+
+            var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests", new
+            {
+                type = "normal",
+                orgPositionId = position.Id,
+                orgPositionInstanceId = position.Instances.Last().Id,
+            });
+            response.Should().BeBadRequest();
+        }
+
+
         #endregion
 
         #region Request flow tests

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/FusionTestProjectBuilder.cs
@@ -96,7 +96,8 @@ namespace Fusion.Testing.Mocks.OrgService
             var bp = new ApiBasePositionV2()
             {
                 Id = Guid.NewGuid(),
-                Name = name
+                Name = name,
+                Settings = new Dictionary<string, object>()
             };
 
             setup?.Invoke(bp);
@@ -105,9 +106,11 @@ namespace Fusion.Testing.Mocks.OrgService
             return bp;
         }
 
-        public ApiPositionV2 AddPosition()
+        public ApiPositionV2 AddPosition(Action<ApiPositionV2> setup = null)
         {
             var position = PositionBuilder.NewPosition();
+
+            setup?.Invoke(position);
 
             position.ProjectId = project.ProjectId;
             position.Project = new ApiProjectReferenceV2


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Some business areas anchor their base positions high up in the organisation as there are multiple paths for resources and no clear ownership.

To support these scenarios a new setting was introduced on the base position, which indicates that normal requests should not be created as these would be assigned to a leader that would not respond to it.

This option should be respected by the resources api when creating requests, not allowing these to be created. 

The api has been updated to resolve the base position for the position the request is created on and checks if the setting is present. If the flag is set to `true` the request is rejected if the sub type is not set to `direct`.

Caveats:
- Used the command validation pipeline to do the validation to hook in to the resolving of subtype. However this project does not have reference to the logic project where the constants live. Instead of refactoring where constants exists a string is used.
- Response out of api after command validation fails results in `BadRequest` however the description is not optimal, however by reading the body one can resolve what is the problem.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Created tests to verify bad request is returned when creating a normal allocation request when the base position has `requireDirectRequest` flag.
~~Created test to verify auto resolving to direct request when no sub type is specified in body~~ (Removed this functionality)
Created test to verify direct request can be created when base position has flag.

Should test how the UI will behave when creating a new request without specifying a person (direct request). Unsure if the frontend will handle the bad request response.


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

[AB#36031](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/36031)

Should update docs to specify functionality.
