### PR TITLE
fix: branch name in cronjob

### DIFF
--- a/pipelines/secret-rotation-pipeline.yml
+++ b/pipelines/secret-rotation-pipeline.yml
@@ -7,7 +7,7 @@ schedules:
   displayName: Monthly key rotation
   branches:
     include:
-    - main
+    - master
   always: true
 
 ##


### PR DESCRIPTION
Cron job not triggering because of wrong branch name.