### PR TITLE
feat: Remove external personnel from summary notification

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/ApiClients/IResourcesApiClient.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ApiClients/IResourcesApiClient.cs
@@ -126,7 +126,7 @@ namespace Fusion.Resources.Functions.ApiClients
             public bool IsResourceOwner { get; set; }
             public string? AccountType { get; set; }
             public List<PersonnelPosition> PositionInstances { get; set; } = new List<PersonnelPosition>();
-            public List<ApiPersonAbsence> ApiPersonAbsences { get; set; } = new List<ApiPersonAbsence>();
+            public List<ApiPersonAbsence> EmploymentStatuses { get; set; } = new List<ApiPersonAbsence>();
         }
 
         public class PersonnelPosition
@@ -151,20 +151,14 @@ namespace Fusion.Resources.Functions.ApiClients
 
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public DateTimeOffset? Created { get; set; }
-
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public InternalPersonnelPerson? CreatedBy { get; set; }
-
             public bool IsPrivate { get; set; }
-
             public string? Comment { get; set; }
-
-            //public ApiTaskDetails? TaskDetails { get; set; } // Trengs denne?
             public DateTimeOffset? AppliesFrom { get; set; }
             public DateTimeOffset? AppliesTo { get; set; }
             public ApiAbsenceType? Type { get; set; }
             public double? AbsencePercentage { get; set; }
-
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public bool IsActive => AppliesFrom <= DateTime.UtcNow.Date && AppliesTo >= DateTime.UtcNow.Date;
         }

--- a/src/backend/function/Fusion.Resources.Functions/ApiClients/ResourcesApiClient.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ApiClients/ResourcesApiClient.cs
@@ -50,7 +50,7 @@ namespace Fusion.Resources.Functions.ApiClients
             string departmentIdentifier)
         {
             var response = await resourcesClient.GetAsJsonAsync<InternalCollection<InternalPersonnelPerson>>(
-                $"departments/{departmentIdentifier}/resources/personnel?api-version=2.0&$includeCurrentAllocations=true");
+       $"departments/{departmentIdentifier}/resources/personnel?api-version=2.0&$includeCurrentAllocations=true");
 
             return response.Value.ToList();
         }

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ResourceOwnerReportDataCreator.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ResourceOwnerReportDataCreator.cs
@@ -21,11 +21,13 @@ public abstract class ResourceOwnerReportDataCreator
         foreach (var personnel in listOfInternalPersonnel)
         {
             actualWorkLoad += personnel.PositionInstances.Where(pos => pos.IsActive).Select(pos => pos.Workload).Sum();
-            actualWorkLoad += personnel.ApiPersonAbsences
+
+            actualWorkLoad += personnel.EmploymentStatuses
                 .Where(ab => ab.Type == IResourcesApiClient.ApiAbsenceType.OtherTasks && ab.IsActive)
                 .Select(ab => ab.AbsencePercentage)
                 .Sum() ?? 0;
-            actualLeave += personnel.ApiPersonAbsences
+
+            actualLeave += personnel.EmploymentStatuses
                 .Where(ab =>
                     ab.Type is IResourcesApiClient.ApiAbsenceType.Absence
                         or IResourcesApiClient.ApiAbsenceType.Vacation && ab.IsActive)
@@ -210,7 +212,7 @@ public class AllocatedPersonnelWithWorkLoad : AllocatedPersonnel
 
     private double CalculateTotalWorkload(IResourcesApiClient.InternalPersonnelPerson person)
     {
-        var totalWorkLoad = person.ApiPersonAbsences
+        var totalWorkLoad = person.EmploymentStatuses
             .Where(ab => ab.Type != IResourcesApiClient.ApiAbsenceType.Absence && ab.IsActive)
             .Select(ab => ab.AbsencePercentage).Sum();
         totalWorkLoad += person.PositionInstances.Where(pos => pos.IsActive).Select(pos => pos.Workload).Sum();

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
@@ -35,8 +35,8 @@ public abstract class NotificationReportApiResponseMock
         for (var i = 0; i < personnelCount; i++)
         {
             personnel.Add(new IResourcesApiClient.InternalPersonnelPerson()
-                {
-                    ApiPersonAbsences = new List<IResourcesApiClient.ApiPersonAbsence>
+            {
+                EmploymentStatuses = new List<IResourcesApiClient.ApiPersonAbsence>
                     {
                         new()
                         {
@@ -60,7 +60,7 @@ public abstract class NotificationReportApiResponseMock
                             AbsencePercentage = absenceLeave
                         }
                     },
-                    PositionInstances = new List<IResourcesApiClient.PersonnelPosition>
+                PositionInstances = new List<IResourcesApiClient.PersonnelPosition>
                     {
                         new()
                         {
@@ -69,7 +69,7 @@ public abstract class NotificationReportApiResponseMock
                             Workload = workload,
                         }
                     }
-                }
+            }
             );
         }
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Have removed external personnel (users with accountType=consultant) from summary notifications so that these are not included in the KPI's.
Did also small adjustments regarding getting leave for calculating capacity. It was not necessarry to get this from an own endpoint so I removed it. The calculation is the same.

[AB#49281](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/49281)



**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Can be tested with running summary notification and verifying that all personnel of type "consultant" has been removed from the notification. It should be possible to find which users are external personnel by checking in Personnel Allocation for a specific department. All of the external personnel should have the name of their affiliated company in parentesies (example: FirstName Lastname (Bouvet ASA)



**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

