### PR TITLE
Updated the PeopleSearchIndex Query to support same manager on multiple Departments at same Level

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -211,8 +211,9 @@ namespace Fusion.Resources.Domain
                 var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
+                
                 if (managers.Any())
-                    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
+                    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}' and isResourceOwner eq true"));
 
 
 


### PR DESCRIPTION
- [ ] New feature
- [X] Bug fix
- [ ] High impact

**Description of work:**

When a User is manager in more than one Departmetn at the same Level, then the search results returnes the personnel from all departments the manager is managing. 
To help mitigate this the code is chagned to also include "isResourceOwner eq true"

This should help remove the problem with the personnell showing in wrong departments. 

Ther are howere cases we need to think  about if is applicable. 

- Should DelegatedResposibility users also be included?
- Should whe check for the role Fusion.ResourseOwner and include them? do they appear as managers in eq One Equinor?
- this appears to be Identical code that are in **LineOrg Service** file  **ListOrgUnitEmployees.cs**

[AB#41694](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/41694)

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->

AB#
**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

