### PR TITLE
fix: Change variable name when getting PersonProfile from PersonAPI

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonProfiles.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonProfiles.cs
@@ -34,9 +34,9 @@ namespace Fusion.Resources.Domain.Queries
                 var tasks = new List<Task<IEnumerable<ResolvedPersonProfile>>>();
 
                 // Max number of identifiers is 500, so we chunk the requests
-                foreach (var req in request.Identifiers.Chunk(500))
+                foreach (var identifierBatch in request.Identifiers.Chunk(500))
                 {
-                    tasks.Add(profileResolver.ResolvePersonsAsync(request.Identifiers));
+                    tasks.Add(profileResolver.ResolvePersonsAsync(identifierBatch));
                 }
 
                 var results = await Task.WhenAll(tasks);


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Was using the wrong variable when looping through all PersonIdentifiers from the request. Changed to the correct variable



**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

