### PR TITLE
feat: Do not set ProposedPerson = NULL when ResetWorkflow

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/ResetWorkflow.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/ResetWorkflow.cs
@@ -36,7 +36,6 @@ namespace Fusion.Resources.Domain.Commands
                 requestItem.State = new DbOpState();
                 requestItem.IsDraft = true;
                 requestItem.AssignedDepartment = null;
-                requestItem.ProposedPerson = new DbOpProposedPerson();
 
                 db.Workflows.RemoveRange(
                     db.Workflows.Where(wf => wf.RequestId == request.requestId)


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When resetting workflow as a step in rejecting a AllocationRequest I have removed functionality to set ProposedPerson to NULL. This is an attempt to make ProposedPerson available when the task owner is responding to a rejected request, which should be to create a new request. It is then easier to know who was the previous suggested resource before creating a new request



**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Can be tested by creating a new request with a specific resource (as proposedPerson). Then the resource owner should reject the request. The rejected request should then still contain the proposedPerson suggested in the first step.



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

