### PR TITLE
fix: Hide expired other task from open view

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -26,9 +26,7 @@ namespace Fusion.Resources.Api.Controllers
         }
 
         public Guid Id { get; set; }
-
         public ApiAdditionalTaskTaskDetails? TaskDetails { get; set; }
-
         public DateTimeOffset AppliesFrom { get; set; }
         public DateTimeOffset? AppliesTo { get; set; }
         public double? Workload { get; set; }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -31,8 +31,6 @@ namespace Fusion.Resources.Api.Controllers
         public DateTimeOffset AppliesFrom { get; set; }
         public DateTimeOffset? AppliesTo { get; set; }
         public double? Workload { get; set; }
-
-
     }
 
     public class ApiAdditionalTaskTaskDetails

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAbsence.cs
@@ -28,6 +28,7 @@ namespace Fusion.Resources.Api.Controllers
         public Guid Id { get; set; }
 
         public ApiAdditionalTaskTaskDetails? TaskDetails { get; set; }
+
         public DateTimeOffset AppliesFrom { get; set; }
         public DateTimeOffset? AppliesTo { get; set; }
         public double? Workload { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -211,9 +211,8 @@ namespace Fusion.Resources.Domain
                 var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
                 var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
-                //Removed manager filter since this causes problems for managers with multiple departments. This should not cause problems since we are filtering on department
-                //if (managers.Any())
-                //    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
+                if (managers.Any())
+                    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}'"));
 
 
 

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonAbsence.cs
@@ -1,6 +1,8 @@
 ﻿using Fusion.Resources.Database;
+using Fusion.Resources.Database.Migrations;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,6 +19,11 @@ namespace Fusion.Resources.Domain
 
         private PersonId PersonId { get; set; }
 
+        /// <summary>
+        /// Enable option to limit query to other tasks which is not marked private.
+        /// </summary>
+        public bool LimitToPublicAllocations { get; set; }
+        public bool FilterPastAllocations { get; set; }
 
         public class Handler : IRequestHandler<GetPersonAbsence, IEnumerable<QueryPersonAbsence>>
         {
@@ -35,7 +42,18 @@ namespace Fusion.Resources.Domain
                     .Include(x => x.TaskDetails)
                     .ToListAsync(cancellationToken);
 
-                var returnItems = items.Select(i => new QueryPersonAbsence(i))
+                if (request.LimitToPublicAllocations)
+                {
+                    items = items
+                        // Only show other tasks that is not marked as private
+                        .Where(a => a.Type == Database.Entities.DbAbsenceType.OtherTasks && a.IsPrivate == false)
+                        .ToList();
+                }
+
+                var returnItems = items
+                    // Remove past allocations
+                    .Where(a => request.FilterPastAllocations == false || a.AppliesTo >= DateTime.Today)
+                    .Select(i => new QueryPersonAbsence(i))
                     .ToList();
 
                 return returnItems;


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Non-private open tasks are visible for all employees to view. However past other tasks should not be visible due to current GDPR limitations.

Refactored trimming logic to be done in the query instead of controller since it is used in multiple endpoints.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Verified by tests


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

