### PR TITLE
feat/chunkGettingPersonProfiles

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonProfiles.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonProfiles.cs
@@ -41,7 +41,7 @@ namespace Fusion.Resources.Domain.Queries
 
                 var results = await Task.WhenAll(tasks);
 
-                var profiles = results.Select(X => X).SelectMany(o => o);
+                var profiles = results.Select(p => p).SelectMany(p => p);
 
                 return profiles
                     .Where(p => p.Success && p.Profile?.AzureUniqueId != null)


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When getting PersonProfiles there is a limitation of 500 personIdentifiers at the time when requesting from PeopleAPI. The problem was identified when trying to access GetAllRequests from FRA.ApplicationManagement.
This change should be a workaround for getting more than 500 at the time so we get all the Requests.





**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

The problem arosed in Production for FRA.Application Management because of the amount of requests we where trying to get. The tests should be to just get requests as normal. There should not be any changes other than the possibility to get more than 500 PersonProfiles at the time, which currently only applies to Production



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

