### PR TITLE
feat(api): V2 endpoint for listing department personnel

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -25,7 +25,9 @@ namespace Fusion.Resources.Api.Controllers
         }
 
         /// <summary>
-        /// Get personnel for a department
+        /// Get personnel for a department.
+        /// 
+        /// Version 2 only changes the data set returned, by utilizing a different query for employees.
         /// </summary>
         /// <param name="fullDepartmentString">The department to retrieve personnel list from.</param>
         /// <param name="timelineStart">Start date of timeline</param>
@@ -43,7 +45,8 @@ namespace Fusion.Resources.Api.Controllers
             [FromQuery] string? timelineDuration = null,
             [FromQuery] DateTime? timelineEnd = null,
             [FromQuery] bool includeSubdepartments = false,
-            [FromQuery] bool includeCurrentAllocations = false)
+            [FromQuery] bool includeCurrentAllocations = false,
+            int? version = null)
         {
             #region Authorization
 
@@ -102,7 +105,8 @@ namespace Fusion.Resources.Api.Controllers
             var command = new GetDepartmentPersonnel(fullDepartmentString, query)
                 .IncludeSubdepartments(includeSubdepartments)
                 .IncludeCurrentAllocations(includeCurrentAllocations)
-                .WithTimeline(shouldExpandTimeline, timelineStart, timelineEnd);
+                .WithTimeline(shouldExpandTimeline, timelineStart, timelineEnd)
+                .WithVersion(version);
 
             var department = await DispatchAsync(command);
 
@@ -115,7 +119,21 @@ namespace Fusion.Resources.Api.Controllers
             return new ApiCollection<ApiInternalPersonnelPerson>(returnModel);
         }
 
-        [HttpGet("sectors/{sectorPath}/resources/personnel")]
+        [MapToApiVersion("2.0")]
+        [HttpGet("departments/{fullDepartmentString}/resources/personnel")]
+        public async Task<ActionResult<ApiCollection<ApiInternalPersonnelPerson>>> GetDepartmentPersonnelV2(string fullDepartmentString,
+            [FromQuery] ODataQueryParams query,
+            [FromQuery] DateTime? timelineStart = null,
+            [FromQuery] string? timelineDuration = null,
+            [FromQuery] DateTime? timelineEnd = null,
+            [FromQuery] bool includeSubdepartments = false,
+            [FromQuery] bool includeCurrentAllocations = false)
+        {
+
+            return await GetDepartmentPersonnel(fullDepartmentString, query, timelineStart, timelineDuration, timelineEnd, includeSubdepartments, includeCurrentAllocations, version: 2);
+        }
+
+            [HttpGet("sectors/{sectorPath}/resources/personnel")]
         public async Task<ActionResult<ApiCollection<ApiInternalPersonnelPerson>>> GetSectorPersonnel(string sectorPath,
             [FromQuery] ODataQueryParams query,
             [FromQuery] DateTime? timelineStart = null,

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/ResolveLineOrgUnit.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/ResolveLineOrgUnit.cs
@@ -1,0 +1,36 @@
+﻿using Fusion.Integration.LineOrg;
+using Fusion.Services.LineOrg.ApiModels;
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain
+{
+    public class ResolveLineOrgUnit : IRequest<ApiOrgUnit?>
+    {
+        public string DepartmentId { get; }
+
+        public ResolveLineOrgUnit(string departmentId)
+        {
+            DepartmentId = departmentId;
+        }
+
+        public class Handler : IRequestHandler<ResolveLineOrgUnit, ApiOrgUnit?>
+        {
+            private readonly ILineOrgResolver lineOrgResolver;
+
+            public Handler(ILineOrgResolver lineOrgResolver)
+            {
+                this.lineOrgResolver = lineOrgResolver;
+            }
+
+            public async Task<ApiOrgUnit?> Handle(ResolveLineOrgUnit request, CancellationToken cancellationToken)
+            {
+                var lineOrgDpt = await lineOrgResolver.ResolveOrgUnitAsync(Integration.LineOrg.DepartmentId.FromFullPath(request.DepartmentId));
+
+                return lineOrgDpt;
+
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Utils/PeopleSearchUtils.cs
@@ -76,7 +76,7 @@ namespace Fusion.Resources.Domain
             return QueryRangedList.FromItems(searchResult.items, searchResult.totalCount, query.Skip);
         }
 
-        private static async Task<List<QueryInternalPersonnelPerson>> GetFromSearchIndexAsync(HttpClient peopleClient, string? filter, string? search = null, List<QueryResourceAllocationRequest>? requests = null)
+        public static async Task<List<QueryInternalPersonnelPerson>> GetFromSearchIndexAsync(HttpClient peopleClient, string? filter, string? search = null, List<QueryResourceAllocationRequest>? requests = null)
         {
             var result = new List<QueryInternalPersonnelPerson>();
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Problems have been identified with the query used to resolve employees in a department, when changing to a context based personnel app.
We cannot use the manager as reference as there are no guarantee that the manager in only manager for the specific department. A person can be manager for multiple departments at the same time, in cases where one has not yet been employeed. 
When there is no maanger, the responsibility falls to the next level up, in SAP, which is synced to AD. 

The v1 view is working with the current app where the manager will get all departments in the same view.. If we update the v1 endpoint, the current app will not work. We cannot publish the new app, as this would make it unusable for the users with multiple departments.

Solution is to introduce a v2 endpoint, which the new app will utilize. Then when old app is no longer, we can change how v1 endpoints return data.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

Verify v1 returns existing data, while v2 returns different result set. 
Verified by using PCA3 and PCAR departments.


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Automatic tests are nor relevant as this is based on external datasets. 
