### PR TITLE
Update to a org api client with longer timeout

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -113,7 +113,7 @@ namespace Fusion.Resources.Api
             services.AddHttpClient<IOrgHttpClient, OrgHttpClient>(client =>
             {
                 client.BaseAddress = new Uri("http://not-implemented-here-but-in-client.com");
-                client.Timeout = TimeSpan.FromSeconds(60 * 10);
+                client.Timeout = TimeSpan.FromMinutes(10);
             });
 
             // Keeping for reference - The validator is not added to the .net core validation pipeline. This is due to limitations in running async 

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -9,6 +9,7 @@ using Fusion.Resources.Api.HostedServices;
 using Fusion.Resources.Api.Middleware;
 using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Commands;
+using Fusion.Resources.Domain.Services;
 using Fusion.Resources.Logic;
 using JSM.FluentValidation.AspNet.AsyncFilter;
 using MediatR;
@@ -22,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using SixLabors.ImageSharp;
+using System;
 using System.Reflection;
 
 namespace Fusion.Resources.Api
@@ -106,8 +108,13 @@ namespace Fusion.Resources.Api
 
             services.AddOrgApiClient(OrgConstants.HttpClients.Application, OrgConstants.HttpClients.Delegate);
 
-            services.AddControllers()
-                .AddModelValidationAsyncActionFilter();
+            services.AddControllers().AddModelValidationAsyncActionFilter();
+
+            services.AddHttpClient<IOrgHttpClient, OrgHttpClient>(client =>
+            {
+                client.BaseAddress = new Uri("http://not-implemented-here-but-in-client.com");
+                client.Timeout = TimeSpan.FromSeconds(60 * 10);
+            });
 
             // Keeping for reference - The validator is not added to the .net core validation pipeline. This is due to limitations in running async 
             // validators. This is required to validate against external requirements, e.g. position exists.

--- a/src/backend/api/Fusion.Resources.Domain/Services/IOrgHttpClient.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/IOrgHttpClient.cs
@@ -1,0 +1,9 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Services;
+
+public interface IOrgHttpClient
+{
+    Task<RequestResponse<T>> SendAsync<T>(HttpRequestMessage request);
+}

--- a/src/backend/api/Fusion.Resources.Domain/Services/OrgHttpClient.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/OrgHttpClient.cs
@@ -13,8 +13,10 @@ public class OrgHttpClient : IOrgHttpClient
     private readonly IFusionTokenProvider _tokenProvider;
     private readonly HttpClient _httpClient;
 
-    public OrgHttpClient(HttpClient httpClient)
+    public OrgHttpClient(IFusionEndpointResolver endpointResolver, IFusionTokenProvider tokenProvider, HttpClient httpClient)
     {
+        _endpointResolver = endpointResolver;
+        _tokenProvider = tokenProvider;
         _httpClient = httpClient;
     }
 

--- a/src/backend/api/Fusion.Resources.Domain/Services/OrgHttpClient.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/OrgHttpClient.cs
@@ -1,0 +1,33 @@
+﻿using Fusion.Integration.Configuration;
+using Fusion.Integration;
+using System;
+using System.Net.Http.Headers;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Services;
+
+public class OrgHttpClient : IOrgHttpClient
+{
+    private readonly IFusionEndpointResolver _endpointResolver;
+    private readonly IFusionTokenProvider _tokenProvider;
+    private readonly HttpClient _httpClient;
+
+    public OrgHttpClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<RequestResponse<T>> SendAsync<T>(HttpRequestMessage request)
+    {
+        var baseUrl = await _endpointResolver.ResolveEndpointAsync(FusionEndpoint.ProOrganisation);
+        var token = await _tokenProvider.GetApplicationTokenAsync();
+
+        request.RequestUri = new Uri(new Uri(baseUrl), request.RequestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _httpClient.SendAsync(request);
+
+        return await RequestResponse<T>.FromResponseAsync(response);
+    }
+}

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -109,7 +109,6 @@ namespace Fusion.Resources.Logic.Commands
 
                         var updateResp
                             = await httpClient.SendAsync<ApiPositionInstanceV2>(request);
-                            //= await client.PatchAsync<ApiPositionInstanceV2>(url, instancePatchRequest);
 
                         if (!updateResp.IsSuccessStatusCode)
                             throw new OrgApiError(updateResp.Response, updateResp.Content);


### PR DESCRIPTION
- [ ] New feature
- [X] Bug fix
- [ ] High impact

**Description of work:**

Created a new client that has the additional configuration to support the needed 10min timeout that Org needs to fulfill the request. 

[[AB#49528](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/49528)](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/47153)


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->

**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

<!--- Other comments --->
