### PR TITLE
fix(api): Users cannot open fusion portal from notifications

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Deployment/webapp.template.json
+++ b/src/backend/api/Fusion.Resources.Api/Deployment/webapp.template.json
@@ -107,10 +107,14 @@
                             "name": "ENVNAME",
                             "value": "[variables('env-name')]"
                         },
-                        {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(concat('microsoft.insights/components/', variables('ai-api-name')), '2015-05-01').InstrumentationKey]"
-                        }
+                      {
+                        "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                        "value": "[reference(concat('microsoft.insights/components/', variables('ai-api-name')), '2015-05-01').InstrumentationKey]"
+                      },
+                      {
+                        "name": "Fusion__ServiceDiscovery__Portal",
+                        "value": "https://fusion.equinor.com"
+                      }
                     ],
                     "linuxFxVersion": "[concat('DOCKER|', parameters('docker').image)]",
                     "appCommandLine": "[parameters('docker').startupCommand]",


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [x] High impact

**Description of work:**
When users receive notifications which lets them open relevant resources in the portal, the hostname is using the old value which is configured to redirect users. 
This creates issues when the browser has to run an signin session at the same time, due to oauth flow.

The portal url is resolved through integration lib. This should be updated to the latest version, but this requires more testing. 

Added quick fix, where resolved host can be overridden through web app config. Updated the web app template for prod to set fusion.equinor.com as hostname for portal.


**Testing:**
- [ ] ~~Can be tested~~
- [ ] ~~Automatic tests created / updated~~
- [ ] ~~Local tests are passing~~

Cannot be tested except for in production environment.


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

