### PR TITLE
feat: Added caching of deleted positionIds when getting requets with expand…

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceAllocationRequests.cs
@@ -422,6 +422,9 @@ namespace Fusion.Resources.Domain.Queries
 
             private bool MemCacheContains(Guid? id)
             {
+                if (id == null)
+                    return false;
+
                 return memoryCache.TryGetValue(id, out id);
             }
 


### PR DESCRIPTION
- [X] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When getting requests with expand field on uri ($expand=orgPositionInstance) the API will try to resolve (get data from other sources) about positions that are refered to in the request. This means that Resource API will try to get position info from Org-API. And if the position does not exist, it will return 404 (naturally), and because many requests are referring to deleted positions the amount of 404s is to many, and therefore we want to reduce this. 

The fix is that we have implemented a InMemoryCache which cache all the positionIds that returns 404, so that we don't try to resolve these anymore.

As per now the timeout for the cache is 7 days so that we don't risk the cache being to big. 
The MemoryCache solution is probably a temporary fix as we in the future may want to tag the requests that have deleted positions to more permanent make sure that they don't try to resolve the deleted positions (see User story 50814)  

Example on a URI that gets all the requests with position data: 
https://resources-api.ci.fusion-dev.net/projects/f1e7d72b-5399-4ea6-8a28-760780bbed83/resources/requests?$expand=orgPositionInstance,actions&$top=500&$filter=state%20neq%20completed&$orderby=lastActivity%20desc

[AB#44789](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/44789)

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Not that easy to test as this is to reduce the errors in application insight. But we should still get the same data when trying to get all the requests. It should only reduce the errors in application insight.

One can use this enpoint directly in Postman to verify that one get all the data that we need:
https://resources-api-pr-624.fusion-dev.net/projects/:projectId/resources/requests?$expand=orgPositionInstance,actions&$top=500&$filter=state%20neq%20completed&$orderby=lastActivity%20desc



**Checklist:**
- [X] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [X] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

