### PR TITLE
feat: Support joint venture account in direct request

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/PersonId.cs
@@ -40,6 +40,22 @@ namespace Fusion.Resources.Domain
 
         public enum IdentifierType { UniqueId, Mail }
 
+        /// <summary>
+        /// Create a new identifier from either the azure id or the mail. Prefers the azure id if not null.
+        /// If both are null, an exception is thrown.
+        /// </summary>
+        /// <returns>Identifer</returns>
+        /// <exception cref="InvalidOperationException">Thrown if both identifiers are null</exception>
+        public static PersonId Create(Guid? azureId, string? mail)
+        {
+            if (azureId.HasValue)
+                return new PersonId(azureId.Value);
+
+            if (string.IsNullOrEmpty(mail))
+                throw new InvalidOperationException("Either azure id or mail must be specified");
+
+            return new PersonId(mail);
+        }
 
         public static implicit operator PersonId(string identifier)
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalRequests/DirectRequestTests.cs
@@ -17,6 +17,7 @@ using Fusion.Testing.Mocks;
 using Fusion.Testing.Mocks.LineOrgService;
 using Fusion.Testing.Mocks.OrgService;
 using Fusion.Testing.Mocks.ProfileService;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -331,6 +332,22 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             var result = await Client.StartProjectRequestAsync(testProject, request.Id);
             result.AssignedDepartment.Should().Be(proposedPerson.FullDepartment);
+        }
+
+        [Fact]
+        public async Task DirectRequest_Start_WhenUserIsExternal()
+        {
+            using var adminScope = fixture.AdminScope();
+
+            var proposedPerson = fixture.AddProfile(FusionAccountType.External);
+            proposedPerson.FullDepartment = null;
+
+            var request = await Client.CreateDefaultRequestAsync(testProject,
+                r => r.AsTypeDirect().WithProposedPerson(proposedPerson).WithAssignedDepartment(null)
+            );
+
+            var newRequestResponse = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}/start", null);
+            newRequestResponse.Should().BeSuccessfull();
         }
 
         [Fact]


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
After the removal of enterprise personnel type property was removed on the positions, it has not been possible to add joint venture/guest accounts to any org charts.
This is due to the direct request assumed that only ad accounts would be used, so the department should exist. 

Updated the validation of direct request initialization to not require the request be assigned to a department if a external account type is proposed.


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Verified by completing a request which failed in CI. 
Created automatic test verifying error and fix


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

Fixes: [AB#43169](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/43169)
