### PR TITLE
feat: Clean up requests when org unit is deleted

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
@@ -49,12 +49,19 @@ namespace Fusion.Resources.Api
                 return;
             }
 
-            if (payloadData.GetChangeType() == LineOrgEventBody.ChangeType.Updated)
+            switch (payloadData.GetChangeType())
             {
-                if (payloadData.Changes?.Any(i => i.EqualsIgnCase("fullDepartment")) == true) 
-                {
-                    await HandleOrgUnitUpdatedAsync(payloadData);
-                }
+                case LineOrgEventBody.ChangeType.Updated:
+                    if (payloadData.Changes?.Any(i => i.EqualsIgnCase("fullDepartment")) == true) 
+                    {
+                        await HandleOrgUnitUpdatedAsync(payloadData);
+                    }
+                    break;
+
+                case LineOrgEventBody.ChangeType.Deleted:
+                    await HandleOrgUnitDeletedAsync(payloadData);
+                    break;
+
             }
         }
 
@@ -76,6 +83,12 @@ namespace Fusion.Resources.Api
             }
 
             await mediator.Publish(new Domain.Notifications.System.OrgUnitPathUpdated(payloadData.SapId, payloadData.FullDepartment, orgUnit.FullDepartment));
+        }
+
+        private async Task HandleOrgUnitDeletedAsync(LineOrgEventBody payloadData)
+        {
+            // Need to disable cache 
+            await mediator.Publish(new Domain.Notifications.System.OrgUnitDeleted(payloadData.SapId, payloadData.FullDepartment));
         }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/LineOrgSyncronizationHandler.cs
@@ -67,8 +67,8 @@ namespace Fusion.Resources.Api
 
         private async Task HandleOrgUnitUpdatedAsync(LineOrgEventBody payloadData)
         {            
-            // Need to disable cache 
-            using var disableCacheScope = new Fusion.Integration.DisableCacheScope();   // Need to verify this works..
+            // Need to disable cache in the resolver so we get a fresh copy
+            using var disableCacheScope = new Fusion.Integration.DisableCacheScope();  
 
             var orgUnit = await mediator.Send(new ResolveLineOrgUnit(payloadData.SapId));
 

--- a/src/backend/api/Fusion.Resources.Domain/Behaviours/AuditableCommandBehaviour.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Behaviours/AuditableCommandBehaviour.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace Fusion.Resources.Domain.Behaviours
-{    
+{
 
     public class TrackableRequestBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
     {
@@ -41,11 +41,17 @@ namespace Fusion.Resources.Domain.Behaviours
 
                     trackableRequest.SetEditor(uniqueId, editor);
                 }
+                
+                if (SystemEditorScope.IsEnabled.Value == true)
+                {
+                    // Ensure system account in db. 
+                    var editor = await profileServices.EnsureSystemAccountAsync();
+
+                    trackableRequest.SetEditor(Guid.Empty, editor);
+                }
             }
 
             return await next();
         }
     }
-
-
 }

--- a/src/backend/api/Fusion.Resources.Domain/Behaviours/AuditableCommandBehaviour.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Behaviours/AuditableCommandBehaviour.cs
@@ -40,9 +40,8 @@ namespace Fusion.Resources.Domain.Behaviours
                         throw new InvalidOperationException("Could not determin editor");
 
                     trackableRequest.SetEditor(uniqueId, editor);
-                }
-                
-                if (SystemEditorScope.IsEnabled.Value == true)
+                } 
+                else if (SystemEditorScope.IsEnabled.Value == true)
                 {
                     // Ensure system account in db. 
                     var editor = await profileServices.EnsureSystemAccountAsync();

--- a/src/backend/api/Fusion.Resources.Domain/Behaviours/MediatorExtension.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Behaviours/MediatorExtension.cs
@@ -1,0 +1,13 @@
+﻿using Fusion.Resources.Domain.Behaviours;
+using MediatR;
+
+namespace Fusion.Resources
+{
+    public static class MediatorExtension
+    {
+        public static SystemEditorScope SystemAccountScope(this IMediator mediator)
+        {
+            return new SystemEditorScope();
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Behaviours/SystemEditorScope.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Behaviours/SystemEditorScope.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading;
+
+namespace Fusion.Resources.Domain.Behaviours
+{
+    /// <summary>
+    /// Scope that will replace the reliance on http context to determine the edit, set by the auditable command behaviour.
+    /// The scope should be used when the system initiate the change.
+    /// 
+    /// The system will act as Guid.Empty as azure id, for tracability.
+    /// </summary>
+    public class SystemEditorScope : IDisposable
+    {
+        public static AsyncLocal<bool> IsEnabled { get; set; } = new AsyncLocal<bool>();
+
+        public SystemEditorScope()
+        {
+            IsEnabled.Value = true;
+        }
+
+        public void Dispose()
+        {
+            IsEnabled.Value = false;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/UpdateInternalRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/UpdateInternalRequest.cs
@@ -39,6 +39,22 @@ namespace Fusion.Resources.Domain.Commands
 
         public MonitorableProperty<List<PersonId>> Candidates { get; set; } = new();
 
+
+        /// <summary>
+        /// Unassign the request. Set assigned department to null.
+        /// 
+        /// Factory to create unassign command more reable.
+        /// </summary>
+        /// <param name="requestId">The request to update</param>
+        /// <returns>Dispatchable command</returns>
+        public static UpdateInternalRequest UnassignRequest(Guid requestId)
+        {
+            var cmd = new UpdateInternalRequest(requestId);
+            cmd.AssignedDepartment = new MonitorableProperty<string?>(null);
+
+            return cmd;
+        }
+
         public class Handler : IRequestHandler<UpdateInternalRequest, QueryResourceAllocationRequest>
         {
             private readonly ResourcesDbContext db;

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.CleanupResponsebilityMatrixHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.CleanupResponsebilityMatrixHandler.cs
@@ -1,0 +1,42 @@
+﻿using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Notifications.System
+{
+    public partial class OrgUnitDeleted
+    {
+        /// <summary>
+        /// Remove all items in the responsebility matrix that route requests to the deleted department.
+        /// </summary>
+        public class CleanupResponsebilityMatrixHandler : INotificationHandler<OrgUnitDeleted>
+        {
+            private readonly ILogger<DeleteDraftChangeRequestsHandler> logger;
+            private readonly ResourcesDbContext db;
+
+            public CleanupResponsebilityMatrixHandler(ILogger<DeleteDraftChangeRequestsHandler> logger, ResourcesDbContext db)
+            {
+                this.logger = logger;
+                this.db = db;
+            }
+
+            public async Task Handle(OrgUnitDeleted notification, CancellationToken cancellationToken)
+            {
+                // No good query to get specific items, it is either all or nothing. Fetching directly from the db.
+                var relevantItems = await db.ResponsibilityMatrices.Where(i => i.Unit == notification.FullDepartment).ToListAsync();
+
+                if (relevantItems.Any())
+                {
+                    logger.LogInformation($"Deleting {relevantItems.Count} responsebility matrix items for {notification.FullDepartment}");
+
+                    db.ResponsibilityMatrices.RemoveRange(relevantItems);
+                    await db.SaveChangesAsync();
+                }
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.DeleteDraftChangeRequestsHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.DeleteDraftChangeRequestsHandler.cs
@@ -1,0 +1,57 @@
+﻿using Fusion.AspNetCore.OData;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Notifications.System
+{
+    public partial class OrgUnitDeleted
+    {
+        /// <summary>
+        /// If an org unit has created draft org units, we should remove these as they will never be started when the org unit has been deleted.
+        /// For those that has actually be sent, we should not unassign as they can still be accepted by the task. 
+        /// </summary>
+        public class DeleteDraftChangeRequestsHandler : INotificationHandler<OrgUnitDeleted>
+        {
+            private readonly ILogger<DeleteDraftChangeRequestsHandler> logger;
+            private readonly IMediator mediator;
+
+            public DeleteDraftChangeRequestsHandler(ILogger<DeleteDraftChangeRequestsHandler> logger, IMediator mediator)
+            {
+                this.logger = logger;
+                this.mediator = mediator;
+            }
+            public async Task Handle(OrgUnitDeleted notification, CancellationToken cancellationToken)
+            {
+                // Fetch all requests that are assigned to the relevant department. 
+                // Only fetch active requests.
+                var query = new AspNetCore.OData.ODataQueryParams()
+                {
+                    Filter = ODataParser.Parse("isDraft eq 'true'"),
+
+                    // Arbitrary number that should get most.. 
+                    Top = 1000
+                };
+
+                var requests = await mediator.Send(new Queries.GetResourceAllocationRequests(query)
+                    .ForResourceOwners()
+                    .WithAssignedDepartment(notification.FullDepartment)
+                    .WithExcludeCompleted());
+
+                using var systemAccountScope = mediator.SystemAccountScope();
+
+                foreach (var request in requests)
+                {
+                    if (request.IsDraft)
+                    {
+                        // Delete
+                        await mediator.Send(new Commands.DeleteInternalRequest(request.RequestId));
+                        logger.LogInformation("Deleted draft change request {RequestNumber} in '{AssignedDepartment}'", request.RequestNumber, request.AssignedDepartment);
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.UnassignAllocationRequestsHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.UnassignAllocationRequestsHandler.cs
@@ -1,0 +1,73 @@
+﻿using Fusion.AspNetCore.OData;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fusion.Resources.Domain.Notifications.System
+{
+    public partial class OrgUnitDeleted
+    {
+        /// <summary>
+        /// Handler to unassign allocation requests which has the deleted org unit as assigned department. 
+        /// These requests should be returned to the unassigned pool so they can be claimed by new resource owners.
+        /// </summary>
+        public class UnassignAllocationRequestsHandler : INotificationHandler<OrgUnitDeleted>
+        {
+            private readonly ILogger<UnassignAllocationRequestsHandler> logger;
+            private readonly IMediator mediator;
+
+            public UnassignAllocationRequestsHandler(ILogger<UnassignAllocationRequestsHandler> logger, IMediator mediator)
+            {
+                this.logger = logger;
+                this.mediator = mediator;
+            }
+
+            public async Task Handle(OrgUnitDeleted notification, CancellationToken cancellationToken)
+            {
+                // Fetch all requests that are assigned to the relevant department. 
+                // Only fetch active requests.
+
+                var query = new AspNetCore.OData.ODataQueryParams()
+                {
+                    Filter = ODataParser.Parse($"type eq '{InternalRequestType.Allocation}'"),
+
+                    // Arbitrary number that should get most.. 
+                    Top = 1000
+                };
+
+                var requests = await mediator.Send(new Queries.GetResourceAllocationRequests(query)
+                    .ForAll()
+                    .WithAssignedDepartment(notification.FullDepartment)
+                    .WithExcludeCompleted());
+
+                var exceptions = new List<Exception>();
+                var failedRequestNumbers = new List<long>();
+
+                // Need to set the editor scope as this is used to log editor in commands.
+                using var systemAccountScope = mediator.SystemAccountScope();
+
+                foreach (var request in requests)
+                {
+                    try
+                    {
+                        await mediator.Send(Commands.UpdateInternalRequest.UnassignRequest(request.RequestId));
+                        logger.LogInformation("Unassigned '{AssignedDepartment}' from request {RequestNumber}", request.AssignedDepartment, request.RequestNumber);
+                    }
+                    catch (Exception ex)
+                    {
+                        failedRequestNumbers.Add(request.RequestNumber);
+                        ex.Data.Add("requestNumber", $"{request.RequestNumber}");
+                        exceptions.Add(ex);
+                    }
+                }
+
+                if (exceptions.Any())
+                    throw new AggregateException($"Failed to unassign {exceptions.Count} requests [{string.Join(",", failedRequestNumbers.Select(n => n.ToString()))}]", exceptions);
+            }
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.cs
@@ -1,0 +1,20 @@
+﻿using Fusion.Resources.Domain.Behaviours;
+using MediatR;
+
+namespace Fusion.Resources.Domain.Notifications.System
+{
+    /// <summary>
+    /// Event that indicates that an org unit has been deleted in the master data (line org which is mirroring SAP).
+    /// </summary>
+    public partial class OrgUnitDeleted : INotification
+    {
+        public OrgUnitDeleted(string sapId, string fullDepartment)
+        {
+            SapId = sapId;
+            FullDepartment = fullDepartment;
+        }
+
+        public string SapId { get; private set; }
+        public string FullDepartment { get; private set; }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
@@ -36,11 +36,11 @@ namespace Fusion.Resources.Domain.Notifications.System
             public async Task Handle(OrgUnitPathUpdated notification, CancellationToken cancellationToken)
             {
 
-                var affectedReqeusts = await db.ResourceAllocationRequests.Where(r => r.AssignedDepartmentId == notification.SapId || (r.AssignedDepartmentId == null && r.AssignedDepartment == notification.FullDepartment))
+                var affectedReqeusts = await db.ResourceAllocationRequests.Where(r => r.AssignedDepartmentId == notification.SapId || (r.AssignedDepartmentId == null && r.AssignedDepartment == notification.FullDepartment))                    
                     .ToListAsync();
 
                 // TODO: Could perhaps generate a summary notification here, informing requests are assigned.
-
+                
                 // As this is only a lookup id, we can just update the properties behind the scene instead of doing it through a request.
                 foreach (var affected in affectedReqeusts)
                 {

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitPathUpdated.cs
@@ -36,11 +36,11 @@ namespace Fusion.Resources.Domain.Notifications.System
             public async Task Handle(OrgUnitPathUpdated notification, CancellationToken cancellationToken)
             {
 
-                var affectedReqeusts = await db.ResourceAllocationRequests.Where(r => r.AssignedDepartmentId == notification.SapId || (r.AssignedDepartmentId == null && r.AssignedDepartment == notification.FullDepartment))                    
+                var affectedReqeusts = await db.ResourceAllocationRequests.Where(r => r.AssignedDepartmentId == notification.SapId || (r.AssignedDepartmentId == null && r.AssignedDepartment == notification.FullDepartment))
                     .ToListAsync();
 
                 // TODO: Could perhaps generate a summary notification here, informing requests are assigned.
-                
+
                 // As this is only a lookup id, we can just update the properties behind the scene instead of doing it through a request.
                 foreach (var affected in affectedReqeusts)
                 {

--- a/src/backend/api/Fusion.Resources.Domain/Services/IProfileServices.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Services/IProfileServices.cs
@@ -33,5 +33,6 @@ namespace Fusion.Resources.Domain
         /// <param name="person"></param>
         /// <returns></returns>
         Task<FusionPersonProfile?> ResolveProfileAsync(PersonId person);
+        Task<DbPerson> EnsureSystemAccountAsync();
     }
 }


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
As we get more requests and the organisation is re-organising we gather more and more data which is connected to deleted references, e.g deleted org units.

We should try and delete data that will never be relevant (draft requests) and "release" requests that are connected to non-existing units. That way they are at least known to be unassigned.

Updated persistant event handler to publish an `OrgUnitDeleted` notification and two handlers which do solve seperate functionality. Wanted to divide this into smaller functions to increase readability.

Updated "editor" concept to support SystemAccount, when HttpContext is not present. Using Guid.Empty here so we can easily catch it and process it seperately as it will not resolve to an active profile.


**Testing:**
- [x] Can be tested
- [ ] ~~Automatic tests created / updated~~
- [x] Local tests are passing

To verify, one can create a new org unit in line org, with a new sap id. Create different requests to verify functionality. The allocation requests can be "reassigned" using the UI, while the change request must be created in a 
different org unit which has employee, then updated using PATCH /.../:requestNumner.
Then the org unit can be deleted in line org and changes verified / confirmed not affected.

- change request which has been sent - Should not be changed at all
- draft change request - should be deleted
- allocation request - should be unassigned


**Checklist:**
- [ ] ~~Considered automated tests~~
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

[AB#53894](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/53894)
