### PR TITLE
feat: Support SAP id in api routes

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Departments/DepartmentsController.cs
@@ -41,30 +41,32 @@ namespace Fusion.Resources.Api.Controllers
         }
 
         [HttpGet("/departments/{departmentString}")]
-        public async Task<ActionResult<ApiDepartment>> GetDepartments(string departmentString)
+        public async Task<ActionResult<ApiDepartment>> GetDepartments([FromRoute] OrgUnitIdentifier departmentString)
         {
-            var department = await DispatchAsync(new GetDepartment(departmentString).ExpandDelegatedResourceOwners());
-            if (department is null) return NotFound();
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
-            return Ok(new ApiDepartment(department));
+            var department = await DispatchAsync(new GetDepartment(departmentString.SapId).ExpandDelegatedResourceOwners());
+
+            return Ok(new ApiDepartment(department!));
         }
 
         [HttpGet("/departments/{departmentString}/related")]
-        public async Task<ActionResult<ApiRelatedDepartments>> GetRelevantDepartments(string departmentString)
+        public async Task<ActionResult<ApiRelatedDepartments>> GetRelevantDepartments([FromRoute] OrgUnitIdentifier departmentString)
         {
-            var departments = await DispatchAsync(new GetRelatedDepartments(departmentString));
-            if (departments is null) return NotFound();
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
-            return Ok(new ApiRelatedDepartments(departments));
+            var departments = await DispatchAsync(new GetRelatedDepartments(departmentString.SapId));
+
+            return Ok(new ApiRelatedDepartments(departments!));
         }
 
         [HttpOptions("/departments/{departmentString}/delegated-resource-owners")]
-        public async Task<ActionResult> GetDelegatedResourceOwnersOptions(string departmentString)
+        public async Task<ActionResult> GetDelegatedResourceOwnersOptions([FromRoute] OrgUnitIdentifier departmentString)
         {
-            var request = await DispatchAsync(new GetDepartment(departmentString));
-
-            if (request == null)
-                return FusionApiError.NotFound(departmentString, "Department not found");
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
             #region Authorization
 
@@ -73,12 +75,12 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.CanDelegateAccessToDepartment(new DepartmentPath(request.FullDepartment));
+                    or.CanDelegateAccessToDepartment(new DepartmentPath(departmentString.FullDepartment));
 
                 });
                 r.LimitedAccessWhen(or =>
                 {
-                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(request.FullDepartment), AccessRoles.ResourceOwner);
+                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString.FullDepartment), AccessRoles.ResourceOwner);
                     or.BeEmployee();
                     or.BeConsultant();
                 });
@@ -102,12 +104,10 @@ namespace Fusion.Resources.Api.Controllers
             return NoContent();
         }
         [HttpGet("/departments/{departmentString}/delegated-resource-owners")]
-        public async Task<ActionResult<IEnumerable<ApiDepartmentResponsible>>> GetDelegatedDepartmentResponsiblesForDepartment(string departmentString, bool shouldIgnoreDateFilter)
+        public async Task<ActionResult<IEnumerable<ApiDepartmentResponsible>>> GetDelegatedDepartmentResponsiblesForDepartment([FromRoute] OrgUnitIdentifier departmentString, bool shouldIgnoreDateFilter)
         {
-            var request = await DispatchAsync(new GetDepartment(departmentString));
-
-            if (request == null)
-                return FusionApiError.NotFound(departmentString, "Department not found");
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
             #region Authorization
 
@@ -116,8 +116,8 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.CanDelegateAccessToDepartment(new DepartmentPath(request.FullDepartment));
-                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(request.FullDepartment), AccessRoles.ResourceOwner);
+                    or.CanDelegateAccessToDepartment(new DepartmentPath(departmentString.FullDepartment));
+                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString.FullDepartment), AccessRoles.ResourceOwner);
                 });
                 r.LimitedAccessWhen(or =>
                 {
@@ -143,12 +143,10 @@ namespace Fusion.Resources.Api.Controllers
 
         [HttpPost("/departments/{departmentString}/delegated-resource-owner")]
         [HttpPost("/departments/{departmentString}/delegated-resource-owners")]
-        public async Task<ActionResult<ApiDepartmentResponsible>> AddDelegatedResourceOwner(string departmentString, [FromBody] AddDelegatedResourceOwnerRequest request)
+        public async Task<ActionResult<ApiDepartmentResponsible>> AddDelegatedResourceOwner([FromRoute] OrgUnitIdentifier departmentString, [FromBody] AddDelegatedResourceOwnerRequest request)
         {
-            var department = await DispatchAsync(new GetDepartment(departmentString));
-
-            if (department == null)
-                return FusionApiError.NotFound(departmentString, "Department not found");
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
             #region Authorization
 
@@ -157,7 +155,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.CanDelegateAccessToDepartment(new DepartmentPath(department.FullDepartment));
+                    or.CanDelegateAccessToDepartment(new DepartmentPath(departmentString.FullDepartment));
                 });
 
             });
@@ -166,9 +164,6 @@ namespace Fusion.Resources.Api.Controllers
                 return authResult.CreateForbiddenResponse();
 
             #endregion Authorization
-
-            var existingDepartment = await DispatchAsync(new GetDepartment(departmentString));
-            if (existingDepartment is null) return NotFound();
 
             try
             {
@@ -187,8 +182,8 @@ namespace Fusion.Resources.Api.Controllers
                 return FusionApiError.ResourceExists($"{request.ResponsibleAzureUniqueId}",
                     $"Person already delegated as resource owner for department '{departmentString}", ex);
             }
-            var departmentResourceOwners =
-                await DispatchAsync(new GetDelegatedDepartmentResponsibles(departmentString).IgnoreDateFilter());
+            var departmentResourceOwners = await DispatchAsync(new GetDelegatedDepartmentResponsibles(departmentString).IgnoreDateFilter());
+
             var itemCreated = departmentResourceOwners.Select(x => new ApiDepartmentResponsible(x)).First(x =>
                 x.DelegatedResponsible!.AzureUniquePersonId == request.ResponsibleAzureUniqueId);
 
@@ -198,12 +193,10 @@ namespace Fusion.Resources.Api.Controllers
 
         [HttpDelete("/departments/{departmentString}/delegated-resource-owner/{azureUniqueId}")]
         [HttpDelete("/departments/{departmentString}/delegated-resource-owners/{azureUniqueId}")]
-        public async Task<IActionResult> DeleteDelegatedResourceOwner(string departmentString, Guid azureUniqueId)
+        public async Task<IActionResult> DeleteDelegatedResourceOwner([FromRoute] OrgUnitIdentifier departmentString, Guid azureUniqueId)
         {
-            var department = await DispatchAsync(new GetDepartment(departmentString));
-
-            if (department == null)
-                return FusionApiError.NotFound(departmentString, "Department not found");
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department not found");
 
             #region Authorization
 
@@ -212,7 +205,7 @@ namespace Fusion.Resources.Api.Controllers
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
                 r.AnyOf(or =>
                 {
-                    or.CanDelegateAccessToDepartment(new DepartmentPath(department.FullDepartment));
+                    or.CanDelegateAccessToDepartment(new DepartmentPath(departmentString.FullDepartment));
                 });
             });
 
@@ -221,9 +214,9 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion Authorization
 
-            var deleted = await DispatchAsync(new DeleteDelegatedResourceOwner(departmentString, azureUniqueId));
-
-            return deleted ? NoContent() : NotFound();
+            var deleted = await DispatchAsync(new DeleteDelegatedResourceOwner(departmentString.SapId, azureUniqueId));
+            
+            return NoContent();
         }
 
         [HttpGet("/projects/{projectId}/positions/{positionId}/instances/{instanceId}/relevant-departments")]

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Identifiers/OrgUnitIdentifier.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Identifiers/OrgUnitIdentifier.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    [ModelBinder(BinderType = typeof(OrgUnitResolver))]
+    public class OrgUnitIdentifier
+    {
+        public OrgUnitIdentifier(string originalIdentifier, string sapId, string fullDepartment, string name)
+        {
+            OriginalIdentifier = originalIdentifier;
+            SapId = sapId;
+            FullDepartment = fullDepartment;
+            Name = name;
+
+            Exists = true;
+        }
+
+        private OrgUnitIdentifier(string originalIdentifier)
+        {
+            Exists = false;
+
+            OriginalIdentifier = originalIdentifier;
+            SapId = originalIdentifier;
+            FullDepartment = originalIdentifier;
+            Name = string.Empty;
+        }
+
+        [JsonIgnore]
+        public string OriginalIdentifier { get; set; }
+        [JsonIgnore]
+        public string SapId { get; set; }
+        [JsonIgnore]
+        public string FullDepartment { get; set; }
+        [JsonIgnore]
+        public string Name { get; set; }
+
+        [JsonIgnore]
+        public bool Exists { get; set; }
+
+        public static OrgUnitIdentifier NotFound(string identifier) => new OrgUnitIdentifier(identifier);
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Identifiers/OrgUnitIdentifier.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Identifiers/OrgUnitIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Fusion.Resources.Domain;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Fusion.Resources.Api.Controllers
@@ -38,6 +39,13 @@ namespace Fusion.Resources.Api.Controllers
         [JsonIgnore]
         public bool Exists { get; set; }
 
+        public override string ToString()
+        {
+            return Exists ? OriginalIdentifier : $"{OriginalIdentifier}:{Exists}";
+        }
+
         public static OrgUnitIdentifier NotFound(string identifier) => new OrgUnitIdentifier(identifier);
+
+        public static implicit operator LineOrgId(OrgUnitIdentifier identifier) => new LineOrgId() { SapId = identifier.SapId, FullDepartment = identifier.FullDepartment };
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -30,7 +30,7 @@ namespace Fusion.Resources.Api.Controllers
         /// 
         /// Version 2 only changes the data set returned, by utilizing a different query for employees.
         /// </summary>
-        /// <param name="fullDepartmentString">The department to retrieve personnel list from.</param>
+        /// <param name="departmentString">The department to retrieve personnel list from. Either SAP id or full department path. Prefer SAP id</param>
         /// <param name="timelineStart">Start date of timeline</param>
         /// <param name="timelineDuration">Optional: duration of timeline i.e. P1M for 1 month</param>
         /// <param name="timelineEnd">Optional: specific end date of timeline</param>
@@ -41,8 +41,8 @@ namespace Fusion.Resources.Api.Controllers
         /// <returns></returns>
         [MapToApiVersion("1.0")]
         [MapToApiVersion("2.0")]
-        [HttpGet("departments/{fullDepartmentString}/resources/personnel")]
-        public async Task<ActionResult<ApiCollection<ApiInternalPersonnelPerson>>> GetDepartmentPersonnel(string fullDepartmentString,
+        [HttpGet("departments/{departmentString}/resources/personnel")]
+        public async Task<ActionResult<ApiCollection<ApiInternalPersonnelPerson>>> GetDepartmentPersonnel([FromRoute] OrgUnitIdentifier departmentString,
             [FromQuery] ODataQueryParams query,
             [FromQuery] DateTime? timelineStart = null,
             [FromQuery] string? timelineDuration = null,
@@ -51,9 +51,13 @@ namespace Fusion.Resources.Api.Controllers
             [FromQuery] bool includeCurrentAllocations = false,
             int? version = 2)
         {
+
+            if (!departmentString.Exists)
+                return FusionApiError.NotFound(departmentString.OriginalIdentifier, "Department does not exist");
+
             #region Authorization
 
-            var sector = new DepartmentPath(fullDepartmentString).Parent();
+            var sector = new DepartmentPath(departmentString.FullDepartment).Parent();
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AnyOf(or =>
@@ -63,12 +67,12 @@ namespace Fusion.Resources.Api.Controllers
 
                     or.FullControlInternal();
                     or.BeResourceOwner(sector, includeParents: false, includeDescendants: true);
-                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(fullDepartmentString), AccessRoles.ResourceOwner);
+                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString.FullDepartment), AccessRoles.ResourceOwner);
                     // - Fusion.Resources.Department.ReadAll in any department scope upwards in line org.
                 });
                 r.LimitedAccessWhen(x =>
                 {
-                    x.BeResourceOwner(new DepartmentPath(fullDepartmentString).GoToLevel(2), includeParents: false, includeDescendants: true);
+                    x.BeResourceOwner(new DepartmentPath(departmentString.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -105,7 +109,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #endregion
 
-            var command = new GetDepartmentPersonnel(fullDepartmentString, query)
+            var command = new GetDepartmentPersonnel(departmentString.FullDepartment, query)
                 .IncludeSubdepartments(includeSubdepartments)
                 .IncludeCurrentAllocations(includeCurrentAllocations)
                 .WithTimeline(shouldExpandTimeline, timelineStart, timelineEnd);
@@ -193,11 +197,15 @@ namespace Fusion.Resources.Api.Controllers
             return new ApiCollection<ApiInternalPersonnelPerson>(returnModel);
         }
 
-        [HttpGet("departments/{fullDepartmentString}/resources/personnel/{personIdentifier}")]
-        public async Task<ActionResult<ApiInternalPersonnelPerson>> GetPersonnelAllocation(string fullDepartmentString, string personIdentifier, [FromQuery] bool includeCurrentAllocations = false)
+        [HttpGet("departments/{departmentString}/resources/personnel/{personIdentifier}")]
+        public async Task<ActionResult<ApiInternalPersonnelPerson>> GetPersonnelAllocation([FromRoute] OrgUnitIdentifier departmentString, string personIdentifier, [FromQuery] bool includeCurrentAllocations = false)
         {
+            // Should validate if department exists here as well, however cannot guarantee that this data is 100% consistent. Could cause 
+            // endpoints to fail with no workaround. Might consider refactoring to reference the person without a department as part of the 
+            // route, and calculate authorization based on the registered department on the user.
+
             #region Authorization
-            var sector = new DepartmentPath(fullDepartmentString).Parent();
+            var sector = new DepartmentPath(departmentString.FullDepartment).Parent();
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AnyOf(or =>
@@ -208,11 +216,11 @@ namespace Fusion.Resources.Api.Controllers
                     or.FullControlInternal();
 
                     or.BeResourceOwner(sector, includeParents: false, includeDescendants: true);
-                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(fullDepartmentString), AccessRoles.ResourceOwner);
+                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString.FullDepartment), AccessRoles.ResourceOwner);
                 });
                 r.LimitedAccessWhen(x =>
                 {
-                    x.BeResourceOwner(new DepartmentPath(fullDepartmentString).GoToLevel(2), includeParents: false, includeDescendants: true);
+                    x.BeResourceOwner(new DepartmentPath(departmentString.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
                 });
             });
 
@@ -227,7 +235,7 @@ namespace Fusion.Resources.Api.Controllers
             if (personnelItem is null)
                 throw new InvalidOperationException("Could locate profile for person");
 
-            if (personnelItem.FullDepartment != fullDepartmentString)
+            if (personnelItem.FullDepartment != departmentString.FullDepartment)
                 return ApiErrors.NotFound($"Person does not belong to department ({personnelItem.FullDepartment})");
 
             var result = authResult.LimitedAuth
@@ -236,9 +244,13 @@ namespace Fusion.Resources.Api.Controllers
 
             return Ok(result);
         }
-        [HttpPost("departments/{fullDepartmentString}/resources/personnel/{personIdentifier}/allocations/{instanceId}/allocation-state/reset")]
-        public async Task<ActionResult> ResetAllocationState(string fullDepartmentString, string personIdentifier, Guid instanceId)
+        [HttpPost("departments/{departmentString}/resources/personnel/{personIdentifier}/allocations/{instanceId}/allocation-state/reset")]
+        public async Task<ActionResult> ResetAllocationState([FromRoute] OrgUnitIdentifier departmentString, string personIdentifier, Guid instanceId)
         {
+            // Should add validation of department here as well, however we cannot guarantee that the user department is consistent with 
+            // what the frontend use as params, ref endpoint above. Should consider allowing this operation outside of the 
+            // department scope in the route. Rather use the users department as source for authorization.
+
             #region Authorization
 
             var authResult = await Request.RequireAuthorizationAsync(r =>
@@ -250,8 +262,8 @@ namespace Fusion.Resources.Api.Controllers
 
                     or.FullControlInternal();
 
-                    or.BeResourceOwner(new DepartmentPath(fullDepartmentString).GoToLevel(2), includeParents: false, includeDescendants: true);
-                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(fullDepartmentString), AccessRoles.ResourceOwner);
+                    or.BeResourceOwner(new DepartmentPath(departmentString.FullDepartment).GoToLevel(2), includeParents: false, includeDescendants: true);
+                    or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(departmentString.FullDepartment), AccessRoles.ResourceOwner);
                 });
             });
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/ConversationsController.cs
@@ -65,7 +65,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
         [HttpPost("/requests/internal/{requestId}/conversation")]
         [HttpPost("/departments/{departmentString}/resources/requests/{requestId}/conversation")]
-        public async Task<ActionResult> AddConversationMessage([FromRoute] Guid requestId, Guid? projectIdentifier, string? departmentString, [FromBody] AddRequestConversationMessageRequest request)
+        public async Task<ActionResult> AddConversationMessage([FromRoute] Guid requestId, Guid? projectIdentifier, [FromRoute] OrgUnitIdentifier? departmentString, [FromBody] AddRequestConversationMessageRequest request)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -139,7 +139,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
         [HttpGet("/requests/internal/{requestId}/conversation")]
         [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation")]
-        public async Task<ActionResult> GetRequestConversation(Guid requestId, string? departmentString)
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, [FromRoute] OrgUnitIdentifier? departmentString)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -205,7 +205,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
         [HttpGet("/requests/internal/{requestId}/conversation/{messageId}")]
         [HttpGet("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
-        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid messageId, string? departmentString)
+        public async Task<ActionResult> GetRequestConversation(Guid requestId, Guid messageId, [FromRoute] OrgUnitIdentifier? departmentString)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -243,8 +243,8 @@ namespace Fusion.Resources.Api.Controllers.Requests
             return Ok(new ApiRequestConversationMessage(conversation));
         }
         [HttpPut("/projects/{projectIdentifier}/requests/{requestId}/conversation/{messageId}")]
-        [HttpPut("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation/{messageId}")]
-        public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, Guid? projectIdentifier, string? departmentString, [FromBody] UpdateRequestConversationMessageRequest request)
+        [HttpPut("/projects/{projectIdentifier}/resources/requests/{requestId}/conversation/{messageId}")]  // This seems like a copy-paste mistake - but out of scope for this update.
+        public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, Guid? projectIdentifier, [FromBody] UpdateRequestConversationMessageRequest request)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");
@@ -283,7 +283,7 @@ namespace Fusion.Resources.Api.Controllers.Requests
 
         [HttpPut("/requests/internal/{requestId}/conversation/{messageId}")]
         [HttpPut("/departments/{departmentString}/resources/requests/{requestId}/conversation/{messageId}")]
-        public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, string? departmentString, [FromBody] UpdateRequestConversationMessageRequest request)
+        public async Task<ActionResult> UpdateRequestConversation(Guid requestId, Guid messageId, [FromRoute] OrgUnitIdentifier? departmentString, [FromBody] UpdateRequestConversationMessageRequest request)
         {
             var requestItem = await DispatchAsync(new GetResourceAllocationRequestItem(requestId));
             if (requestItem is null) return FusionApiError.NotFound(requestId, $"Request with id '{requestId}' was not found.");

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Fusion.Resources.Domain;
 using Microsoft.Extensions.Caching.Memory;
 using Fusion.Resources.Application.LineOrg;
+using Fusion.Resources.Api.Controllers;
 
 namespace Fusion.Resources.Api
 {
@@ -25,6 +26,9 @@ namespace Fusion.Resources.Api
         {
             await orgUnitCache.ClearOrgUnitCacheAsync();
             cache.Remove(LineOrgClient.OrgUnitsMemCacheKey);
+
+            // Just clearing all org unit cache if there are changes.
+            OrgUnitResolver.ClearCache();
         }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Resolvers/OrgUnitResolver.cs
+++ b/src/backend/api/Fusion.Resources.Api/Resolvers/OrgUnitResolver.cs
@@ -17,8 +17,7 @@ namespace Fusion.Resources.Api.Controllers
         {
             resolvedIdentifier.Clear();
         }
-
-
+        
         public static void ClearCache(string identifier)
         {
             var cachedItems = resolvedIdentifier

--- a/src/backend/api/Fusion.Resources.Api/Resolvers/OrgUnitResolver.cs
+++ b/src/backend/api/Fusion.Resources.Api/Resolvers/OrgUnitResolver.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Fusion.Resources.Domain;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fusion.Resources.Api.Controllers
+{
+    public class OrgUnitResolver : IModelBinder
+    {
+        private static ConcurrentDictionary<string, OrgUnitIdentifier> resolvedIdentifier = new ConcurrentDictionary<string, OrgUnitIdentifier>();
+
+        public static void ClearCache()
+        {
+            resolvedIdentifier.Clear();
+        }
+
+
+        public static void ClearCache(string identifier)
+        {
+            var cachedItems = resolvedIdentifier
+                .Where(kv => kv.Value.SapId.EqualsIgnCase(identifier) || kv.Value.FullDepartment.EqualsIgnCase(identifier))
+                .Select(kv => kv.Key)
+                .ToList();
+
+            cachedItems.ForEach(k => resolvedIdentifier.TryRemove(k, out _));
+        }
+
+        public async Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+
+            bindingContext.HttpContext.Request.EnableBuffering();
+
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.FieldName);
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                return;
+            }
+
+            var value = valueProviderResult.FirstValue;
+
+
+            // Resolve the project 
+
+            var identifier = await ResolveOrgUnitAsync(bindingContext, value);
+
+            // We want to return an identifier so action can handle not found.
+            bindingContext.Result = ModelBindingResult.Success(identifier);
+        }
+
+        private async Task<OrgUnitIdentifier> ResolveOrgUnitAsync(ModelBindingContext bindingContext, string? identifier)
+        {
+            // Check if the argument value is null or empty
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return OrgUnitIdentifier.NotFound(identifier ?? string.Empty);
+            }
+
+            var normalizedDomain = identifier.ToLower();
+
+            if (resolvedIdentifier.ContainsKey(normalizedDomain))
+            {
+                return resolvedIdentifier[identifier];
+            }
+
+            var mediator = bindingContext.HttpContext.RequestServices.GetRequiredService<IMediator>();
+
+            var result = await mediator.Send(new ResolveLineOrgUnit(identifier));
+
+            var resolvedOrgUnitIdentifier = result is null ? OrgUnitIdentifier.NotFound(identifier) 
+                : new OrgUnitIdentifier(identifier, result.SapId, result.FullDepartment, result.Name);
+
+            resolvedIdentifier[identifier] = resolvedOrgUnitIdentifier;
+
+            return resolvedOrgUnitIdentifier;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Resolvers/ProjectResolver.cs
+++ b/src/backend/api/Fusion.Resources.Api/Resolvers/ProjectResolver.cs
@@ -193,5 +193,4 @@ namespace Fusion.Resources.Api.Controllers
         }
     
     }
-
 }

--- a/src/backend/api/Fusion.Resources.Api/Swagger/StartupExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Swagger/StartupExtensions.cs
@@ -3,9 +3,6 @@ using Fusion.Resources.Api.Swagger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
-using System;
-using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -22,9 +19,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 .AddApiPreview()
                 .ForceStringConverter<PathProjectIdentifier>()
+                .ForceStringConverter<OrgUnitIdentifier>()
                 .ForceStringConverter<RequestIdentifier>()
                 .ConfigureSwaggerGen(s =>
                 {
+                    s.MapType<OrgUnitIdentifier>(() => new OpenApiSchema { Type = "string", Description = "Line org unit by sap id or full department string" });
                     s.MapType<PathProjectIdentifier>(() => new OpenApiSchema { Type = "string", Description = "Org project id or context id" });
                     s.MapType<RequestIdentifier>(() => new OpenApiSchema {  Type = "string", Description = "Request id or request number" });
 

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Departments/AddDelegatedResourceOwner.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Departments/AddDelegatedResourceOwner.cs
@@ -11,7 +11,7 @@ namespace Fusion.Resources.Domain.Commands.Departments
 {
     public class AddDelegatedResourceOwner : IRequest
     {
-        public AddDelegatedResourceOwner(string departmentId, Guid responsibleAzureUniqueId)
+        public AddDelegatedResourceOwner(LineOrgId departmentId, Guid responsibleAzureUniqueId)
         {
             DepartmentId = departmentId;
             ResponsibleAzureUniqueId = responsibleAzureUniqueId;
@@ -19,7 +19,7 @@ namespace Fusion.Resources.Domain.Commands.Departments
 
         public DateTimeOffset DateFrom { get; set; }
         public DateTimeOffset DateTo { get; set; }
-        public string DepartmentId { get; }
+        public LineOrgId DepartmentId { get; }
         public Guid ResponsibleAzureUniqueId { get; }
         public Guid? UpdatedByAzureUniqueId { get; set; }
 
@@ -46,7 +46,7 @@ namespace Fusion.Resources.Domain.Commands.Departments
             {
                 var alreadyDelegated = db.DelegatedDepartmentResponsibles.Any(x =>
                     x.ResponsibleAzureObjectId == request.ResponsibleAzureUniqueId &&
-                    x.DepartmentId == request.DepartmentId);
+                    x.DepartmentId == request.DepartmentId.FullDepartment);
 
                 if (alreadyDelegated)
                     throw new RoleDelegationExistsError();
@@ -55,7 +55,7 @@ namespace Fusion.Resources.Domain.Commands.Departments
                 {
                     Identifier = Guid.NewGuid().ToString(),
                     RoleName = AccessRoles.ResourceOwner,
-                    Scope = new RoleAssignment.RoleScope("OrgUnit", request.DepartmentId),
+                    Scope = new RoleAssignment.RoleScope("OrgUnit", request.DepartmentId.FullDepartment),
                     Source = "Fusion.Resources.DelegatedResourceOwner",
                     ValidTo = request.DateTo
                 });
@@ -65,7 +65,7 @@ namespace Fusion.Resources.Domain.Commands.Departments
                     DateCreated = DateTime.UtcNow,
                     DateFrom = request.DateFrom,
                     DateTo = request.DateTo,
-                    DepartmentId = request.DepartmentId,
+                    DepartmentId = request.DepartmentId.FullDepartment,
                     ResponsibleAzureObjectId = request.ResponsibleAzureUniqueId,
                     Reason = request.Reason,
                     UpdatedBy = request.UpdatedByAzureUniqueId

--- a/src/backend/api/Fusion.Resources.Domain/Identifiers/LineOrgId.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Identifiers/LineOrgId.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain
+{
+    public struct LineOrgId
+    {
+        public string SapId { get; set; }
+        public string FullDepartment { get; set; }       
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetDelegatedDepartmentResponsibles.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetDelegatedDepartmentResponsibles.cs
@@ -15,12 +15,12 @@ namespace Fusion.Resources.Domain
     {
 
         private bool shouldIgnoreDateFilter;
-        public GetDelegatedDepartmentResponsibles(string departmentId)
+        public GetDelegatedDepartmentResponsibles(LineOrgId departmentId)
         {
             DepartmentId = departmentId;
         }
 
-        private string DepartmentId { get; set; }
+        private LineOrgId DepartmentId { get; set; }
 
         public GetDelegatedDepartmentResponsibles IgnoreDateFilter(bool ignore = true)
         {
@@ -32,23 +32,18 @@ namespace Fusion.Resources.Domain
         {
             private readonly ResourcesDbContext db;
             private readonly IFusionProfileResolver profileResolver;
-            private readonly IMediator mediator;
 
-            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver, IMediator mediator)
+            public Handler(ResourcesDbContext db, IFusionProfileResolver profileResolver)
             {
                 this.db = db;
                 this.profileResolver = profileResolver;
-                this.mediator = mediator;
             }
 
             public async Task<IEnumerable<QueryDepartmentResponsible>> Handle(GetDelegatedDepartmentResponsibles request, CancellationToken cancellationToken)
             {
                 var returnModel = new List<QueryDepartmentResponsible>();
-                var department = await mediator.Send(new GetDepartment(request.DepartmentId));
-                if (department is null)
-                    return returnModel;
 
-                var query =  db.DelegatedDepartmentResponsibles.AsNoTracking().Where(x => x.DepartmentId == request.DepartmentId);
+                var query = db.DelegatedDepartmentResponsibles.AsNoTracking().Where(x => x.DepartmentId == request.DepartmentId.FullDepartment);
                 if (!request.shouldIgnoreDateFilter)
                 {
                     query =  query.Where(r => r.DateFrom.Date <= DateTime.UtcNow.Date && r.DateTo.Date >= DateTime.UtcNow.Date);


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Support full department and sap id interchangable in api endpoint routes.

This will enable a switch to primarily use sap id in the frontend, instead of using full department string which is a less stable identifier.

- Updated applicable controllers, keeping exiting expectation of full department string in internal domain intact
- Added some 404 validations where "safe"
- Verified tests are working as expected 
- Added some tests to verify SAP id works in same way as full department string

**Note: PR is forked from #636, many of changes are originating from there.**

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

All existing endpoints which accepts full department should support sap id as well. Function should not be changed.

- Added some new tests to verify SAP id along side existing full department use
- Added new tests to verify not found on some endpoint

**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

[AB#53751](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/53751)

Discovered some inconsistency in endpoints related to comments and second opinion. It seems like the endpoints should have used /departments/:id as path, but instead used /projects/... Did not fix these as it was not in scope.
