### PR TITLE
Bug/department personel

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -211,7 +211,7 @@ namespace Fusion.Resources.Domain
                 var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
-                // This Code appear to be no longer needed as we do not need to find based on manager, this also creates problems when manager is manager in mulitple departments
+                // This Code appears to be no longer needed as we do not need to find based on manager, this also creates problems when manager is manager in mulitple departments
                 //if (managers.Any())
                 //    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -211,7 +211,7 @@ namespace Fusion.Resources.Domain
                 var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
-                // This Code appears to be no longer needed as we do not need to find based on manager, this also creates problems when manager is manager in mulitple departments
+                //Removed manager filter since this causes problems for managers with multiple departments. This should not cause problems since we are filtering on department
                 //if (managers.Any())
                 //    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -212,7 +212,7 @@ namespace Fusion.Resources.Domain
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
                 if (managers.Any())
-                    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
+                    queryString += " and " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
 
 
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -211,8 +211,9 @@ namespace Fusion.Resources.Domain
                 var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
-                if (managers.Any())
-                    queryString += " and " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
+                // This Code appear to be no longer needed as we do not need to find based on manager, this also creates problems when manager is manager in mulitple departments
+                //if (managers.Any())
+                //    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
 
 
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
After Unifying of V1 and V2  Endpoint for departments/{fullDepartmentString}/resources/personnel
there is some errors where personnel appears to be returned wrong based on the manager. 

After checking the code it appears the query taht are run against people service have a or clause , asking where perosn have manager.  This does not seem logical anymore as we are trying to get personel based on what department they are in and not what manager htey have. 

the problem is that the current query tries to get all personel in department, but it also tries to find based on manager, wich does not appear to be correct

[AB#41694](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/41694)

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

