### PR TITLE
Fix: adjusted runtime and batch test

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
@@ -49,7 +49,7 @@ public class ScheduledReportTimerTriggerFunction
 
     [FunctionName("scheduled-report-timer-trigger-function")]
     public async Task RunAsync(
-        [TimerTrigger("0 10 2 * * MON", RunOnStartup = false)]
+        [TimerTrigger("0 10 0 * * MON", RunOnStartup = true)]
         TimerInfo scheduledReportTimer)
     {
         _logger.LogInformation(
@@ -94,10 +94,9 @@ public class ScheduledReportTimerTriggerFunction
 
             var resourceOwnersToSendNotifications = resourceOwners.DistinctBy(ro => ro.AzureUniqueId).ToList();
 
-            var batchTimeInMinutes = totalBatchTimeInMinutes / resourceOwnersToSendNotifications.Count;
+            var batchTimeInMinutes = totalBatchTimeInMinutes * 1f / resourceOwnersToSendNotifications.Count;
 
-            if (batchTimeInMinutes < 1)
-                batchTimeInMinutes = 1;
+            _logger.LogInformation($"Batching time is calculated to {batchTimeInMinutes.ToString("F2")} minutes ({(60 * batchTimeInMinutes).ToString("F2")} sec)");
 
             var resourceOwnerMessageSent = 0;
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Work description**:

Adjusted runtime as its in UTC. We need to take into account winter and summer time.  Also found that batching had a minimum check to 1m, and with 2000 entities it would take 2000 minutes (33h) to complete the job when it should be done in 4,5h.

**Expected result**: Be able to start and complete the job in 4.5h.

Link to workitem: [#LINK](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/53765)

**Test description**:

- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing


**Checklist**:

- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review