### PR TITLE
Fix/check positions before sending request

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/IOrgApiClientExtensions.cs
@@ -114,7 +114,6 @@ namespace Fusion.Resources
 
             return publishedDraft;
         }
-
     }
 
     public class RequestResponse<TResponse>

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -61,7 +61,7 @@ namespace Fusion.Resources.Logic.Commands
                             {
                                 retriesCounter++;
 
-                                var p = await client.GetAsync<ApiPositionV2>($"/projects/{projectId}/drafts/{draftId}/positions/{positionId}");
+                                var p = await client.GetAsync<ApiPositionV2>($"/projects/{projectId}/drafts/{draftId}/positions/{positionId}?api-version=2.0");
 
                                 if( !p.IsSuccessStatusCode )
                                 {

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -2,7 +2,6 @@
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using MediatR;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -49,7 +49,7 @@ namespace Fusion.Resources.Logic.Commands
 
                         var draft = await CreateProvisionDraftAsync(dbRequest);
 
-                        var projectId = position.ProjectId;
+                        var projectId = dbRequest.ProjectId;
                         var positionId = position.Id;
                         var draftId = draft.Id;
 

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResourceOwner/ProvisionResourceOwnerRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/ResourceOwner/ProvisionResourceOwnerRequest.cs
@@ -257,7 +257,6 @@ namespace Fusion.Resources.Logic.Commands
                         }
                     }
 
-
                     private async Task UpdateFutureSplitAsync(DbResourceAllocationRequest dbRequest, JObject rawPosition)
                     {
                         // Update existing 
@@ -271,8 +270,6 @@ namespace Fusion.Resources.Logic.Commands
 
                         if (dbRequest.ProposedPerson.AzureUniqueId != null)
                             instancePatchRequest.SetPropertyValue<ApiPositionInstanceV2>(i => i.AssignedPerson, new ApiPersonV2() { AzureUniqueId = dbRequest.ProposedPerson.AzureUniqueId });
-
-                        
 
                         if (proposedChanges.TryGetValue("workload", StringComparison.InvariantCultureIgnoreCase, out var workload))
                             instancePatchRequest.SetPropertyValue<ApiPositionInstanceV2>(i => i.Workload!, workload);

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
@@ -444,8 +444,12 @@ namespace Fusion.Resources.Logic.Tests
             var factoryMock = new Mock<IOrgApiClientFactory>();
             factoryMock.Setup(c => c.CreateClient(ApiClientMode.Application)).Returns(orgClientMock.Object);
 
-            var cmd = new ResourceAllocationRequest.Allocation.ProvisionAllocationRequest(request.Id);           
-            var handler = new ResourceAllocationRequest.Allocation.ProvisionAllocationRequest.Handler(dbContext, factoryMock.Object)
+            var cmd = new ResourceAllocationRequest.Allocation.ProvisionAllocationRequest(request.Id);
+
+            // Add telemetry client that does not send any telemetry.
+            var mockTelemetryClient = new Microsoft.ApplicationInsights.TelemetryClient(new TelemetryConfiguration() { DisableTelemetry = true });
+
+            var handler = new ResourceAllocationRequest.Allocation.ProvisionAllocationRequest.Handler(mockTelemetryClient, dbContext, factoryMock.Object)
                 as IRequestHandler<ResourceAllocationRequest.Allocation.ProvisionAllocationRequest>;
             await handler.Handle(cmd, CancellationToken.None);
 

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/AllocationTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Azure;
+using FluentAssertions;
 using Fusion.ApiClients.Org;
 using Fusion.Integration.Profile.ApiClient;
 using Fusion.Resources.Database;
@@ -31,6 +32,7 @@ namespace Fusion.Resources.Logic.Tests
         Mock<IOrgApiClient> orgClientMock;
         private readonly Guid testProjectId;
         private readonly Guid draftId;
+        private readonly Guid positionId;
 
         public AllocationTests()
         {
@@ -41,6 +43,7 @@ namespace Fusion.Resources.Logic.Tests
             dbContext = new ResourcesDbContext(options);
             testProjectId = Guid.NewGuid();
             draftId = Guid.NewGuid();
+            positionId = Guid.NewGuid();
 
             orgClientMock = new Mock<IOrgApiClient>();
 
@@ -61,6 +64,17 @@ namespace Fusion.Resources.Logic.Tests
                 StatusCode = System.Net.HttpStatusCode.OK,
                 Content = new StringContent(JsonConvert.SerializeObject(new ApiDraftV2() { Id = draftId, Status = "Published" }), Encoding.UTF8, "application/json")
             });
+
+            // Must mock getting position
+            orgClientMock.Setup(c => c.GetAsync<ApiPositionV2>($"/projects/{testProjectId}/drafts/{draftId}/positions/{positionId}?api-version=2.0")).Returns(RequestResponse<ApiPositionV2>.FromResponseAsync(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(new ApiPositionV2()
+                {
+                    Id = draftId,
+                    ProjectId = testProjectId
+                }), Encoding.UTF8, "application/json")
+            }));
         }
 
 

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/MockRequest.cs
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Provisioning/MockRequest.cs
@@ -13,6 +13,10 @@ namespace Fusion.Resources.Logic.Tests
         {
             return It.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post && IsUri(r, uri));
         }
+        public static HttpRequestMessage GET(string uri)
+        {
+            return It.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && IsUri(r, uri));
+        }
 
         private static bool IsUri(HttpRequestMessage request, string uri)
         {

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Api/Controllers/PositionsController.cs
@@ -52,7 +52,8 @@ namespace Fusion.Testing.Mocks.OrgService.Api.Controllers
 
         [MapToApiVersion("2.0")]
         [HttpGet("/projects/{projectId}/positions/{positionId}")]
-        public ActionResult<ApiPositionV2> GetPosition(string projectId, Guid positionId)
+        [HttpGet("/projects/{projectId}/drafts/{draftId}/positions/{positionId}")]
+        public ActionResult<ApiPositionV2> GetPosition(string projectId, Guid? draftId, Guid positionId)
         {
             var position = OrgServiceMock.positions.FirstOrDefault(p => p.Id == positionId);
 


### PR DESCRIPTION
- [] New feature
- [X] Bug fix
- [] High impact

**Work description:**

Added retry logic for handling of provision allocation requests in order to ensure its _ready_. The problem the bug points to indicates that the positions was not ready further down when calling logic in regards to drafting. Polling for them earlier solves the problem.

Link to workitem: [#47153](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/47153)

**Test description:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

**Checklist:**
- [x] Considered automated tests
- [] Considered updating specification / documentation
- [] Considered work items 
- [] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review