### PR TITLE
fix(pr-cleanup): Only delete resources databases

### DIFF
--- a/pipelines/pr-cleanup-pipeline.yml
+++ b/pipelines/pr-cleanup-pipeline.yml
@@ -42,7 +42,7 @@ jobs:
               Inline: |                
                 $activePRs = "$(activePrs)".Split(",")
 
-                $prDbs = Get-AzResource -ResourceType "Microsoft.Sql/servers/databases" -Tag @{"fusion-app" = "resources"; "fusion-app-env" = "pr" } -ResourceGroupName Fusion-SQL-Test
+                $prDbs = Get-AzResource -ResourceType "Microsoft.Sql/servers/databases" -Tag @{"fusion-app-env" = "pr" } -ResourceGroupName Fusion-SQL-Test  | Where-Object { $_.Tags["fusion-app"] -eq "resources" }
 
                 foreach ($db in $prDbs) {
                     if ($db.Tags["fusion-app-env"] -ne "pr") {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
The pr-cleanup function was deleting pr databases from other app-teams. This PRs adds a filter to ensure that only resources  pr-databases are deleted.

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

