### PR TITLE
feat: Adjusted the calculation of the field "Project changes last week affecting next 3 months" for a department to use AllocationState/AllocationUpdated

### DIFF
--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
@@ -51,9 +51,7 @@ public abstract class NotificationReportApiResponseMock
                         {
                             AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
                             AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
-                            Workload = workload,
-                            AllocationState = null,
-                            AllocationUpdated = null,
+                            Workload = workload
                         }
                     }
             }
@@ -64,19 +62,19 @@ public abstract class NotificationReportApiResponseMock
         return personnel;
     }
 
-    public static List<IResourcesApiClient.InternalPersonnelPerson> GetMockedInternalPersonnelWithAllocationUpdated(
-      double personnelCount
-      )
+    public static List<IResourcesApiClient.InternalPersonnelPerson> GetMockedInternalPersonnelWithInstancesWithAndWithoutChanges(double personnelCount)
     {
         var personnel = new List<IResourcesApiClient.InternalPersonnelPerson>();
         for (var i = 0; i < personnelCount; i++)
         {
             personnel.Add(new IResourcesApiClient.InternalPersonnelPerson()
             {
+                // Should return 4 instances for each person
                 PositionInstances = new List<IResourcesApiClient.PersonnelPosition>
                     {
                         new()
                         {
+                            // One active instance without any changes
                             AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
                             AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
                             AllocationState = null,
@@ -84,26 +82,28 @@ public abstract class NotificationReportApiResponseMock
                         },
                         new()
                         {
+                            // One active instance that contains changes done within the last week
                             AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
                             AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
                             AllocationState = "ChangeByTaskOwner",
                             AllocationUpdated = DateTime.UtcNow,
                         },
-                        new()                           
+                        new()
                         {
+                            // One active instance that contains changes done more than a week ago
                             AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
                             AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
                             AllocationState = "ChangeByTaskOwner",
-                            AllocationUpdated = DateTime.UtcNow.AddDays(-10),
+                            AllocationUpdated = DateTime.UtcNow.AddDays(-8),
                         },
-                        new()                           
+                        new()
                         {
-                            AppliesFrom = DateTime.UtcNow.AddDays(91),
-                            AppliesTo = DateTime.UtcNow.AddDays(60 + i * 10),
+                            // One instance that will become active in more than 3 months that contains changes
+                            AppliesFrom = DateTime.UtcNow.AddMonths(4),
+                            AppliesTo = DateTime.UtcNow.AddMonths(4 + i),
                             AllocationState = "ChangeByTaskOwner",
                             AllocationUpdated = DateTime.UtcNow,
                         }
-
                     }
             }
             );

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/Mock/NotificationReportApiResponseMock.cs
@@ -8,21 +8,6 @@ namespace Fusion.Resources.Functions.Tests.Notifications.Mock;
 
 public abstract class NotificationReportApiResponseMock
 {
-    public static List<ApiChangeLogEvent> GetMockedChangeLogEvents()
-    {
-        // Loop through the ChangeType enum and create a list of ApiChangeLogEvent objects
-        var events = new List<ApiChangeLogEvent>();
-        foreach (var changeType in Enum.GetValues<ChangeType>())
-        {
-            events.Add(new ApiChangeLogEvent
-            {
-                ChangeType = changeType.ToString(),
-                TimeStamp = DateTime.UtcNow
-            });
-        }
-
-        return events;
-    }
 
     public static List<IResourcesApiClient.InternalPersonnelPerson> GetMockedInternalPersonnel(
         double personnelCount,
@@ -67,10 +52,62 @@ public abstract class NotificationReportApiResponseMock
                             AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
                             AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
                             Workload = workload,
+                            AllocationState = null,
+                            AllocationUpdated = null,
                         }
                     }
             }
             );
+            ;
+        }
+
+        return personnel;
+    }
+
+    public static List<IResourcesApiClient.InternalPersonnelPerson> GetMockedInternalPersonnelWithAllocationUpdated(
+      double personnelCount
+      )
+    {
+        var personnel = new List<IResourcesApiClient.InternalPersonnelPerson>();
+        for (var i = 0; i < personnelCount; i++)
+        {
+            personnel.Add(new IResourcesApiClient.InternalPersonnelPerson()
+            {
+                PositionInstances = new List<IResourcesApiClient.PersonnelPosition>
+                    {
+                        new()
+                        {
+                            AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
+                            AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
+                            AllocationState = null,
+                            AllocationUpdated = null,
+                        },
+                        new()
+                        {
+                            AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
+                            AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
+                            AllocationState = "ChangeByTaskOwner",
+                            AllocationUpdated = DateTime.UtcNow,
+                        },
+                        new()                           
+                        {
+                            AppliesFrom = DateTime.UtcNow.AddDays(-1 - i),
+                            AppliesTo = DateTime.UtcNow.AddDays(1 + i * 10),
+                            AllocationState = "ChangeByTaskOwner",
+                            AllocationUpdated = DateTime.UtcNow.AddDays(-10),
+                        },
+                        new()                           
+                        {
+                            AppliesFrom = DateTime.UtcNow.AddDays(91),
+                            AppliesTo = DateTime.UtcNow.AddDays(60 + i * 10),
+                            AllocationState = "ChangeByTaskOwner",
+                            AllocationUpdated = DateTime.UtcNow,
+                        }
+
+                    }
+            }
+            );
+            ;
         }
 
         return personnel;

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
@@ -12,11 +12,12 @@ namespace Fusion.Resources.Functions.Tests.Notifications;
 public class ScheduledReportNotificationBuilderTests
 {
     [Fact]
-    public void GetProjectChanges_ShouldReturnCountOfRelevantEventsForNextThreeMonths() // Need renaming
+    public void GetChangesForDepartment_Should_ResultInNumberOfChanges()
     {
         // Arrange
         const int personnelCount = 4;
-        var personnel = NotificationReportApiResponseMock.GetMockedInternalPersonnelWithAllocationUpdated(
+        // Returns 4 different instances pr personnel
+        var personnel = NotificationReportApiResponseMock.GetMockedInternalPersonnelWithInstancesWithAndWithoutChanges(
             personnelCount);
 
         // Act

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
@@ -12,16 +12,18 @@ namespace Fusion.Resources.Functions.Tests.Notifications;
 public class ScheduledReportNotificationBuilderTests
 {
     [Fact]
-    public void GetProjectChanges_ShouldReturnCountOfRelevantEventsForNextThreeMonths()
+    public void GetProjectChanges_ShouldReturnCountOfRelevantEventsForNextThreeMonths() // Need renaming
     {
         // Arrange
-        var events = NotificationReportApiResponseMock.GetMockedChangeLogEvents();
+        const int personnelCount = 4;
+        var personnel = NotificationReportApiResponseMock.GetMockedInternalPersonnelWithAllocationUpdated(
+            personnelCount);
 
         // Act
-        var changes = ResourceOwnerReportDataCreator.GetProjectChangesAffectingNextThreeMonths(events);
+        var changes = ResourceOwnerReportDataCreator.CalculateDepartmentChangesLastWeek(personnel);
 
         // Assert
-        changes.Should().Be(4);
+        changes.Should().Be(8);
     }
 
     [Fact]


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Because of the big load time when getting from /change-log from Org-API we now use the fields AllocationState and AllocationUpdated to calculate which instanses that have been updated the last week. We also only include active instances 

[AB#51384](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/51384)

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing
We need to execute the function "scheduled-report-timer-trigger-function" and then we need to verify that the field "Project changes last week affecting next 3 months" is correct. This is done by checking a the notifications for departments and verify that the number of changes matches the field "Project changes last week affecting next 3 months"

We also need to check the execution time

**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

