### PR TITLE
fix: Increased time of delay for each retry of queued message (Provision)

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
@@ -66,6 +66,7 @@ namespace Fusion.Resources.Functions
 
                     retryMessage.ApplicationProperties["retry-count"] = retryCount;
                     retryMessage.ApplicationProperties["original-SequenceNumber"] = originalSequence;
+                    retryMessage.ScheduledEnqueueTime = scheduledTime;
                     await sender.AddAsync(retryMessage);
                     await receiver.CompleteMessageAsync(message);                    
 

--- a/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
@@ -61,7 +61,7 @@ namespace Fusion.Resources.Functions
                 {
                     var retryMessage = new ServiceBusMessage(message);
                     retryCount++;
-                    var interval = 60 * retryCount;
+                    var interval = 30 * retryCount;
                     var scheduledTime = DateTimeOffset.Now.AddSeconds(interval);
 
                     retryMessage.ApplicationProperties["retry-count"] = retryCount;

--- a/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ServiceBus/QueueMessageProcessor.cs
@@ -61,7 +61,7 @@ namespace Fusion.Resources.Functions
                 {
                     var retryMessage = new ServiceBusMessage(message);
                     retryCount++;
-                    var interval = 10 * retryCount;
+                    var interval = 60 * retryCount;
                     var scheduledTime = DateTimeOffset.Now.AddSeconds(interval);
 
                     retryMessage.ApplicationProperties["retry-count"] = retryCount;


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

[AB#44549](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/44549)

**Description of work:**
Because there have been some requests that have timed out when running its natural cause and there are not obvious exceptions we will try to increase the amount of time we delay the retry. We increase from 10 seconds * retryCount to 30 seconds * retryCount. This means that we will wait around 4 minutes before retrying the last time (fourth time).

NB! The initial code did prepare scheduledTime to be increased 10 seconds for each retry, but the value was never assigned to retryMessage. We will still increase the delay to be 30 seconds for each try.



**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

The function could be tested with natural processing of a request going through all the stages (create a new request, approve that request and then check that the request are beeing processed in provision). It is only when the provision-stage fails that we may experience the fix. 

**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

