### PR TITLE
fix (resource): Adjust AverageTimeToHandleRequests field on summary notification 

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/ApiClients/IResourcesApiClient.cs
+++ b/src/backend/function/Fusion.Resources.Functions/ApiClients/IResourcesApiClient.cs
@@ -97,6 +97,7 @@ namespace Fusion.Resources.Functions.ApiClients
         public class ProposedPerson
         {
             public InternalPersonnelPerson Person { get; set; } = null!;
+            public DateTimeOffset ProposedAt { get; set; }
         }
 
         public class Person

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ResourceOwnerReportDataCreator.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ResourceOwnerReportDataCreator.cs
@@ -99,26 +99,29 @@ public abstract class ResourceOwnerReportDataCreator
         IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests)
     {
         /*
-         * Average time to handle request: average number of days from request created/sent to candidate is proposed - last 3 months
+         * Average time to handle request: average number of days from request created/sent to candidate is proposed - last 12 months
          * Calculation:
-         * The number of days that it takes from when a requests is created (which is when the request is sent from Task Owner to ResourceOwner) 
-         * to the requests is handeled by ResourceOwner (proposed person)
+         * We find all the requests for the last 12 months that are not of type "ResourceOwnerChange" (for the specific Department)
+         * For each of these request we find the number of days that it takes from when a requests is created (which is when the request is sent from Task Owner to ResourceOwner) 
+         * to the requests is handeled by ResourceOwner (a person is proposed). If the request is still being processed it will not have a date for when
+         * it is handled (proposed date), and then we will use todays date.
+         * We then sum up the total amount of days used to handle a request and divide by the total number of requests for which we have found the handle-time
          */
 
         var requestsHandledByResourceOwner = 0;
         var totalNumberOfDays = 0.0;
-        var threeMonthsAgo = DateTime.UtcNow.AddMonths(-3);
+        var twelveMonths = DateTime.UtcNow.AddMonths(-12);
 
 
         // Not to include requests that are sent by ResourceOwners (ResourceOwnerChange) or requests created more than 3 months ago
-        var requestsLastThreeMonthsWithoutResourceOwnerChangeRequest = requests
-            .Where(req => req.Created > threeMonthsAgo)
+        var requestsLastTwelveMonthsWithoutResourceOwnerChangeRequest = requests
+            .Where(req => req.Created > twelveMonths)
             .Where(r => r.Workflow is not null)
             .Where(_ => true)
             .Where(req => req.Type != null && !req.Type.Equals(RequestType.ResourceOwnerChange.ToString(),
                 StringComparison.OrdinalIgnoreCase));
 
-        foreach (var request in requestsLastThreeMonthsWithoutResourceOwnerChangeRequest)
+        foreach (var request in requestsLastTwelveMonthsWithoutResourceOwnerChangeRequest)
         {
             // If the requests doesnt have state it means that it is in draft. Do not need to check these
             if (request.State == null)
@@ -127,18 +130,18 @@ public abstract class ResourceOwnerReportDataCreator
                 continue;
 
             // First: find the date for creation (this implies that the request has been sent to resourceowner)
-            var dateForCreation = request.Workflow.Steps
-                .FirstOrDefault(step => step.Name.Equals("Created") && step.IsCompleted)?.Completed.Value.DateTime;
+            var dateForCreation = request.Created.Date;
 
-            // Second: Find the date for proposed (this implies that resourceowner have handled the request)
-            var dateForApproval = request.Workflow.Steps
-                .FirstOrDefault(step => step.Name.Equals("Proposed") && step.IsCompleted)?.Completed.Value.DateTime;
-            if (dateForCreation == null || dateForApproval == null)
-                continue;
+            //Second: Try to find the date for proposed (this implies that resourceowner have handled the request)
+            // if there are no proposal date we will used todays date for calculation 
+            var dateOfApprovalOrToday = request.ProposedPerson?.ProposedAt.Date ?? DateTime.Now;
+
+            // Only for testing:
+            //dateOfApprovalOrToday = dateOfApprovalOrToday.Value.AddDays(100);
 
             requestsHandledByResourceOwner++;
-            var timespanDifference = dateForApproval - dateForCreation;
-            var differenceInDays = timespanDifference.Value.TotalDays;
+            var timespanDifference = dateOfApprovalOrToday - dateForCreation;
+            var differenceInDays = timespanDifference.TotalDays;
             totalNumberOfDays += differenceInDays;
         }
 

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
@@ -216,7 +216,7 @@ public class ScheduledReportContentBuilderFunction
                 averageTimeToHandleRequests > 0
                     ? averageTimeToHandleRequests + " day(s)"
                     : "Less than a day",
-                "Average time to handle request (last 12 months"))
+                "Average time to handle request (last 12 months)"))
             .AddColumnSet(new AdaptiveCardColumn(
                 ResourceOwnerReportDataCreator.GetAllocationChangesAwaitingTaskOwnerAction(requests).ToString(),
                 "Allocation changes awaiting task owner action"))

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
@@ -216,7 +216,7 @@ public class ScheduledReportContentBuilderFunction
                 averageTimeToHandleRequests > 0
                     ? averageTimeToHandleRequests + " day(s)"
                     : "Less than a day",
-                "Average time to handle request"))
+                "Average time to handle request (last 12 months"))
             .AddColumnSet(new AdaptiveCardColumn(
                 ResourceOwnerReportDataCreator.GetAllocationChangesAwaitingTaskOwnerAction(requests).ToString(),
                 "Allocation changes awaiting task owner action"))


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
The field "Average time to handle request" on the Summary Notification did not give a correct number. The reason was that we checked for that the requests was in state == completed, meaning that we did not include requests that where finished from all parts (resourceowners and taskowners). We want to include requests that have been handled by ResourceOwner, but also those that are still open. 
We have also adjusted so that we include requests for the last 12 months (instead of 3 months).
If we don't find the date for proposal we will use todays date for when calculating the amount of time used to handle a request 

[AB#52911](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/52911)

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Can be tested with running Summary Notifications and check that the value on "Average time to handle request" is correct. May need to manually calculate this value for verify this. See the work item for description on how to test this.

**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] ~~Considered work items~~ 
- [ ] ~~Considered security~~
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

