### PR TITLE
fix/Adjust AllocationChangesAwaitingTaskOwnerAction for summary notifications

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ScheduledReportContentBuilderFunction.cs
@@ -152,21 +152,21 @@ public class ScheduledReportContentBuilderFunction
             .Where(p => p.TotalWorkload > 100);
 
         var card = ResourceOwnerAdaptiveCardBuilder(new ResourceOwnerAdaptiveCardData
-            {
-                TotalNumberOfPersonnel = personnelForDepartment.Count(),
-                CapacityInUse = capacityInUse,
-                NumberOfRequestsLastWeek = numberOfRequestsLastWeek,
-                NumberOfOpenRequests = totalNumberOfOpenRequests,
-                NumberOfRequestsStartingInMoreThanThreeMonths =
+        {
+            TotalNumberOfPersonnel = personnelForDepartment.Count(),
+            CapacityInUse = capacityInUse,
+            NumberOfRequestsLastWeek = numberOfRequestsLastWeek,
+            NumberOfOpenRequests = totalNumberOfOpenRequests,
+            NumberOfRequestsStartingInMoreThanThreeMonths =
                     numberOfDepartmentRequestWithMoreThanThreeMonthsBeforeStart,
-                NumberOfRequestsStartingInLessThanThreeMonths =
+            NumberOfRequestsStartingInLessThanThreeMonths =
                     numberOfDepartmentRequestWithLessThanThreeMonthsBeforeStartAndNoNomination,
-                AverageTimeToHandleRequests = averageTimeToHandleRequest,
-                AllocationChangesAwaitingTaskOwnerAction = numberOfAllocationChangesAwaitingTaskOwnerAction,
-                ProjectChangesAffectingNextThreeMonths = numberOfChangesAffectingNextThreeMonths,
-                PersonnelPositionsEndingWithNoFutureAllocation = listOfPersonnelWithoutFutureAllocations,
-                PersonnelAllocatedMoreThan100Percent = personnelAllocatedMoreThan100Percent
-            },
+            AverageTimeToHandleRequests = averageTimeToHandleRequest,
+            AllocationChangesAwaitingTaskOwnerAction = numberOfAllocationChangesAwaitingTaskOwnerAction,
+            ProjectChangesAffectingNextThreeMonths = numberOfChangesAffectingNextThreeMonths,
+            PersonnelPositionsEndingWithNoFutureAllocation = listOfPersonnelWithoutFutureAllocations,
+            PersonnelAllocatedMoreThan100Percent = personnelAllocatedMoreThan100Percent
+        },
             fullDepartment, departmentSapId);
 
         var sendNotification = await _notificationsClient.SendNotification(
@@ -299,12 +299,9 @@ public class ScheduledReportContentBuilderFunction
     }
 
     private static int GetChangesAwaitingTaskOwnerAction(IEnumerable<ResourceAllocationRequest> listOfRequests)
-        => listOfRequests
-            .Where((req => req.Type is "ResourceOwnerChange"))
-            .Where(req =>
-                req.Workflow != null && req.Workflow.Steps.Any(step => step.Name.Equals("Accept") && !step.IsCompleted))
-            .ToList()
-            .Count;
+    => listOfRequests
+        .Where((req => req.Type is "ResourceOwnerChange"))
+    .Where(req => req.State != null && req.State.Equals("created", StringComparison.OrdinalIgnoreCase)).ToList().Count();
 
 
     private static string CalculateAverageTimeToHandleRequests(IEnumerable<ResourceAllocationRequest> listOfRequests)


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Have changed the way we find AllocationChangesAwaitingTaskOwnerAction which is based on resource allocation requests which is in the state "created" and is of type "ResourceOwnerChange". 




**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

Can be tested with starting the scheduled function for sending out all summary notifications. The field AllocationChangesAwaitingTaskOwnerAction on the notifications that are generated should be compared with what is displayed in Personnel Allocation (specified orgunit) -> Dashboard -> field: Change requests pending acceptance from project



**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

