### PR TITLE
Added LineOrgUnitChangedEvent and possiblity to cleare cache if needed

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Admin.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Admin.cs
@@ -17,23 +17,24 @@ namespace Fusion.Resources.Api.Controllers
     [ApiVersion("1.0")]
     [Authorize]
     [ApiController]
-    public class InternalDepartmentsController : ResourceControllerBase
+    public class AdminController : ResourceControllerBase
     {
 
         private readonly IOrgUnitCache orgUnitCache;
 
-        public InternalDepartmentsController(IOrgApiClientFactory orgApiClientFactory, IRequestRouter requestRouter, IOrgUnitCache orgUnitCache)
+        public AdminController(IOrgUnitCache orgUnitCache)
         {
 
             this.orgUnitCache = orgUnitCache;
         }
 
-        [HttpGet("/ClearLineOrgCache")]
+        [HttpGet("admin/cache/org-units")]
 
-        public async void CleareCache()
+        public async Task<ActionResult> CleareCache()
         {
             await orgUnitCache.ClearOrgUnitCacheAsync();
 
+            return Ok();
         }
 
       

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/InternalDepartmentsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/InternalDepartmentsController.cs
@@ -1,0 +1,41 @@
+﻿using Fusion.AspNetCore.FluentAuthorization;
+using Fusion.Authorization;
+using Fusion.Integration.LineOrg;
+using Fusion.Resources.Domain;
+using Fusion.Resources.Domain.Commands.Departments;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    [ApiVersion("1.0-preview")]
+    [ApiVersion("1.0")]
+    [Authorize]
+    [ApiController]
+    public class InternalDepartmentsController : ResourceControllerBase
+    {
+
+        private readonly IOrgUnitCache orgUnitCache;
+
+        public InternalDepartmentsController(IOrgApiClientFactory orgApiClientFactory, IRequestRouter requestRouter, IOrgUnitCache orgUnitCache)
+        {
+
+            this.orgUnitCache = orgUnitCache;
+        }
+
+        [HttpGet("/ClearLineOrgCache")]
+
+        public async void CleareCache()
+        {
+            await orgUnitCache.ClearOrgUnitCacheAsync();
+
+        }
+
+      
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
@@ -8,12 +8,12 @@ namespace Fusion.Resources.Api
     /// <summary>
     /// Handler listening on Line-Org service changes to org-units.
     /// </summary>
-    public class LineOrgOrgUnitChangedEvent : ISubscriptionHandler
+    public class LineOrgOrgUnitHandler : ISubscriptionHandler
     {
         private readonly IOrgUnitCache orgUnitCache;
 
 
-        public LineOrgOrgUnitChangedEvent(IOrgUnitCache orgUnitCache)
+        public LineOrgOrgUnitHandler(IOrgUnitCache orgUnitCache)
         {
             this.orgUnitCache = orgUnitCache;
         }

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -87,7 +87,7 @@ namespace Fusion.Resources.Api
                     e.OnlyTriggerOn(OrgEventTypes.Project);
                 });
 
-                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(LineOrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
+                s.AddTransientHandler<LineOrgOrgUnitHandler>(LineOrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
                 {
                    var LineOrgUnit = new FusionEventType("lineorg.org-unit" );
                     e.OnlyTriggerOn(LineOrgUnit);

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -1,6 +1,7 @@
 using FluentValidation.AspNetCore;
 using Fusion.Events;
 using Fusion.Integration.Authentication;
+using Fusion.Integration.LineOrg;
 using Fusion.Integration.Org;
 using Fusion.Resources.Api.Authentication;
 using Fusion.Resources.Api.HostedServices;
@@ -86,7 +87,7 @@ namespace Fusion.Resources.Api
                     e.OnlyTriggerOn(OrgEventTypes.Project);
                 });
 
-                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(OrgConstants.HttpClients.Application, "/lineorg", e =>
+                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(LineOrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
                 {
                    var LineOrgUnit = new FusionEventType("lineorg.org-unit" );
                     e.OnlyTriggerOn(LineOrgUnit);

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -86,7 +86,7 @@ namespace Fusion.Resources.Api
                     e.OnlyTriggerOn(OrgEventTypes.Project);
                 });
 
-                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(OrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
+                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(OrgConstants.HttpClients.Application, "/lineorg", e =>
                 {
                    var LineOrgUnit = new FusionEventType("lineorg.org-unit" );
                     e.OnlyTriggerOn(LineOrgUnit);

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -85,6 +85,12 @@ namespace Fusion.Resources.Api
                 {
                     e.OnlyTriggerOn(OrgEventTypes.Project);
                 });
+
+                s.AddTransientHandler<LineOrgOrgUnitChangedEvent>(OrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
+                {
+                   var LineOrgUnit = new FusionEventType("lineorg.org-unit" );
+                    e.OnlyTriggerOn(LineOrgUnit);
+                });
             });
             // Add custom claims provider, to sort delegated responsibilities
             services.AddScoped<ILocalClaimsTransformation, ResourcesLocalClaimsTransformation>();


### PR DESCRIPTION
- [ ] ~~New feature~~
- [X] Bug fix
- [ ] ~~High impact~~

**Description of work:**

The LineOrgOrgUnitChangedEvent was not added to the Startup.cs resulting it never listening for lineOrgUnit Changes events. 
also added a ability to cleare the cache if needed


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing




**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [x] Considered security
- [x] Performed developer testing
- [ ] Checklist finalized / ready for review

