### PR TITLE
Feat: Change running config for summary function

### DIFF
--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
@@ -82,7 +82,7 @@ public class ScheduledReportContentBuilderFunction
     {
         //  Requests for department
         var departmentRequests = (await _resourceClient.GetAllRequestsForDepartment(fullDepartment)).ToList();
-        
+
         // Personnel for the department
         var departmentPersonnel =
             (await GetPersonnelForDepartmentExludingConsultantAndExternal(fullDepartment)).ToList();

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
@@ -82,7 +82,7 @@ public class ScheduledReportContentBuilderFunction
     {
         //  Requests for department
         var departmentRequests = (await _resourceClient.GetAllRequestsForDepartment(fullDepartment)).ToList();
-
+        
         // Personnel for the department
         var departmentPersonnel =
             (await GetPersonnelForDepartmentExludingConsultantAndExternal(fullDepartment)).ToList();

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
@@ -85,7 +85,7 @@ public class ScheduledReportTimerTriggerFunction
                 throw new Exception("No departments found.");
 
             var selectedDepartments = departments
-                .Where(d => d.FullDepartment != null && d.FullDepartment.Contains("PRD")).Distinct().ToList();
+                .Where(d => d.FullDepartment != null).Distinct().ToList();
 
             var resourceOwners = await GetLineOrgPersonsFromDepartmentsChunked(selectedDepartments);
 

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportTimerTriggerFunction.cs
@@ -85,7 +85,7 @@ public class ScheduledReportTimerTriggerFunction
                 throw new Exception("No departments found.");
 
             var selectedDepartments = departments
-                .Where(d => d.FullDepartment != null).Distinct().ToList();
+                .Where(d => d.FullDepartment != null && d.FullDepartment.Contains("PRD")).Distinct().ToList();
 
             var resourceOwners = await GetLineOrgPersonsFromDepartmentsChunked(selectedDepartments);
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Work description**:

Configured the worker to start 02:10 instead of 05:00 and also gave the batching job a space of 4.5h to do the job so it does not put a strain on the other APIs. 

**Expected result**: A longer running job with fewer integration errors

**Test description**:

- [ ] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing


**Checklist**:

- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review