### PR TITLE
chore(Summary): Filter departments to PRD and also send report to delegated responsibles

### DIFF
--- a/src/Fusion.Resources.Functions.Common/ApiClients/ISummaryApiClient.cs
+++ b/src/Fusion.Resources.Functions.Common/ApiClients/ISummaryApiClient.cs
@@ -23,23 +23,17 @@ public interface ISummaryApiClient
 
 public class ApiResourceOwnerDepartment
 {
-    public ApiResourceOwnerDepartment(string departmentSapId, string fullDepartmentName,
-        Guid resourceOwnerAzureUniqueId)
-    {
-        DepartmentSapId = departmentSapId;
-        FullDepartmentName = fullDepartmentName;
-        ResourceOwnerAzureUniqueId = resourceOwnerAzureUniqueId;
-    }
-
     public ApiResourceOwnerDepartment()
     {
     }
 
-    public string DepartmentSapId { get; init; } = string.Empty;
+    public string DepartmentSapId { get; init; } = null!;
+    public string FullDepartmentName { get; init; } = null!;
 
-    public string FullDepartmentName { get; init; } = string.Empty;
+    public Guid[] ResourceOwnersAzureUniqueId { get; init; } = null!;
 
-    public Guid ResourceOwnerAzureUniqueId { get; init; }
+    public Guid[] DelegateResourceOwnersAzureUniqueId { get; init; } = null!;
+
 }
 
 public record ApiCollection<T>(ICollection<T> Items);

--- a/src/Fusion.Summary.Api/BaseController.cs
+++ b/src/Fusion.Summary.Api/BaseController.cs
@@ -31,4 +31,10 @@ public class BaseController : ControllerBase
         var profileResolver = HttpContext.RequestServices.GetRequiredService<IFusionProfileResolver>();
         return await profileResolver.ResolvePersonBasicProfileAsync(personId);
     }
+
+    protected async Task<IEnumerable<ResolvedPersonProfile>> ResolvePersonsAsync(IEnumerable<PersonIdentifier> personIdentifiers)
+    {
+        var profileResolver = HttpContext.RequestServices.GetRequiredService<IFusionProfileResolver>();
+        return await profileResolver.ResolvePersonsAsync(personIdentifiers);
+    }
 }

--- a/src/Fusion.Summary.Api/Controllers/ApiModels/ApiDepartment.cs
+++ b/src/Fusion.Summary.Api/Controllers/ApiModels/ApiDepartment.cs
@@ -5,16 +5,20 @@ namespace Fusion.Summary.Api.Controllers.ApiModels;
 public class ApiDepartment
 {
     public string DepartmentSapId { get; set; } = string.Empty;
-    public Guid ResourceOwnerAzureUniqueId { get; set; }
     public string FullDepartmentName { get; set; } = string.Empty;
+
+    public Guid[] ResourceOwnersAzureUniqueId { get; init; } = null!;
+
+    public Guid[] DelegateResourceOwnersAzureUniqueId { get; init; } = null!;
 
     public static ApiDepartment FromQueryDepartment(QueryDepartment queryDepartment)
     {
         return new ApiDepartment
         {
             DepartmentSapId = queryDepartment.SapDepartmentId,
-            ResourceOwnerAzureUniqueId = queryDepartment.ResourceOwnerAzureUniqueId,
-            FullDepartmentName = queryDepartment.FullDepartmentName
+            FullDepartmentName = queryDepartment.FullDepartmentName,
+            ResourceOwnersAzureUniqueId = queryDepartment.ResourceOwnersAzureUniqueId.ToArray(),
+            DelegateResourceOwnersAzureUniqueId = queryDepartment.DelegateResourceOwnersAzureUniqueId.ToArray()
         };
     }
 }

--- a/src/Fusion.Summary.Api/Controllers/DepartmentsController.cs
+++ b/src/Fusion.Summary.Api/Controllers/DepartmentsController.cs
@@ -126,8 +126,13 @@ public class DepartmentsController : BaseController
             .Concat(request.DelegateResourceOwnersAzureUniqueId)
             .Select(p => new PersonIdentifier(p));
 
-        if ((await ResolvePersonsAsync(personIdentifiers)).FirstOrDefault(r => !r.Success) is { } unresolvedProfile)
-            return BadRequest($"{unresolvedProfile.Identifier} could not be resolved");
+        var unresolvedProfiles = (await ResolvePersonsAsync(personIdentifiers))
+            .Where(r => !r.Success)
+            .ToList();
+
+        if (unresolvedProfiles.Count != 0)
+            return BadRequest($"Profiles: {string.Join(',', unresolvedProfiles)} could not be resolved");
+
 
         var department = await DispatchAsync(new GetDepartment(sapDepartmentId));
 

--- a/src/Fusion.Summary.Api/Controllers/DepartmentsController.cs
+++ b/src/Fusion.Summary.Api/Controllers/DepartmentsController.cs
@@ -1,5 +1,6 @@
 ﻿using Fusion.AspNetCore.FluentAuthorization;
 using Fusion.Authorization;
+using Fusion.Integration.Profile;
 using Fusion.Summary.Api.Authorization.Extensions;
 using Fusion.Summary.Api.Controllers.ApiModels;
 using Fusion.Summary.Api.Controllers.Requests;
@@ -121,8 +122,12 @@ public class DepartmentsController : BaseController
         if (string.IsNullOrWhiteSpace(sapDepartmentId))
             return BadRequest("SapDepartmentId route parameter is required");
 
-        if (await ResolvePersonAsync(request.ResourceOwnerAzureUniqueId) is null)
-            return BadRequest("Resource owner not found in azure ad");
+        var personIdentifiers = request.ResourceOwnersAzureUniqueId
+            .Concat(request.DelegateResourceOwnersAzureUniqueId)
+            .Select(p => new PersonIdentifier(p));
+
+        if ((await ResolvePersonsAsync(personIdentifiers)).FirstOrDefault(r => !r.Success) is { } unresolvedProfile)
+            return BadRequest($"{unresolvedProfile.Identifier} could not be resolved");
 
         var department = await DispatchAsync(new GetDepartment(sapDepartmentId));
 
@@ -132,19 +137,23 @@ public class DepartmentsController : BaseController
             await DispatchAsync(
                 new CreateDepartment(
                     sapDepartmentId,
-                    request.ResourceOwnerAzureUniqueId,
-                    request.FullDepartmentName));
+                    request.FullDepartmentName,
+                    request.ResourceOwnersAzureUniqueId,
+                    request.DelegateResourceOwnersAzureUniqueId));
 
             return Created();
         }
-        // Check if department owner has changed
-        else if (department.ResourceOwnerAzureUniqueId != request.ResourceOwnerAzureUniqueId)
+
+        // Check if department owners has changed
+        if (!department.ResourceOwnersAzureUniqueId.SequenceEqual(request.ResourceOwnersAzureUniqueId) ||
+            !department.DelegateResourceOwnersAzureUniqueId.SequenceEqual(request.DelegateResourceOwnersAzureUniqueId))
         {
             await DispatchAsync(
                 new UpdateDepartment(
                     sapDepartmentId,
-                    request.ResourceOwnerAzureUniqueId,
-                    request.FullDepartmentName));
+                    request.FullDepartmentName,
+                    request.ResourceOwnersAzureUniqueId,
+                    request.DelegateResourceOwnersAzureUniqueId));
 
             return Ok();
         }

--- a/src/Fusion.Summary.Api/Controllers/Requests/PutDepartmentRequest.cs
+++ b/src/Fusion.Summary.Api/Controllers/Requests/PutDepartmentRequest.cs
@@ -9,6 +9,9 @@ public record PutDepartmentRequest(string FullDepartmentName, Guid[] ResourceOwn
         public Validator()
         {
             RuleFor(x => x.FullDepartmentName).NotEmpty();
+            RuleFor(x => x.ResourceOwnersAzureUniqueId.Concat(x.DelegateResourceOwnersAzureUniqueId))
+                .NotEmpty()
+                .WithMessage($"Either {nameof(ResourceOwnersAzureUniqueId)} or {nameof(DelegateResourceOwnersAzureUniqueId)} must contain at least one element.");
         }
     }
 };

--- a/src/Fusion.Summary.Api/Controllers/Requests/PutDepartmentRequest.cs
+++ b/src/Fusion.Summary.Api/Controllers/Requests/PutDepartmentRequest.cs
@@ -2,14 +2,13 @@ using FluentValidation;
 
 namespace Fusion.Summary.Api.Controllers.Requests;
 
-public record PutDepartmentRequest(string FullDepartmentName, Guid ResourceOwnerAzureUniqueId)
+public record PutDepartmentRequest(string FullDepartmentName, Guid[] ResourceOwnersAzureUniqueId, Guid[] DelegateResourceOwnersAzureUniqueId)
 {
     public class Validator : AbstractValidator<PutDepartmentRequest>
     {
         public Validator()
         {
             RuleFor(x => x.FullDepartmentName).NotEmpty();
-            RuleFor(x => x.ResourceOwnerAzureUniqueId).NotEmpty();
         }
     }
 };

--- a/src/Fusion.Summary.Api/Database/Migrations/20240821133720_Initial.Designer.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/20240821133720_Initial.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Fusion.Summary.Api.Database.Migrations
 {
     [DbContext(typeof(SummaryDbContext))]
-    [Migration("20240807132047_Initial")]
+    [Migration("20240821133720_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -30,12 +30,17 @@ namespace Fusion.Summary.Api.Database.Migrations
                     b.Property<string>("DepartmentSapId")
                         .HasColumnType("nvarchar(450)");
 
+                    b.Property<string>("DelegateResourceOwnersAzureUniqueId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("FullDepartmentName")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("ResourceOwnerAzureUniqueId")
-                        .HasColumnType("uniqueidentifier");
+                    b.Property<string>("ResourceOwnersAzureUniqueId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("DepartmentSapId");
 

--- a/src/Fusion.Summary.Api/Database/Migrations/20240821133720_Initial.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/20240821133720_Initial.cs
@@ -16,8 +16,9 @@ namespace Fusion.Summary.Api.Database.Migrations
                 columns: table => new
                 {
                     DepartmentSapId = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    ResourceOwnerAzureUniqueId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    FullDepartmentName = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                    FullDepartmentName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ResourceOwnersAzureUniqueId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DelegateResourceOwnersAzureUniqueId = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/Fusion.Summary.Api/Database/Migrations/SummaryDbContextModelSnapshot.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/SummaryDbContextModelSnapshot.cs
@@ -27,12 +27,17 @@ namespace Fusion.Summary.Api.Database.Migrations
                     b.Property<string>("DepartmentSapId")
                         .HasColumnType("nvarchar(450)");
 
+                    b.Property<string>("DelegateResourceOwnersAzureUniqueId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("FullDepartmentName")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("ResourceOwnerAzureUniqueId")
-                        .HasColumnType("uniqueidentifier");
+                    b.Property<string>("ResourceOwnersAzureUniqueId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("DepartmentSapId");
 

--- a/src/Fusion.Summary.Api/Database/Models/DbDepartment.cs
+++ b/src/Fusion.Summary.Api/Database/Models/DbDepartment.cs
@@ -6,16 +6,20 @@ namespace Fusion.Summary.Api.Database.Models;
 public class DbDepartment
 {
     public string DepartmentSapId { get; set; } = string.Empty;
-    public Guid ResourceOwnerAzureUniqueId { get; set; }
     public string FullDepartmentName { get; set; } = string.Empty;
+
+    public List<Guid> ResourceOwnersAzureUniqueId { get; set; } = [];
+
+    public List<Guid> DelegateResourceOwnersAzureUniqueId { get; set; } = [];
 
     public static DbDepartment FromQueryDepartment(QueryDepartment queryDepartment)
     {
         return new DbDepartment
         {
             DepartmentSapId = queryDepartment.SapDepartmentId,
-            ResourceOwnerAzureUniqueId = queryDepartment.ResourceOwnerAzureUniqueId,
-            FullDepartmentName = queryDepartment.FullDepartmentName
+            FullDepartmentName = queryDepartment.FullDepartmentName,
+            ResourceOwnersAzureUniqueId = queryDepartment.ResourceOwnersAzureUniqueId.ToList(),
+            DelegateResourceOwnersAzureUniqueId = queryDepartment.DelegateResourceOwnersAzureUniqueId.ToList()
         };
     }
 

--- a/src/Fusion.Summary.Api/Domain/Commands/CreateDepartment.cs
+++ b/src/Fusion.Summary.Api/Domain/Commands/CreateDepartment.cs
@@ -9,13 +9,15 @@ public class CreateDepartment : IRequest
 {
     private QueryDepartment _queryDepartment;
 
-    public CreateDepartment(string SapDepartmentId, Guid ResourceOwnerAzureUniqueId, string FullDepartmentName)
+    public CreateDepartment(string sapDepartmentId, string fullDepartmentName,
+        IEnumerable<Guid> resourceOwnersAzureUniqueId, IEnumerable<Guid> delegateResourceOwnersAzureUniqueId)
     {
         _queryDepartment = new QueryDepartment
         {
-            SapDepartmentId = SapDepartmentId,
-            ResourceOwnerAzureUniqueId = ResourceOwnerAzureUniqueId,
-            FullDepartmentName = FullDepartmentName
+            SapDepartmentId = sapDepartmentId,
+            FullDepartmentName = fullDepartmentName,
+            ResourceOwnersAzureUniqueId = resourceOwnersAzureUniqueId.ToList(),
+            DelegateResourceOwnersAzureUniqueId = delegateResourceOwnersAzureUniqueId.ToList()
         };
     }
 

--- a/src/Fusion.Summary.Api/Domain/Commands/UpdateDepartment.cs
+++ b/src/Fusion.Summary.Api/Domain/Commands/UpdateDepartment.cs
@@ -10,13 +10,15 @@ public class UpdateDepartment : IRequest
 {
     private QueryDepartment _queryDepartment;
 
-    public UpdateDepartment(string SapDepartmentId, Guid ResourceOwnerAzureUniqueId, string FullDepartmentName)
+    public UpdateDepartment(string sapDepartmentId, string fullDepartmentName,
+        IEnumerable<Guid> resourceOwnersAzureUniqueId, IEnumerable<Guid> delegateResourceOwnersAzureUniqueId)
     {
         _queryDepartment = new QueryDepartment
         {
-            SapDepartmentId = SapDepartmentId,
-            ResourceOwnerAzureUniqueId = ResourceOwnerAzureUniqueId,
-            FullDepartmentName = FullDepartmentName
+            SapDepartmentId = sapDepartmentId,
+            FullDepartmentName = fullDepartmentName,
+            ResourceOwnersAzureUniqueId = resourceOwnersAzureUniqueId.ToList(),
+            DelegateResourceOwnersAzureUniqueId = delegateResourceOwnersAzureUniqueId.ToList()
         };
     }
 
@@ -35,12 +37,10 @@ public class UpdateDepartment : IRequest
 
             if (existingDepartment != null)
             {
-                if (existingDepartment.ResourceOwnerAzureUniqueId != request._queryDepartment.ResourceOwnerAzureUniqueId)
-                {
-                    existingDepartment.ResourceOwnerAzureUniqueId = request._queryDepartment.ResourceOwnerAzureUniqueId;
+                existingDepartment.ResourceOwnersAzureUniqueId = request._queryDepartment.ResourceOwnersAzureUniqueId.ToList();
+                existingDepartment.DelegateResourceOwnersAzureUniqueId = request._queryDepartment.DelegateResourceOwnersAzureUniqueId.ToList();
 
-                    await _context.SaveChangesAsync();
-                }
+                await _context.SaveChangesAsync();
             }
         }
     }

--- a/src/Fusion.Summary.Api/Domain/Models/QueryDepartment.cs
+++ b/src/Fusion.Summary.Api/Domain/Models/QueryDepartment.cs
@@ -6,16 +6,19 @@ namespace Fusion.Summary.Api.Domain.Models;
 public class QueryDepartment
 {
     public string SapDepartmentId { get; set; } = string.Empty;
-    public Guid ResourceOwnerAzureUniqueId { get; set; }
     public string FullDepartmentName { get; set; } = string.Empty;
+    public List<Guid> ResourceOwnersAzureUniqueId { get; set; } = null!;
+
+    public List<Guid> DelegateResourceOwnersAzureUniqueId { get; set; } = null!;
 
     public static QueryDepartment FromDbDepartment(DbDepartment dbDepartment)
     {
         return new QueryDepartment
         {
             SapDepartmentId = dbDepartment.DepartmentSapId,
-            ResourceOwnerAzureUniqueId = dbDepartment.ResourceOwnerAzureUniqueId,
-            FullDepartmentName = dbDepartment.FullDepartmentName
+            FullDepartmentName = dbDepartment.FullDepartmentName,
+            ResourceOwnersAzureUniqueId = dbDepartment.ResourceOwnersAzureUniqueId.ToList(),
+            DelegateResourceOwnersAzureUniqueId = dbDepartment.DelegateResourceOwnersAzureUniqueId.ToList()
         };
     }
 
@@ -24,7 +27,9 @@ public class QueryDepartment
         return new QueryDepartment
         {
             SapDepartmentId = apiDepartment.DepartmentSapId,
-            FullDepartmentName = apiDepartment.FullDepartmentName
+            FullDepartmentName = apiDepartment.FullDepartmentName,
+            ResourceOwnersAzureUniqueId = apiDepartment.ResourceOwnersAzureUniqueId.ToList(),
+            DelegateResourceOwnersAzureUniqueId = apiDepartment.DelegateResourceOwnersAzureUniqueId.ToList()
         };
     }
 }

--- a/src/Fusion.Summary.Functions/Deployment/disabled-functions.json
+++ b/src/Fusion.Summary.Functions/Deployment/disabled-functions.json
@@ -2,8 +2,8 @@
   {
     "environment": "pr",
     "disabledFunctions": [
-      "department-resource-owner-sync",
-      "weekly-report-sender"
+      "weekly-department-recipients-sync",
+      "weekly-department-summary-sender"
     ]
   }
 ]

--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -41,7 +41,7 @@ public class DepartmentResourceOwnerSync
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
-    [FunctionName("department-resource-owner-sync")]
+    [FunctionName("weekly-department-recipients-sync")]
     public async Task RunAsync(
         [TimerTrigger("0 05 00 * * *", RunOnStartup = false)]
         TimerInfo timerInfo, CancellationToken cancellationToken

--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -34,7 +34,8 @@ public class DepartmentResourceOwnerSync
         if (!selectedDepartments.Any())
             throw new Exception("No departments found.");
 
-        // TODO: Retrieving resource-owners wil be refactored later
+        // TODO: Retrieving resource-owners wil be refactored later to be more optimized
+        // But this will do for the first iteration
         var resourceOwners = new List<LineOrgPerson>();
         foreach (var orgUnitsChunk in selectedDepartments.Chunk(10))
         {

--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -18,6 +18,7 @@ public class DepartmentResourceOwnerSync
     private readonly ILineOrgApiClient lineOrgApiClient;
     private readonly ISummaryApiClient summaryApiClient;
     private readonly IConfiguration configuration;
+    private readonly IResourcesApiClient resourcesApiClient;
 
     private string _serviceBusConnectionString;
     private string _weeklySummaryQueueName;
@@ -25,11 +26,13 @@ public class DepartmentResourceOwnerSync
     public DepartmentResourceOwnerSync(
         ILineOrgApiClient lineOrgApiClient, 
         ISummaryApiClient summaryApiClient,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IResourcesApiClient resourcesApiClient)
     {
         this.lineOrgApiClient = lineOrgApiClient;
         this.summaryApiClient = summaryApiClient;
         this.configuration = configuration;
+        this.resourcesApiClient = resourcesApiClient;
     }
 
     /// <summary>
@@ -54,33 +57,31 @@ public class DepartmentResourceOwnerSync
         var sender = client.CreateSender(_weeklySummaryQueueName);
 
         // Fetch all departments
-        var departments = await lineOrgApiClient.GetOrgUnitDepartmentsAsync();
+        var departments = (await lineOrgApiClient.GetOrgUnitDepartmentsAsync())
+            .DistinctBy(d => d.SapId)
+            .Where(d => d.FullDepartment != null && d.SapId != null)
+            .Where(d => d.FullDepartment!.Contains("PRD"))
+            .Where(d => d.Management.Persons.Length > 0);
 
-        var selectedDepartments = departments
-            .Where(d => d.FullDepartment != null).DistinctBy(d => d.SapId).ToList();
 
-        if (!selectedDepartments.Any())
-            throw new Exception("No departments found.");
+        var apiDepartments = new List<ApiResourceOwnerDepartment>();
 
-        // TODO: Retrieving resource-owners wil be refactored later to be more optimized
-        // But this will do for the first iteration
-        var resourceOwners = new List<LineOrgPerson>();
-        foreach (var orgUnitsChunk in selectedDepartments.Chunk(10))
+        foreach (var orgUnit in departments)
         {
-            var chunkedResourceOwners =
-                await lineOrgApiClient.GetResourceOwnersFromFullDepartment(orgUnitsChunk);
-            resourceOwners.AddRange(chunkedResourceOwners);
+            var delegatedResponsibles = (await resourcesApiClient
+                    .GetDelegatedResponsibleForDepartment(orgUnit.SapId!))
+                .Select(d => Guid.Parse(d.DelegatedResponsible.AzureUniquePersonId))
+                .Distinct()
+                .ToArray();
+
+            apiDepartments.Add(new ApiResourceOwnerDepartment()
+            {
+                DepartmentSapId = orgUnit.SapId!,
+                FullDepartmentName = orgUnit.FullDepartment!,
+                ResourceOwnersAzureUniqueId = orgUnit.Management.Persons.Select(p => Guid.Parse(p.AzureUniqueId)).Distinct().ToArray(),
+                DelegateResourceOwnersAzureUniqueId = delegatedResponsibles
+            });
         }
-
-        if (!resourceOwners.Any())
-            throw new Exception("No resource-owners found.");
-
-        var resourceOwnerDepartments = resourceOwners
-            .Where(ro => ro.DepartmentSapId is not null && Guid.TryParse(ro.AzureUniqueId, out _))
-            .Select(resourceOwner => new
-                ApiResourceOwnerDepartment(resourceOwner.DepartmentSapId!, resourceOwner.FullDepartment,
-                    Guid.Parse(resourceOwner.AzureUniqueId)));
-
 
         var parallelOptions = new ParallelOptions()
         {
@@ -89,7 +90,7 @@ public class DepartmentResourceOwnerSync
         };
 
         // Use Parallel.ForEachAsync to easily limit the number of parallel requests
-        await Parallel.ForEachAsync(resourceOwnerDepartments, parallelOptions,
+        await Parallel.ForEachAsync(apiDepartments, parallelOptions,
             async (ownerDepartment, token) =>
             {
                 // Update the database

--- a/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
@@ -13,17 +13,17 @@ using static Fusion.Summary.Functions.CardBuilder.AdaptiveCardBuilder;
 
 namespace Fusion.Summary.Functions.Functions;
 
-public class WeeklyReportSender
+public class WeeklyDepartmentSummarySender
 {
     private readonly ISummaryApiClient summaryApiClient;
     private readonly IResourcesApiClient resourcesApiClient;
     private readonly INotificationApiClient notificationApiClient;
-    private readonly ILogger<WeeklyReportSender> logger;
+    private readonly ILogger<WeeklyDepartmentSummarySender> logger;
     private readonly IConfiguration configuration;
 
 
-    public WeeklyReportSender(ISummaryApiClient summaryApiClient, INotificationApiClient notificationApiClient,
-        ILogger<WeeklyReportSender> logger, IConfiguration configuration, IResourcesApiClient resourcesApiClient)
+    public WeeklyDepartmentSummarySender(ISummaryApiClient summaryApiClient, INotificationApiClient notificationApiClient,
+        ILogger<WeeklyDepartmentSummarySender> logger, IConfiguration configuration, IResourcesApiClient resourcesApiClient)
     {
         this.summaryApiClient = summaryApiClient;
         this.notificationApiClient = notificationApiClient;
@@ -32,7 +32,7 @@ public class WeeklyReportSender
         this.resourcesApiClient = resourcesApiClient;
     }
 
-    [FunctionName("weekly-report-sender")]
+    [FunctionName("weekly-department-summary-sender")]
     public async Task RunAsync([TimerTrigger("0 0 8 * * 1", RunOnStartup = false)] TimerInfo timerInfo)
     {
         var departments = 

--- a/src/tests/Fusion.Summary.Api.Tests/HandlerTests/DepartmentTests.cs
+++ b/src/tests/Fusion.Summary.Api.Tests/HandlerTests/DepartmentTests.cs
@@ -42,7 +42,7 @@ namespace Fusion.Summary.Api.Tests.HandlerTests
             var department = new DbDepartment { DepartmentSapId = "1001", FullDepartmentName = "Department A" };
 
             // Act
-            await handler.Handle(new CreateDepartment(department.DepartmentSapId, department.ResourceOwnerAzureUniqueId, department.FullDepartmentName), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(department.DepartmentSapId, department.FullDepartmentName, [], []), CancellationToken.None);
 
             // Assert
             var dbDepartment = _context.Departments.FirstOrDefault(d => d.DepartmentSapId == department.DepartmentSapId);
@@ -58,11 +58,11 @@ namespace Fusion.Summary.Api.Tests.HandlerTests
             var handler = new CreateDepartment.Handler(_context);
             var queryHandler = new GetAllDepartments.Handler(_context);
 
-            var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A", ResourceOwnerAzureUniqueId = Guid.Empty };
-            var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B", ResourceOwnerAzureUniqueId = Guid.Empty };
+            var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A", ResourceOwnersAzureUniqueId = [], DelegateResourceOwnersAzureUniqueId = [] };
+            var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B", ResourceOwnersAzureUniqueId = [], DelegateResourceOwnersAzureUniqueId = [] };
 
-            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.ResourceOwnerAzureUniqueId, departmentA.FullDepartmentName), CancellationToken.None);
-            await handler.Handle(new CreateDepartment(departmentB.SapDepartmentId, departmentB.ResourceOwnerAzureUniqueId, departmentB.FullDepartmentName), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.FullDepartmentName, departmentA.ResourceOwnersAzureUniqueId, departmentA.DelegateResourceOwnersAzureUniqueId), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentB.SapDepartmentId, departmentB.FullDepartmentName, departmentB.ResourceOwnersAzureUniqueId, departmentB.DelegateResourceOwnersAzureUniqueId), CancellationToken.None);
 
             // Act
             var result = await queryHandler.Handle(new GetAllDepartments(), CancellationToken.None);
@@ -84,8 +84,8 @@ namespace Fusion.Summary.Api.Tests.HandlerTests
             var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A" };
             var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B" };
 
-            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.ResourceOwnerAzureUniqueId, departmentA.FullDepartmentName), CancellationToken.None);
-            await handler.Handle(new CreateDepartment(departmentB.SapDepartmentId, departmentB.ResourceOwnerAzureUniqueId, departmentB.FullDepartmentName), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.FullDepartmentName, [], []), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentB.SapDepartmentId, departmentB.FullDepartmentName, [], []), CancellationToken.None);
 
             // Act
             var result = await queryHandler.Handle(new GetDepartment(departmentA.SapDepartmentId), CancellationToken.None);
@@ -118,22 +118,22 @@ namespace Fusion.Summary.Api.Tests.HandlerTests
             var updateHandler = new UpdateDepartment.Handler(_context);
             var queryHandler = new GetDepartment.Handler(_context);
 
-            var resourceOwner1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
-            var resourceOwner2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+            Guid[] resourceOwners1 = [Guid.Parse("00000000-0000-0000-0000-000000000001")];
+            Guid[] resourceOwners2 = [Guid.Parse("00000000-0000-0000-0000-000000000002")];
 
             var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A" };
             var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B" };
 
-            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, resourceOwner1, departmentA.FullDepartmentName), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.FullDepartmentName, resourceOwners1, []), CancellationToken.None);
 
             // Act
-            await updateHandler.Handle(new UpdateDepartment(departmentA.SapDepartmentId, resourceOwner2, departmentA.FullDepartmentName), CancellationToken.None);
+            await updateHandler.Handle(new UpdateDepartment(departmentA.SapDepartmentId, departmentA.FullDepartmentName, resourceOwners2, []), CancellationToken.None);
 
             var result = await queryHandler.Handle(new GetDepartment(departmentA.SapDepartmentId), CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(resourceOwner2, result.ResourceOwnerAzureUniqueId);
+            Assert.Equal(resourceOwners2, result.ResourceOwnersAzureUniqueId);
         }
 
         [Fact]
@@ -144,22 +144,22 @@ namespace Fusion.Summary.Api.Tests.HandlerTests
             var updateHandler = new UpdateDepartment.Handler(_context);
             var queryHandler = new GetDepartment.Handler(_context);
 
-            var resourceOwner1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
-            var resourceOwner2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+            List<Guid> resourceOwner1 = [Guid.Parse("00000000-0000-0000-0000-000000000001")];
+            List<Guid> resourceOwner2 = [Guid.Parse("00000000-0000-0000-0000-000000000002")];
 
-            var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A", ResourceOwnerAzureUniqueId = resourceOwner1 };
-            var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B", ResourceOwnerAzureUniqueId = resourceOwner2 };
+            var departmentA = new QueryDepartment { SapDepartmentId = "1001", FullDepartmentName = "Department A", ResourceOwnersAzureUniqueId = resourceOwner1 };
+            var departmentB = new QueryDepartment { SapDepartmentId = "1002", FullDepartmentName = "Department B", ResourceOwnersAzureUniqueId = resourceOwner2 };
 
-            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.ResourceOwnerAzureUniqueId, departmentA.FullDepartmentName), CancellationToken.None);
+            await handler.Handle(new CreateDepartment(departmentA.SapDepartmentId, departmentA.FullDepartmentName, departmentA.ResourceOwnersAzureUniqueId, []), CancellationToken.None);
 
             // Act
-            await updateHandler.Handle(new UpdateDepartment(departmentB.SapDepartmentId, resourceOwner2, departmentB.FullDepartmentName), CancellationToken.None);
+            await updateHandler.Handle(new UpdateDepartment(departmentB.SapDepartmentId, departmentB.FullDepartmentName, departmentB.ResourceOwnersAzureUniqueId, []), CancellationToken.None);
 
             var result = await queryHandler.Handle(new GetDepartment(departmentA.SapDepartmentId), CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(resourceOwner1, result.ResourceOwnerAzureUniqueId);
+            Assert.Equal(resourceOwner1, result.ResourceOwnersAzureUniqueId);
         }
     }
 }

--- a/src/tests/Fusion.Summary.Api.Tests/Helpers/DepartmentHelpers.cs
+++ b/src/tests/Fusion.Summary.Api.Tests/Helpers/DepartmentHelpers.cs
@@ -10,7 +10,8 @@ public static class DepartmentHelpers
         {
             FullDepartmentName = $"Test FullDepartmentName {Guid.NewGuid()}",
             DepartmentSapId = $"Test DepartmentSapId {Guid.NewGuid()}",
-            ResourceOwnerAzureUniqueId = resourceOwnerAzureUniqueId
+            ResourceOwnersAzureUniqueId = [resourceOwnerAzureUniqueId],
+            DelegateResourceOwnersAzureUniqueId = []
         };
 
     public static async Task<ApiDepartment> PutDepartmentAsync(this HttpClient client, Guid resourceOwnerAzureUniqueId,

--- a/src/tests/Fusion.Summary.Api.Tests/IntegrationTests/DepartmentTests.cs
+++ b/src/tests/Fusion.Summary.Api.Tests/IntegrationTests/DepartmentTests.cs
@@ -66,8 +66,8 @@ public class DepartmentTests : TestBase
         updatedDepartment.DepartmentSapId.Should()
             .Be(department.DepartmentSapId, "It is still the same department with the same sap id");
 
-        updatedDepartment.ResourceOwnerAzureUniqueId.Should()
-            .Be(newOwner.AzureUniqueId!.Value, "The owner should be updated");
+        updatedDepartment.ResourceOwnersAzureUniqueId.Should()
+            .Contain(newOwner.AzureUniqueId!.Value, "The owner should be updated");
 
         updatedDepartment.FullDepartmentName.Should()
             .Be(department.FullDepartmentName, "It is still the same department with the same full department name");


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**

Renamed functions.

Now only takes PRD departmens like the old function did.

The Departments model has been reworked and now has a field for Resource owners and Delegated resource owners. This required refactoring of a lot of code.

For now they're separated into two properties but could be merged into a single recipients list instead,


**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing


**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

