### PR TITLE
feat: Add Fusion.Resources.Read role to GetAllRequests endpoint

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Fusion.Resources.Api.Controllers
             return builder;
         }
 
-        public static IAuthorizationRequirementRule GlobalRoleAccess(this IAuthorizationRequirementRule builder, params string[] roles)
+       public static IAuthorizationRequirementRule GlobalRoleAccess(this IAuthorizationRequirementRule builder, params string[] roles)
         {
             return builder.AddRule(new GlobalRoleRequirement(roles));
         }
@@ -145,6 +145,17 @@ namespace Fusion.Resources.Api.Controllers
         {
             var policy = new AuthorizationPolicyBuilder()
                 .RequireAssertion(c => c.User.IsInRole("Fusion.Resources.FullControl"))
+                .Build();
+
+            builder.AddRule((auth, user) => auth.AuthorizeAsync(user, policy));
+
+            return builder;
+        }
+
+        public static IAuthorizationRequirementRule ResourcesRead(this IAuthorizationRequirementRule builder)
+        {
+            var policy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(c => c.User.IsInRole("Fusion.Resources.Read"))
                 .Build();
 
             builder.AddRule((auth, user) => auth.AuthorizeAsync(user, policy));

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -501,6 +501,7 @@ namespace Fusion.Resources.Api.Controllers
                         );
                         or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString), AccessRoles.ResourceOwner);
                     }
+                    or.ResourcesRead();
                 });
             });
 


### PR DESCRIPTION
- [X] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Added a role neede to be able to read from Fusion.Resources. Only added specifically to GetAllRequests endpoint (resources/requests/internal)

**Testing:**
- [X] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->
Strip down user and try to access that specific endpoint without any roles claimed. And then try to add that specific role, and observe that it is allowed to use the endpoint. Applies to endpoint "resources/requests/internal"

[AB#43635](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/43635)
**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

