### PR TITLE
Feat: Summary sync puts department on bus

### DIFF
--- a/pipelines/templates/deploy-function-pr-template.yml
+++ b/pipelines/templates/deploy-function-pr-template.yml
@@ -65,7 +65,6 @@ steps:
           queues = @{
               provisionPosition = "provision-position"
               scheduledNotificationReportQueue = "scheduled-notification"
-              departmentSummaryWeeklyQueue = "department-summary-weekly-queue"
           }
       }
      

--- a/pipelines/templates/deploy-function-pr-template.yml
+++ b/pipelines/templates/deploy-function-pr-template.yml
@@ -65,6 +65,7 @@ steps:
           queues = @{
               provisionPosition = "provision-position"
               scheduledNotificationReportQueue = "scheduled-notification"
+              departmentSummaryWeeklyQueue = "department-summary-weekly-queue"
           }
       }
      

--- a/pipelines/templates/deploy-function-template.yml
+++ b/pipelines/templates/deploy-function-template.yml
@@ -61,6 +61,7 @@ steps:
           queues = @{
               provisionPosition = "provision-position"
               scheduledNotificationReportQueue = "scheduled-notification"
+              departmentSummaryWeeklyQueue = "department-summary-weekly-queue"
           }
       }
 

--- a/pipelines/templates/deploy-summary-function-pr-template.yml
+++ b/pipelines/templates/deploy-summary-function-pr-template.yml
@@ -65,8 +65,6 @@ steps:
               fusion = "${{ parameters.fusionResource }}"
           }
           queues = @{
-              provisionPosition = "provision-position"
-              scheduledNotificationReportQueue = "scheduled-notification"
               departmentSummaryWeeklyQueue = "department-summary-weekly-queue"
           }
       }

--- a/pipelines/templates/deploy-summary-function-pr-template.yml
+++ b/pipelines/templates/deploy-summary-function-pr-template.yml
@@ -67,6 +67,7 @@ steps:
           queues = @{
               provisionPosition = "provision-position"
               scheduledNotificationReportQueue = "scheduled-notification"
+              departmentSummaryWeeklyQueue = "department-summary-weekly-queue"
           }
       }
      

--- a/src/Fusion.Summary.Functions/Deployment/function.template.json
+++ b/src/Fusion.Summary.Functions/Deployment/function.template.json
@@ -159,6 +159,10 @@
             {
               "name": "Endpoints_Resources_Fusion",
               "value": "[parameters('settings').resources.fusion]"
+            },
+            {
+              "name": "department_summary_weekly_queue",
+              "value": "[parameters('settings').queues.departmentSummaryWeeklyQueue]"
             }
           ]
         }

--- a/src/Fusion.Summary.Functions/Deployment/function.template.json
+++ b/src/Fusion.Summary.Functions/Deployment/function.template.json
@@ -27,6 +27,7 @@
           "fusion": "5a842df8-3238-415d-b168-9f16a6a6031b"
         },
         "queues": {
+          "departmentSummaryWeeklyQueue": "department-summary-weekly-queue"
         }
       }
     },

--- a/src/Fusion.Summary.Functions/Fusion.Summary.Functions.csproj
+++ b/src/Fusion.Summary.Functions/Fusion.Summary.Functions.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Fusion.Resources.Functions.Common\Fusion.Resources.Functions.Common.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="host.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="local.settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Fusion.Resources.Functions.Common\Fusion.Resources.Functions.Common.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/Fusion.Summary.Functions/Fusion.Summary.Functions.generated.sln
+++ b/src/Fusion.Summary.Functions/Fusion.Summary.Functions.generated.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fusion.Summary.Functions", "Fusion.Summary.Functions.csproj", "{A7707D46-393A-4CFB-8EF0-9C07F869AAB0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7707D46-393A-4CFB-8EF0-9C07F869AAB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7707D46-393A-4CFB-8EF0-9C07F869AAB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7707D46-393A-4CFB-8EF0-9C07F869AAB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7707D46-393A-4CFB-8EF0-9C07F869AAB0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2D189714-F592-4D5E-8842-CDD6131DF283}
+	EndGlobalSection
+EndGlobal

--- a/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
+++ b/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
@@ -27,7 +27,9 @@
         },
         "queues": {
           "provisionPosition": "provision-position",
-          "scheduledNotificationReportQueue": "scheduled-notification"
+          "scheduledNotificationReportQueue": "scheduled-notification",
+          "departmentSummaryWeeklyQueue": "department-summary-weekly-queue"
+          
         }
       }
     },

--- a/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
+++ b/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
@@ -27,8 +27,7 @@
         },
         "queues": {
           "provisionPosition": "provision-position",
-          "scheduledNotificationReportQueue": "scheduled-notification",
-          "departmentSummaryWeeklyQueue": "department-summary-weekly-queue"
+          "scheduledNotificationReportQueue": "scheduled-notification"
           
         }
       }

--- a/src/backend/function/Fusion.Resources.Functions/Fusion.Resources.Functions.csproj
+++ b/src/backend/function/Fusion.Resources.Functions/Fusion.Resources.Functions.csproj
@@ -1,48 +1,48 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
-	  <AzureFunctionsVersion>v4</AzureFunctionsVersion>
-	  <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="3.1.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="7.0.0" />
-    <PackageReference Include="Fusion.Integration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
+		<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="AdaptiveCards" Version="3.1.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Fusion.ApiClients.Org" Version="7.0.0" />
+		<PackageReference Include="Fusion.Integration" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+		<PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
 
-    <PackageReference Include="Fusion.Events.Azure.Functions.Extensions" Version="6.0.2" />
-    <PackageReference Include="Fusion.Events.Services" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.13" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Fusion.Resources.Functions.Common\Fusion.Resources.Functions.Common.csproj" />
-    <ProjectReference Include="..\..\integration\Fusion.Resources.Integration.Models\Fusion.Resources.Integration.Models.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-    <None Update="local.settings.template.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Fusion.Resources.Functions.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+		<PackageReference Include="Fusion.Events.Azure.Functions.Extensions" Version="6.0.2" />
+		<PackageReference Include="Fusion.Events.Services" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.8.1" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.13" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Fusion.Resources.Functions.Common\Fusion.Resources.Functions.Common.csproj" />
+		<ProjectReference Include="..\..\integration\Fusion.Resources.Integration.Models\Fusion.Resources.Integration.Models.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="host.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="local.settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+		<None Update="local.settings.template.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+		<None Update="local.settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Fusion.Resources.Functions.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/src/backend/function/Fusion.Resources.Functions/local.settings.template.json
+++ b/src/backend/function/Fusion.Resources.Functions/local.settings.template.json
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "provision_position_queue": "provision-position-[REPLACE WITH DEV QUEUE]",
     "scheduled_notification_report_queue": "scheduled-notification-[REPLACE WITH DEV QUEUE]",
+    "department_summary_weekly_queue": "department-summary-weekly-queue-[REPLACE WITH DEV QUEUE]",
     "AzureWebJobsServiceBus": "[REPLACE WITH SB CONNECTION STRING]",
     "AzureAd_TenantId": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
     "AzureAd_ClientId": "5a842df8-3238-415d-b168-9f16a6a6031b",


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Work description**:

In addition to save department to the database the worker should also send the department (id) to the bus for the weekly worker to pick up. Look at Summary notification architecture (https://miro.com/app/board/uXjVN7jm0Tg=/).

**Expected result**: The servicebus queue is utilized to enable the weekly worker

Link to workitem: [LINK](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/53776)

**Test description**:

- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing


**Checklist**:

- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review