### PR TITLE
feature: Consultant and Employee should get limited Delegated Resource Owners

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiDepartmentResponsible.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/ApiModels/ApiDepartmentResponsible.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
+using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Models;
 
 
@@ -21,6 +22,24 @@ namespace Fusion.Resources.Api.Controllers
             if (responsible.CreatedBy != null)
                 CreatedBy = new ApiPerson(responsible.CreatedBy);
         }
+
+        public ApiDepartmentResponsible(QueryDepartmentResponsible responsible, bool limit)
+        {
+            Name = responsible.DepartmentId;
+            if (responsible.DelegatedResponsible != null)
+                DelegatedResponsible = new ApiPerson(responsible.DelegatedResponsible);
+
+            DateFrom = responsible.DateFrom;
+            DateTo = responsible.DateTo;
+            Reason = limit ? null : responsible.Reason;
+
+            CreatedDate = responsible.CreatedDate;
+            if (responsible.CreatedBy != null && !limit)
+                CreatedBy = new ApiPerson(responsible.CreatedBy);
+        }
+
+        public static ApiDepartmentResponsible CreateLimitedDelegatedResponsible(QueryDepartmentResponsible responsible) => new ApiDepartmentResponsible(responsible, limit: true);
+
 
         public string? Name { get; set; } = null!;
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -301,6 +301,36 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task Options_As_NormalEmployee_Should_Be_Able_To_Get_DelegatedResourceOwners()
+        {
+            var testSector = "MY TPD LIN";
+            var testDepartment = "MY TPD LIN DEP5";
+            fixture.EnsureDepartment(testDepartment, testSector);
+
+            var employee = fixture.AddProfile(FusionAccountType.Employee);
+
+            using var adminScope = fixture.UserScope(employee);
+            var result = await Client.TestClientOptionsAsync($"/departments/{testDepartment}/delegated-resource-owners");
+            result.Should().BeSuccessfull();
+            result.CheckAllowHeader("OPTIONS, !DELETE, !POST, GET");
+        }
+
+        [Fact]
+        public async Task Options_As_Consultant_Should_Be_Able_To_Get_DelegatedResourceOwners()
+        {
+            var testSector = "MY TPD LIN";
+            var testDepartment = "MY TPD LIN DEP5";
+            fixture.EnsureDepartment(testDepartment, testSector);
+
+            var employee = fixture.AddProfile(FusionAccountType.Consultant);
+
+            using var adminScope = fixture.UserScope(employee);
+            var result = await Client.TestClientOptionsAsync($"/departments/{testDepartment}/delegated-resource-owners");
+            result.Should().BeSuccessfull();
+            result.CheckAllowHeader("OPTIONS, !DELETE, !POST, GET");
+        }
+
+        [Fact]
         public async Task AddDepartmentResponsible_ShouldBeAllowed_WhenAdmin()
         {
             var testDepartment = "TPD LIN ORG TST";
@@ -440,8 +470,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             LineOrgServiceMock.AddDepartment(department, children);
             LineOrgServiceMock.AddDepartment("PDP TST", siblings);
 
-            foreach (var sibling in siblings) fixture.EnsureDepartment(sibling);
-            foreach (var child in children) fixture.EnsureDepartment(child);
+            foreach (var sibling in siblings)
+                fixture.EnsureDepartment(sibling);
+            foreach (var child in children)
+                fixture.EnsureDepartment(child);
 
             var project = new FusionTestProjectBuilder();
             var pos = project.AddPosition().WithEnsuredFutureInstances();
@@ -472,8 +504,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             LineOrgServiceMock.AddDepartment(department, children);
             LineOrgServiceMock.AddDepartment("PDP TST", siblings);
 
-            foreach (var sibling in siblings) fixture.EnsureDepartment(sibling);
-            foreach (var child in children) fixture.EnsureDepartment(child);
+            foreach (var sibling in siblings)
+                fixture.EnsureDepartment(sibling);
+            foreach (var child in children)
+                fixture.EnsureDepartment(child);
 
             var project = new FusionTestProjectBuilder();
             var pos = project.AddPosition().WithEnsuredFutureInstances();
@@ -498,8 +532,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             LineOrgServiceMock.AddDepartment(department, children);
             LineOrgServiceMock.AddDepartment("PDP TST", siblings);
 
-            foreach (var sibling in siblings) fixture.EnsureDepartment(sibling);
-            foreach (var child in children) fixture.EnsureDepartment(child);
+            foreach (var sibling in siblings)
+                fixture.EnsureDepartment(sibling);
+            foreach (var child in children)
+                fixture.EnsureDepartment(child);
 
             var project = new FusionTestProjectBuilder();
             var pos = project.AddPosition().WithEnsuredFutureInstances();
@@ -525,8 +561,10 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             LineOrgServiceMock.AddDepartment(department, children);
             LineOrgServiceMock.AddDepartment("PDP TST", siblings);
 
-            foreach (var sibling in siblings) fixture.EnsureDepartment(sibling);
-            foreach (var child in children) fixture.EnsureDepartment(child);
+            foreach (var sibling in siblings)
+                fixture.EnsureDepartment(sibling);
+            foreach (var child in children)
+                fixture.EnsureDepartment(child);
 
             var project = new FusionTestProjectBuilder();
             var pos = project.AddPosition().WithEnsuredFutureInstances();


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Users of type Consultant and Employee should be able to see delegated resource owners. 
Have updated both GET and OPTIONS endpoint for getting delegated resource owners for specific department:

        [HttpGet("/departments/{departmentString}/delegated-resource-owners")]

        [HttpOptions("/departments/{departmentString}/delegated-resource-owners")]

Both Consultant and Employee should only get limited DepartmentResponsible which means that they don't get the fields "Reason" and "CreatedBy"

[AB#50694](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/50694)
**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

To test, use postman and try both these endpoints
Endpoint 1: 
GET - https://resources-api-pr-623.fusion-dev.net/departments/{departmentString}/delegated-resource-owners
_NB! Replace {departmentString} with a department that you want to check who is delegated resource owners_


You should receive these fields as a consultant (or employee):
- Name
 - DelegatedResponsible
  - DateFrom
  - DateTo 
 - CreatedDate 

If you activate the role **Fusion Resources Full Control** you should also get "Reason" and "CreatedBy".

Endpoint 2:
OPTIONS - https://resources-api-pr-623.fusion-dev.net/departments/{departmentString}/delegated-resource-owners
_NB! Replace {departmentString} with a department that you want to check who is delegated resource owners_


You should receive the which kind of access you have for that specific endpoint. It will be described in the headers. And for Consultant or Employee it should be GET and OPTIONS



**Checklist:**
- [X] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [X] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

