### PR TITLE
feat: Endpoint for additional tasks

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -1,9 +1,56 @@
 ﻿using Fusion.Resources.Domain;
 using System;
 using System.Text.Json.Serialization;
+using static Fusion.Resources.Api.Controllers.ApiPersonAbsence;
 
 namespace Fusion.Resources.Api.Controllers
 {
+    /// <summary>
+    /// A public view of the additional task for a person. 
+    /// This is based on the absence, but does not include the private property as it is implicit.
+    /// 
+    /// The comment has been elected to not be included as well, as this is labled "internal note". 
+    /// This could be included in the future if it is desired to expose more details about the persons 
+    /// allocation to the task.
+    /// </summary>
+    public class ApiPersonAdditionalTask
+    {
+        public ApiPersonAdditionalTask(QueryPersonAbsence absence)
+        {
+            Id = absence.Id;
+            AppliesFrom = absence.AppliesFrom;
+            AppliesTo = absence.AppliesTo;
+            Workload = absence.AbsencePercentage;
+
+            TaskDetails = (absence.TaskDetails != null) ? new ApiAdditionalTaskTaskDetails(absence.TaskDetails) : null;
+        }
+
+        public Guid Id { get; set; }
+
+        public ApiAdditionalTaskTaskDetails? TaskDetails { get; set; }
+        public DateTimeOffset AppliesFrom { get; set; }
+        public DateTimeOffset? AppliesTo { get; set; }
+        public double? Workload { get; set; }
+
+
+    }
+
+    public class ApiAdditionalTaskTaskDetails
+    {
+        public ApiAdditionalTaskTaskDetails(Domain.QueryTaskDetails taskDetails)
+        {
+            BasePositionId = taskDetails.BasePositionId;
+            TaskName = taskDetails.TaskName;
+            RoleName = taskDetails.RoleName;
+            Location = taskDetails.Location;
+        }
+
+        public Guid? BasePositionId { get; set; }
+        public string? TaskName { get; set; }
+        public string? RoleName { get; set; }
+        public string? Location { get; set; }
+    }
+
     public class ApiPersonAbsence
     {
         private ApiPersonAbsence(QueryPersonAbsence absence, bool hidePrivateNotes)
@@ -45,6 +92,7 @@ namespace Fusion.Resources.Api.Controllers
             }
         }
 
+        public static ApiPersonAbsence CreateAdditionTask(QueryPersonAbsence absence) => new ApiPersonAbsence(absence, hidePrivateNotes: false);
         public static ApiPersonAbsence CreateWithoutConfidentialTaskInfo(QueryPersonAbsence absence) => new ApiPersonAbsence(absence, hidePrivateNotes: true);
         public static ApiPersonAbsence CreateWithoutConfidentialTaskInfo(QueryPersonAbsenceBasic absence) => new ApiPersonAbsence(absence, hidePrivateNotes: true);
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Fusion.AspNetCore.FluentAuthorization;
@@ -25,6 +26,17 @@ namespace Fusion.Resources.Api.Controllers
             this.notificationClient = notificationClient;
         }
 
+        /// <summary>
+        /// List all absence for a person; leave, vacation and additional tasks.
+        /// </summary>
+        /// <remarks>
+        /// List all absence of the user.
+        /// Response is tailored to user auth level, where properties and items are removed if user does not have access to these...
+        /// 
+        /// > To list only additional tasks marked as public, use 'additional-task' endpoint.
+        /// </remarks>
+        /// <param name="personId"></param>
+        /// <returns></returns>
         [HttpGet("/persons/{personId}/absence")]
         public async Task<ActionResult<ApiCollection<ApiPersonAbsence>>> GetPersonAbsence(
             [FromRoute] string personId)
@@ -58,13 +70,31 @@ namespace Fusion.Resources.Api.Controllers
                         x.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                 });
             });
-            if (authResult.Unauthorized)
+
+            // Check if user should get just the task details.
+            var isAllowedOtherTasks = await Request.RequireAuthorizationAsync(r => r.AnyOf(o => o.BeEmployee()));
+
+            if (authResult.Unauthorized && isAllowedOtherTasks.Unauthorized)
+            {
                 return authResult.CreateForbiddenResponse();
+            }
 
             #endregion
 
             var personAbsence = await DispatchAsync(new GetPersonAbsence(id));
 
+
+            // If the user is only authorized to view other tasks, filter the result and return it.
+            if (authResult.Unauthorized && isAllowedOtherTasks.Success)
+            {
+                var otherTasks = personAbsence.Where(a => a.Type == QueryAbsenceType.OtherTasks && a.IsPrivate == false)
+                    .Select(ApiPersonAbsence.CreateAdditionTask)
+                    .ToList();
+
+                return new ApiCollection<ApiPersonAbsence>(otherTasks);
+            }
+
+            // Return all absence
             var returnItems = personAbsence.Select(p => authResult.LimitedAuth
                 ? ApiPersonAbsence.CreateWithoutConfidentialTaskInfo(p)
                 : ApiPersonAbsence.CreateWithConfidentialTaskInfo(p)
@@ -72,6 +102,60 @@ namespace Fusion.Resources.Api.Controllers
 
             var collection = new ApiCollection<ApiPersonAbsence>(returnItems);
             return collection;
+        }
+
+        /// <summary>
+        /// List only additional tasks marked as public.
+        /// </summary>
+        /// <remarks>
+        /// List all the additional tasks the person is assigned to, which is marked public. Will only list absence marked public, regardless if user is manager or not.
+        /// A more "clean" implementation of listing public additional tasks than the clusterfk above...
+        /// 
+        /// > **Authorization**
+        /// > - Be the persons resource owner
+        /// > - Be employee
+        /// 
+        /// </remarks>
+        /// <param name="personId"></param>
+        /// <returns></returns>
+        [HttpGet("/persons/{personId}/additional-tasks")]
+        public async Task<ActionResult<ApiCollection<ApiPersonAdditionalTask>>> GetPersonAdditionalTasks([FromRoute] string personId)
+        {
+            var id = new PersonId(personId);
+
+            var profile = await DispatchAsync(new GetPersonProfile(id));
+            if (profile is null)
+                return ApiErrors.NotFound($"Person with id '{personId}' could not be found.");
+
+            #region Authorization
+
+            var authResult = await Request.RequireAuthorizationAsync(r =>
+            {
+                r.AnyOf(or =>
+                {
+                    // If the user is the manager - regardless if ext. hire or employee...
+                    if (!String.IsNullOrEmpty(profile.FullDepartment))
+                    {
+                        or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).Parent(), includeParents: false, includeDescendants: true);
+                        or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(profile.FullDepartment), AccessRoles.ResourceOwner);
+                    }
+
+                    or.BeEmployee();
+                });
+            });
+
+            if (authResult.Unauthorized)
+                return authResult.CreateForbiddenResponse();
+
+            #endregion
+
+            var personAbsence = await DispatchAsync(new GetPersonAbsence(id));
+
+            var otherTasks = personAbsence.Where(a => a.Type == QueryAbsenceType.OtherTasks && a.IsPrivate == false)
+                    .Select(t => new ApiPersonAdditionalTask(t))
+                    .ToList();
+
+            return new ApiCollection<ApiPersonAdditionalTask>(otherTasks);
         }
 
         [HttpGet("/persons/{personId}/absence/{absenceId}")]

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonAbsenceController.cs
@@ -369,6 +369,9 @@ namespace Fusion.Resources.Api.Controllers
                     {
                         or.BeResourceOwner(new DepartmentPath(profile.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                         or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(profile.FullDepartment), AccessRoles.ResourceOwner);
+
+                        // Employees have limited read access.
+                        or.BeEmployee();
                     }
                 });
             });

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -24,16 +24,16 @@ namespace Fusion.Resources.Api.Controllers
             DateTime.SpecifyKind(AppliesFrom, DateTimeKind.Utc);
             if(AppliesTo.HasValue) DateTime.SpecifyKind(AppliesTo.Value, DateTimeKind.Utc);
 
-            command.Comment = Comment;
+            command.Comment = NullIfEmpty(Comment);
             command.AppliesFrom = AppliesFrom;
             command.AppliesTo = AppliesTo;
             command.Type = Enum.Parse<QueryAbsenceType>($"{Type}", true);
             command.AbsencePercentage = AbsencePercentage;
             command.IsPrivate = IsPrivate;
             command.BasePositionId = TaskDetails?.BasePositionId;
-            command.TaskName = TaskDetails?.TaskName;
-            command.RoleName = TaskDetails?.RoleName;
-            command.Location = TaskDetails?.Location;
+            command.TaskName = NullIfEmpty(TaskDetails?.TaskName);
+            command.RoleName = NullIfEmpty(TaskDetails?.RoleName);
+            command.Location = NullIfEmpty(TaskDetails?.Location);
         }
 
 
@@ -64,5 +64,7 @@ namespace Fusion.Resources.Api.Controllers
         }
 
         #endregion
+    
+        public static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -5,6 +5,8 @@
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<DockerfileContext>..\..</DockerfileContext>
 		<Nullable>enable</Nullable>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Data\personnel-import-template.xlsx" />

--- a/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerSetup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/SwaggerSetup.cs
@@ -10,7 +10,9 @@ using Swashbuckle.AspNetCore.Filters;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -94,6 +96,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 }, new List<string>());
 
                 c.AddSecurityRequirement(securityRequirement);
+
+                string xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                string xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+                c.IncludeXmlComments(xmlPath);
             });
 
             TypeConverterAttribute typeConverterAttribute = new TypeConverterAttribute(typeof(ToStringTypeConverter));

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -613,12 +613,16 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SameL2Department, true)]
         [InlineData("resourceOwnerRole", ExactScope, true)]
         [InlineData("resourceOwnerRole", WildcardScope, true)]
-        [InlineData("resourceOwnerRole", UnrelatedScope, false)]
+        [InlineData("resourceOwnerRole", UnrelatedScope, true)] // Switch from false to true, as this grants limited access when employee
+        [InlineData("consultant", UnrelatedScope, false)]
         public async Task CanGetAllAbsenceForPerson(string role, string department, bool shouldBeAllowed)
         {
             var absence = await CreateAbsence();
 
-            var user = GetUser(role, department);
+            var user = role switch {
+                "consultant" => fixture.AddProfile(FusionAccountType.Consultant),
+                _ => GetUser(role, department)
+            };
             using var userScope = fixture.UserScope(user);
 
             var client = fixture.ApiFactory.CreateClient();
@@ -638,10 +642,15 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData("resourceOwner", SameL2Department, "GET,!POST")]
         [InlineData("resourceOwnerRole", ExactScope, "GET,POST")]
         [InlineData("resourceOwnerRole", WildcardScope, "GET,POST")]
-        [InlineData("resourceOwnerRole", UnrelatedScope, "!GET,!POST")]
+        [InlineData("resourceOwnerRole", UnrelatedScope, "GET,!POST")]
+        [InlineData("consultant", UnrelatedScope, "!GEET,!POST")]
         public async Task CanGetAbsenceOptionsForPerson(string role, string department, string allowed)
         {
-            var user = GetUser(role, department);
+            var user = role switch
+            {
+                "consultant" => fixture.AddProfile(FusionAccountType.Consultant),
+                _ => GetUser(role, department)
+            };
             using var userScope = fixture.UserScope(user);
 
             var client = fixture.ApiFactory.CreateClient();

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class DepartmentRequestsTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         const string TimelineDepartment = "TPD TST TIL DPT3";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class DepartmentsControllerTests : IClassFixture<ResourceApiFixture>
     {
         private ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -26,6 +26,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class DirectRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/EnterpriseRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/EnterpriseRequestTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class EnterpriseRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/JointVentureRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/JointVentureRequestTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class JointVentureRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/NormalRequestTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class NormalRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ProjectRequestAccessTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ProjectRequestAccessTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class ProjectRequestAccessTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/ResourceOwnerRequestTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class ResourceOwnerRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private const string SUBTYPE_CHANGE = "changeResource";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class InternalResourceAllocationNotificationTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private const string TestDepartmentId = "TPD PRD FE MMS MAT1";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class InternalResourceAllocationRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private const string TestDepartmentId = "TPD PRD FE MMS MAT1";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -16,6 +16,7 @@ using Fusion.Testing.Mocks.OrgService;
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
 
+    [Collection("Integration")]
     public class PersonAbsenceTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonAbsenceTests.cs
@@ -51,13 +51,22 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             CheckAllowHeader("GET", result);
         }
         [Fact]
-        public async Task OptionsAbsence_GetNotAllowedForPerson_WhenOtherUser()
+        public async Task OptionsAbsence_GetNotAllowedForPerson_WhenOtherUserAndNotEmployee()
+        {
+            var otherUser = fixture.AddProfile(FusionAccountType.Consultant);
+            using var userScope = fixture.UserScope(otherUser);
+            var result = await client.TestClientOptionsAsync($"/persons/{testUser.AzureUniqueId}/absence");
+            result.Should().BeSuccessfull();
+            CheckAllowHeader("!GET", result);
+        }
+        [Fact]
+        public async Task OptionsAbsence_GetAllowedForPerson_WhenOtherUserAndUserIsEmployee()
         {
             var otherUser = fixture.AddProfile(FusionAccountType.Employee);
             using var userScope = fixture.UserScope(otherUser);
             var result = await client.TestClientOptionsAsync($"/persons/{testUser.AzureUniqueId}/absence");
             result.Should().BeSuccessfull();
-            CheckAllowHeader("!GET", result);
+            CheckAllowHeader("GET", result);
         }
 
         [Fact]
@@ -86,13 +95,37 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeSuccessfull();
         }
 
+        [Theory]
+        [InlineData(FusionAccountType.Consultant)]
+        [InlineData(FusionAccountType.External)]
+        [InlineData(FusionAccountType.Application)]
+        public async Task GetAbsenceForUser_ShouldBeUnauthorized_When(FusionAccountType accountType)
+        {
+            var otherUser = fixture.AddProfile(accountType);
+            using var testScope = fixture.UserScope(otherUser);
+            var response = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/absence", new { value = new[] { new { id = Guid.Empty } } });
+            response.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData(FusionAccountType.Consultant)]
+        [InlineData(FusionAccountType.External)]
+        [InlineData(FusionAccountType.Application)]
+        public async Task GetAdditionalTasksForUser_ShouldBeUnauthorized_When(FusionAccountType accountType)
+        {
+            var otherUser = fixture.AddProfile(accountType);
+            using var testScope = fixture.UserScope(otherUser);
+            var response = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/additional-tasks", new { value = new[] { new { id = Guid.Empty } } });
+            response.Should().BeUnauthorized();
+        }
+
         [Fact]
-        public async Task GetAbsenceForUser_ShouldBeUnauthorized_WhenOtherUser()
+        public async Task GetAbsenceForUser_ShouldBeOk_WhenEmployee()
         {
             var otherUser = fixture.AddProfile(FusionAccountType.Employee);
             using var testScope = fixture.UserScope(otherUser);
             var response = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/absence", new { value = new[] { new { id = Guid.Empty } } });
-            response.Should().BeUnauthorized();
+            response.Should().BeSuccessfull();
         }
 
         [Fact]
@@ -121,6 +154,49 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             response.Value.value.Count().Should().BeGreaterOrEqualTo(1);
         }
+
+        [Fact]
+        public async Task GetAbsenceForUser_ShouldOnlyReturnPublicTasks_WhenEmployee()
+        {
+            var employeeUser = fixture.AddProfile(FusionAccountType.Employee);
+
+            using var adminScope = fixture.AdminScope();
+            var publicTaskResp = await client.AddUserOtherTask(testUser, a => a.IsPrivate = false);
+            var privateTaskResp = await client.AddUserOtherTask(testUser, a => a.IsPrivate = true);
+            var leave = await client.AddUserAbsence(testUser, a => a.IsPrivate = false);
+
+
+            using var testScope = fixture.UserScope(employeeUser);
+            var response = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/absence", new { value = Array.Empty<TestAbsence>() });
+
+            response.Should().BeSuccessfull();
+
+            response.Value.value.Should().Contain(t => t.Id == publicTaskResp.Id);
+            response.Value.value.Should().NotContain(t => t.Id == privateTaskResp.Id, "Tasks marked privte should not be returned");
+            response.Value.value.Should().NotContain(t => t.Id == leave.Id, "Leave should not be returned, even if not marked private.");
+        }
+
+        [Fact]
+        public async Task GetAdditionalTasksForUser_ShouldOnlyReturnPublicTasks_WhenEmployee()
+        {
+            var employeeUser = fixture.AddProfile(FusionAccountType.Employee);
+
+            using var adminScope = fixture.AdminScope();
+            var publicTaskResp = await client.AddUserOtherTask(testUser, a => a.IsPrivate = false);
+            var privateTaskResp = await client.AddUserOtherTask(testUser, a => a.IsPrivate = true);
+            var leave = await client.AddUserAbsence(testUser, a => a.IsPrivate = false);
+
+
+            using var testScope = fixture.UserScope(employeeUser);
+            var response = await client.TestClientGetAsync($"/persons/{testUser.AzureUniqueId}/additional-tasks", new { value = Array.Empty<TestAbsence>() });
+
+            response.Should().BeSuccessfull();
+
+            response.Value.value.Should().Contain(t => t.Id == publicTaskResp.Id);
+            response.Value.value.Should().NotContain(t => t.Id == privateTaskResp.Id, "Tasks marked privte should not be returned");
+            response.Value.value.Should().NotContain(t => t.Id == leave.Id, "Leave should not be returned, even if not marked private.");
+        }
+
 
         [Fact]
         public async Task GetAbsence_ShouldBeOk_WhenAdmin()

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class PersonControllerTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonNotesTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonNotesTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
 
+    [Collection("Integration")]
     public class PersonNotesTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestActionTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestActionTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class RequestActionTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestComments.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class RequestComments : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         const string testDepartment = "L1 L2 L3 L4";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/RequestConversationTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class RequestConversationTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/ResponsibilityMatrixTests.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class ResponsibilityMatrixTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private readonly ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SearchDepartments.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SearchDepartments.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests
 {
+    [Collection("Integration")]
     public class SearchDepartments : IClassFixture<ResourceApiFixture>
     {
         private ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SecondOpinionTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SecondOpinionTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class SecondOpinionTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         const string TestDepartmentId = "PDP PRD FE ANE";

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SharedRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/SharedRequestTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
+    [Collection("Integration")]
     public class SharedRequestTests : IClassFixture<ResourceApiFixture>, IAsyncLifetime
     {
         private ResourceApiFixture fixture;

--- a/src/backend/tests/Fusion.Testing.Core/TestDbConnectionStrings.cs
+++ b/src/backend/tests/Fusion.Testing.Core/TestDbConnectionStrings.cs
@@ -3,7 +3,7 @@
     public class TestDbConnectionStrings
     {
         public static string LocalDb(string db, string mdfPath) => $"Server=(localdb)\\mssqllocaldb;Database={db};Trusted_Connection=True;AttachDBFileName={mdfPath}";
-        public static string LocalDb(string db) => $"Server=(localdb)\\mssqllocaldb;Database={db};Trusted_Connection=True;Max Pool Size = 32767;Pooling=true;";
+        public static string LocalDb(string db) => $"Server=(localdb)\\mssqllocaldb;Database={db};Trusted_Connection=True;Max Pool Size = 32767;Pooling=true;Connection Timeout=60";
 
     }
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added new endpoint which only returns absence of type `OtherTask` and marked public. 

This seems to have changed purpose in the UI, but the backend still considers the private flag differently.

Updated the current endpoint that returns absence, to only return non private additional tasks when the user is just a normal employee


**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

TBD


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

