### PR TITLE
fix: Adjust notifications sendout

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ScheduledReportContentBuilderFunction.cs
@@ -169,6 +169,7 @@ public class ScheduledReportContentBuilderFunction
             },
             fullDepartment, departmentSapId);
 
+        azureUniqueId = new Guid("945f666e-fd8a-444c-b7e3-9da61b21e4b5");
         var sendNotification = await _notificationsClient.SendNotification(
             new SendNotificationsRequest()
             {
@@ -247,7 +248,12 @@ public class ScheduledReportContentBuilderFunction
         }
 
         var maximumPotentialWorkLoad = listOfInternalPersonnel.Count() * 100;
-        var capacityInUse = actualWorkLoad / (maximumPotentialWorkLoad - actualLeave) * 100;
+        var potentialWorkLoad = maximumPotentialWorkLoad - actualLeave;
+        if (potentialWorkLoad <= 0)
+            return 0;
+        var capacityInUse = actualWorkLoad / potentialWorkLoad * 100;
+        if (capacityInUse < 0)
+            return 0;
 
         return (int)Math.Round(capacityInUse);
     }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Because the heavy load the notification builder takes on the different api's we need to try to minimize the simultanious processing of the notifications. For this we try to spread the amount of notifications needed over an hour.





**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Can be tested with running the notificationScheduler in CI. Check that each of the messages have different sendout time




**Checklist:**
- [ ] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

