### PR TITLE
feat: Update assigned department on request when org unit is renamed

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgEventBody.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgEventBody.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Fusion.Resources.Api
+{
+    public class LineOrgEventBody
+    {
+        /// <summary>
+        /// SAP id of org unit. Should not change. Primary identifier.
+        /// </summary>
+        public string SapId { get; set; } = null!;
+
+        /// <summary>
+        /// The full department string pre update. This might change in an re-organisation.
+        /// </summary>
+        public string FullDepartment { get; set; } = null!;
+
+        public string Type { get; set; }
+        public List<string> Changes { get; set; } = new List<string>();
+
+        public ChangeType GetChangeType() => Enum.TryParse<ChangeType>(Type, true, out var changeType) ? changeType : ChangeType.Unknown;
+
+        public enum ChangeType { Unknown, Updated, Created, Deleted }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgOrgUnitHandler.cs
@@ -5,11 +5,18 @@ using Fusion.Resources.Domain;
 using Microsoft.Extensions.Caching.Memory;
 using Fusion.Resources.Application.LineOrg;
 using Fusion.Resources.Api.Controllers;
+using Newtonsoft.Json;
 
 namespace Fusion.Resources.Api
 {
+
     /// <summary>
     /// Handler listening on Line-Org service changes to org-units.
+    /// 
+    /// Transient handler which should be executed in all instances of the api. 
+    /// Primarily used for invalidating and clearing cache. 
+    /// 
+    /// Operations that modify data should be run in the persistant handler.
     /// </summary>
     public class LineOrgOrgUnitHandler : ISubscriptionHandler
     {
@@ -27,8 +34,40 @@ namespace Fusion.Resources.Api
             await orgUnitCache.ClearOrgUnitCacheAsync();
             cache.Remove(LineOrgClient.OrgUnitsMemCacheKey);
 
-            // Just clearing all org unit cache if there are changes.
-            OrgUnitResolver.ClearCache();
+            // Process the even 
+            switch (ctx.Event.Type)
+            {
+                case var org when org == LineOrgEventTypes.OrgUnit.Name:
+                    await HandleOrgUnitEventAsync(body);
+                    break;
+            }
         }
+
+        private Task HandleOrgUnitEventAsync(string? body)
+        {   
+            var payloadData = JsonConvert.DeserializeObject<LineOrgEventBody>(body ?? "");
+
+            if (payloadData is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (payloadData.GetChangeType() == LineOrgEventBody.ChangeType.Updated)
+            {
+                OrgUnitResolver.ClearCache(payloadData.SapId);
+                OrgUnitResolver.ClearCache(payloadData.FullDepartment);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /* Example payload
+        * {
+        *  "SapId":"53079987",                      // Sap id, should not change
+        *  "FullDepartment":"EPI DEV CADS BRA",     // The fullDepartment, pre update
+        *  "Type":"Updated",
+        *  "Changes":["Name","ShortName","Department","FullDepartment","ParentSapId","Parents"]
+        * }
+        */
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
@@ -1,0 +1,81 @@
+﻿using Fusion.Events;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Resources.Domain;
+using Newtonsoft.Json;
+using MediatR;
+using System;
+using System.Linq;
+
+namespace Fusion.Resources.Api
+{
+    /// <summary>
+    /// Handler to execute syncronisation events from the line org service. 
+    /// We only want updates to be executed by a single instance in case of multiple instances running the api. 
+    /// 
+    /// The handler should accept events, collect relevant data, determine if event is relevant and dispatch events the domain should handle to perform updates.
+    /// 
+    /// Should consider what the handler actually does (running in context of the event execution) or if some work could be dispatched to an async handler (e.g. service bus). 
+    /// If the handler throws an unhandled exception, the whole processing will be terminated and re-executed as the message is retried. If it consistently fail it will fall to a dead letter queue.
+    /// 
+    /// </summary>
+    public class LineOrgSyncronizationHandler : ISubscriptionHandler
+    {
+        private readonly IMediator mediator;
+
+        public LineOrgSyncronizationHandler(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+
+        public async Task ProcessMessageAsync(MessageContext ctx, string? body, CancellationToken cancellationToken)
+        {
+
+            // Process the even 
+            switch (ctx.Event.Type)
+            {
+                case var org when org == LineOrgEventTypes.OrgUnit.Name:
+                    await HandleOrgUnitEventAsync(body);
+                    break;
+            }
+        }
+
+        private async Task HandleOrgUnitEventAsync(string? body)
+        {
+            var payloadData = JsonConvert.DeserializeObject<LineOrgEventBody>(body ?? "");
+
+            if (payloadData is null)
+            {
+                return;
+            }
+
+            if (payloadData.GetChangeType() == LineOrgEventBody.ChangeType.Updated)
+            {
+                if (payloadData.Changes?.Any(i => i.EqualsIgnCase("fullDepartment")) == true) 
+                {
+                    await HandleOrgUnitUpdatedAsync(payloadData);
+                }
+            }
+        }
+
+        private async Task HandleOrgUnitUpdatedAsync(LineOrgEventBody payloadData)
+        {            
+            // Need to disable cache 
+            using var disableCacheScope = new Fusion.Integration.DisableCacheScope();   // Need to verify this works..
+
+            var orgUnit = await mediator.Send(new ResolveLineOrgUnit(payloadData.SapId));
+
+            if (orgUnit is null) 
+            {
+                throw new InvalidOperationException("Updated org unit could no longer be resolved. Was it deleted as well?");
+            }
+
+            if (orgUnit.FullDepartment.EqualsIgnCase(payloadData.FullDepartment))
+            {
+                throw new InvalidOperationException("Resolved fullDepartment is same as existing. Caching issue? Terminating operation and hoping retry will solve issue.");
+            }
+
+            await mediator.Publish(new Domain.Notifications.System.OrgUnitPathUpdated(payloadData.SapId, payloadData.FullDepartment, orgUnit.FullDepartment));
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -93,10 +93,20 @@ namespace Fusion.Resources.Api
                     e.OnlyTriggerOn(OrgEventTypes.Project);
                 });
 
+
+                /*
+                 * Add event handlers to line org. 
+                 * We need one persistant that can track changes and do internal updates. These we only want executed once across multiple instances. 
+                 * The transient handler will provide cache control on events, this will be executed across all instances as it updates in-memory objects.
+                 */
+                var LineOrgUnitEventType = new FusionEventType("lineorg.org-unit");
+                s.AddPersistentHandler<LineOrgSyncronizationHandler>(LineOrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
+                {
+                    e.OnlyTriggerOn(LineOrgUnitEventType);
+                });
                 s.AddTransientHandler<LineOrgOrgUnitHandler>(LineOrgConstants.HttpClients.Application, "/subscriptions/lineorg", e =>
                 {
-                   var LineOrgUnit = new FusionEventType("lineorg.org-unit" );
-                    e.OnlyTriggerOn(LineOrgUnit);
+                    e.OnlyTriggerOn(LineOrgUnitEventType);
                 });
             });
             // Add custom claims provider, to sort delegated responsibilities

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
@@ -1,0 +1,55 @@
+﻿using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+
+namespace Fusion.Resources.Domain.Notifications.System
+{
+    public class OrgUnitPathUpdated : INotification
+    {
+        public OrgUnitPathUpdated(string sapId, string fullDepartment, string newFullDepartment)
+        {
+            SapId = sapId;
+            FullDepartment = fullDepartment;
+            NewFullDepartment = newFullDepartment;
+        }
+
+        public string SapId { get; }
+        public string FullDepartment { get; }
+        public string NewFullDepartment { get; }
+
+
+        public class RequestAssignedDepartmentHandler : NotificationHandler<OrgUnitPathUpdated>
+        {
+            private readonly ILogger<RequestAssignedDepartmentHandler> logger;
+            private readonly ResourcesDbContext db;
+
+            public RequestAssignedDepartmentHandler(ILogger<RequestAssignedDepartmentHandler> logger, ResourcesDbContext db)
+            {
+                this.logger = logger;
+                this.db = db;
+            }
+
+            protected override async void Handle(OrgUnitPathUpdated notification)
+            {
+
+                var affectedReqeusts = await db.ResourceAllocationRequests.Where(r => r.AssignedDepartmentId == notification.SapId || (r.AssignedDepartmentId == null && r.AssignedDepartment == notification.FullDepartment))                    
+                    .ToListAsync();
+
+                // TODO: Could perhaps generate a summary notification here, informing requests are assigned.
+                
+                // As this is only a lookup id, we can just update the properties behind the scene instead of doing it through a request.
+                foreach (var affected in affectedReqeusts)
+                {
+                    logger.LogInformation("Updating assigned department for request {RequestNumber} to {SapId} [{FullDepartment}]", affected.RequestNumber, notification.SapId, notification.NewFullDepartment);
+
+                    affected.AssignedDepartment = notification.NewFullDepartment;
+                    affected.AssignedDepartmentId = notification.SapId;
+                }
+
+                await db.SaveChangesAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
When org units are renamed or moved we still persist the old full department string. This can leave requests connected to org units that no longer exists -> orphan requests.

We can subscribe for events comming from line org to act when these changes are done. This should be done as a persistant event handler so we are guaranteed delivery in case of downtime etc.

- Added persistant event handler to perform sync on assigned department for requests

The transient handler are used to invalidate cache, as this is executed on all instances of the api.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

Can be verified by assigning a ticket to some department (use one not commonly used, so we dont cause much problems).
PATCH the org unit in lineorg, chaning the full department (add a character etc).
Verify requests are assigned to that department
PATCH the org unit back to the original value (clean up)
Can verify requests are assigned back


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

[AB#53786](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/53786)
Limited changes to only requests. There are other entities which stores full department reference. These should be changed in own prs.
