### PR TITLE
fix: Summary report email layout

### DIFF
--- a/src/Fusion.Resources.Functions.Common/ApiClients/ApiModels/Notifications.cs
+++ b/src/Fusion.Resources.Functions.Common/ApiClients/ApiModels/Notifications.cs
@@ -7,11 +7,11 @@ public class SendNotificationsRequest
 {
     [JsonProperty("emailPriority")] public int EmailPriority { get; set; }
 
-    [JsonProperty("title")] public string Title { get; set; }
+    [JsonProperty("title")] public string? Title { get; set; }
 
-    [JsonProperty("description")] public string Description { get; set; }
+    [JsonProperty("description")] public string? Description { get; set; }
 
-    [JsonProperty("appKey")] public string AppKey { get; set; }
+    [JsonProperty("appKey")] public string? AppKey { get; set; }
 
-    [JsonProperty("card")] public AdaptiveCard Card { get; set; }
+    [JsonProperty("card")] public AdaptiveCard? Card { get; set; }
 }

--- a/src/Fusion.Resources.Functions.Common/ApiClients/ApiModels/Notifications.cs
+++ b/src/Fusion.Resources.Functions.Common/ApiClients/ApiModels/Notifications.cs
@@ -11,5 +11,7 @@ public class SendNotificationsRequest
 
     [JsonProperty("description")] public string Description { get; set; }
 
+    [JsonProperty("appKey")] public string AppKey { get; set; }
+
     [JsonProperty("card")] public AdaptiveCard Card { get; set; }
 }

--- a/src/Fusion.Summary.Functions/CardBuilder/AdaptiveCardBuilder.cs
+++ b/src/Fusion.Summary.Functions/CardBuilder/AdaptiveCardBuilder.cs
@@ -7,7 +7,7 @@ namespace Fusion.Summary.Functions.CardBuilder;
 
 public class AdaptiveCardBuilder
 {
-    private readonly AdaptiveCard _adaptiveCard = new(new AdaptiveSchemaVersion(1, 0));
+    private readonly AdaptiveCard _adaptiveCard = new(new AdaptiveSchemaVersion(1, 2));
 
     public AdaptiveCardBuilder AddHeading(string text)
     {

--- a/src/Fusion.Summary.Functions/CardBuilder/AdaptiveCardBuilder.cs
+++ b/src/Fusion.Summary.Functions/CardBuilder/AdaptiveCardBuilder.cs
@@ -24,14 +24,30 @@ public class AdaptiveCardBuilder
         return this;
     }
 
-    public AdaptiveCardBuilder AddColumnSet(params AdaptiveCardColumn[] columns)
+    public AdaptiveCardBuilder AddTextRow(string valueText, string headerText, string customText = "")
     {
-        var columnSet = new AdaptiveColumnSet
+        var container = new AdaptiveContainer()
         {
-            Columns = columns.Select(col => col.Column).ToList(),
-            Separator = true
+            Separator = true,
+            Items = new List<AdaptiveElement>()
+            {
+                new AdaptiveTextBlock
+                {
+                    Text = $"{valueText} {customText}",
+                    Wrap = true,
+                    HorizontalAlignment = AdaptiveHorizontalAlignment.Center,
+                    Size = AdaptiveTextSize.ExtraLarge
+                },
+                new AdaptiveTextBlock
+                {
+                    Text = headerText,
+                    Wrap = true,
+                    HorizontalAlignment = AdaptiveHorizontalAlignment.Center
+                }
+            }
         };
-        _adaptiveCard.Body.Add(columnSet);
+
+        _adaptiveCard.Body.Add(container);
         return this;
     }
 
@@ -41,31 +57,45 @@ public class AdaptiveCardBuilder
         var listContainer = new AdaptiveContainer
         {
             Separator = true,
-            Items = new List<AdaptiveElement>
+        };
+
+        var header = new AdaptiveTextBlock
+        {
+            Weight = AdaptiveTextWeight.Bolder,
+            Text = headerText,
+            Wrap = true,
+            Size = AdaptiveTextSize.Large,
+            HorizontalAlignment = AdaptiveHorizontalAlignment.Center
+        };
+
+        var rows = new List<AdaptiveColumnSet>();
+
+        foreach (var listObject in objectLists)
+        {
+            var row = new AdaptiveColumnSet()
             {
-                new AdaptiveTextBlock
+                Columns = listObject.Select(o => new AdaptiveColumn()
                 {
-                    Weight = AdaptiveTextWeight.Bolder,
-                    Text = headerText,
-                    Wrap = true,
-                    Size = AdaptiveTextSize.Large
-                },
-                new AdaptiveColumnSet
-                {
-                    Columns = new List<AdaptiveColumn>
+                    Width = AdaptiveColumnWidth.Stretch,
+                    Items = new List<AdaptiveElement>
                     {
-                        new()
+                        new AdaptiveTextBlock
                         {
-                            Width = AdaptiveColumnWidth.Stretch,
-                            Items = new List<AdaptiveElement>
-                            {
-                                new AdaptiveCardList(objectLists).List
-                            }
+                            Text = o.Value,
+                            Wrap = true,
+                            HorizontalAlignment = o.Alignment
                         }
                     }
-                }
-            }
-        };
+                }).ToList()
+            };
+
+            rows.Add(row);
+        }
+
+        listContainer.Items.Add(header);
+        listContainer.Items.AddRange(rows);
+
+
         _adaptiveCard.Body.Add(listContainer);
         return this;
     }
@@ -100,76 +130,6 @@ public class AdaptiveCardBuilder
         return _adaptiveCard;
     }
 
-    public class AdaptiveCardColumn
-    {
-        public AdaptiveColumn Column { get; }
-
-        public AdaptiveCardColumn(string numberText, string headerText, string customText = "")
-        {
-            Column = new AdaptiveColumn
-            {
-                Width = AdaptiveColumnWidth.Stretch,
-                Separator = true,
-                Spacing = AdaptiveSpacing.Medium,
-                Items = new List<AdaptiveElement>
-                {
-                    new AdaptiveTextBlock
-                    {
-                        Text = $"{numberText} {customText}",
-                        Wrap = true,
-                        HorizontalAlignment = AdaptiveHorizontalAlignment.Center,
-                        Size = AdaptiveTextSize.ExtraLarge
-                    },
-                    new AdaptiveTextBlock
-                    {
-                        Text = headerText,
-                        Wrap = true,
-                        HorizontalAlignment = AdaptiveHorizontalAlignment.Center
-                    }
-                }
-            };
-        }
-    }
-
-    private class AdaptiveCardList
-    {
-        public AdaptiveContainer List { get; }
-
-        public AdaptiveCardList(List<List<ListObject>> objectLists)
-        {
-            var listItems = new List<AdaptiveElement>();
-            foreach (var objects in objectLists)
-            {
-                var columns = new List<AdaptiveColumn>();
-                foreach (var o in objects)
-                {
-                    var column = new AdaptiveColumn()
-                    {
-                        Width = AdaptiveColumnWidth.Stretch,
-                        Items = new List<AdaptiveElement>
-                        {
-                            new AdaptiveTextBlock
-                            {
-                                Text = $"{o.Value} ", Wrap = true,
-                                HorizontalAlignment = o.Alignment
-                            }
-                        }
-                    };
-                    columns.Add(column);
-                }
-
-                listItems.Add(new AdaptiveColumnSet()
-                {
-                    Columns = columns
-                });
-            }
-
-            List = new AdaptiveContainer
-            {
-                Items = listItems
-            };
-        }
-    }
 
     public class ListObject
     {

--- a/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
@@ -166,7 +166,7 @@ public class WeeklyReportSender
             Title = $"Weekly summary - {department.FullDepartmentName}",
             EmailPriority = 1,
             Card = card,
-            // AppKey = "resources", // This does not work, get 400 from notification api
+            AppKey = "personnel-allocation",
             Description = $"Weekly report for department - {department.FullDepartmentName}"
         };
     }

--- a/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
@@ -70,7 +70,13 @@ public class WeeklyReportSender
                 throw;
             }
 
-            await notificationApiClient.SendNotification(notification, department.ResourceOwnerAzureUniqueId);
+            var result = await notificationApiClient.SendNotification(notification, department.ResourceOwnerAzureUniqueId);
+
+            if (!result)
+            {
+                logger.LogError("Failed to send notification for department {@Department} | {ReportId}", department, summaryReport.Id);
+            }
+
         });
     }
 
@@ -118,37 +124,36 @@ public class WeeklyReportSender
 
         var card = new AdaptiveCardBuilder()
             .AddHeading($"**Weekly summary - {department.FullDepartmentName}**")
-            .AddColumnSet(new AdaptiveCardColumn(
+            .AddTextRow(
                 report.NumberOfPersonnel,
-                "Number of personnel (employees and external hire)"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Number of personnel (employees and external hire)")
+            .AddTextRow(
                 report.CapacityInUse,
                 "Capacity in use",
-                "%"))
-            .AddColumnSet(
-                new AdaptiveCardColumn(
+                "%")
+            .AddTextRow(
                     report.NumberOfRequestsLastPeriod,
-                    "New requests last week"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                    "New requests last week")
+            .AddTextRow(
                 report.NumberOfOpenRequests,
-                "Open requests"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Open requests")
+            .AddTextRow(
                 report.NumberOfRequestsStartingInLessThanThreeMonths,
-                "Requests with start date < 3 months"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Requests with start date < 3 months")
+            .AddTextRow(
                 report.NumberOfRequestsStartingInMoreThanThreeMonths,
-                "Requests with start date > 3 months"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Requests with start date > 3 months")
+            .AddTextRow(
                 averageTimeToHandleRequests > 0
                     ? averageTimeToHandleRequests + " day(s)"
                     : "Less than a day",
-                "Average time to handle request (last 12 months)"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Average time to handle request (last 12 months)")
+            .AddTextRow(
                 report.AllocationChangesAwaitingTaskOwnerAction,
-                "Allocation changes awaiting task owner action"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Allocation changes awaiting task owner action")
+            .AddTextRow(
                 report.ProjectChangesAffectingNextThreeMonths,
-                "Project changes last week affecting next 3 months"))
+                "Project changes last week affecting next 3 months")
             .AddListContainer("Allocations ending soon with no future allocation:", endingPositionsObjectList)
             .AddListContainer("Personnel with more than 100% workload:", personnelMoreThan100PercentObjectList)
             .AddNewLine()
@@ -161,7 +166,7 @@ public class WeeklyReportSender
             Title = $"Weekly summary - {department.FullDepartmentName}",
             EmailPriority = 1,
             Card = card,
-            AppKey = "resources",
+            // AppKey = "resources", // This does not work, get 400 from notification api
             Description = $"Weekly report for department - {department.FullDepartmentName}"
         };
     }

--- a/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyReportSender.cs
@@ -161,6 +161,7 @@ public class WeeklyReportSender
             Title = $"Weekly summary - {department.FullDepartmentName}",
             EmailPriority = 1,
             Card = card,
+            AppKey = "resources",
             Description = $"Weekly report for department - {department.FullDepartmentName}"
         };
     }

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/AdaptiveCardBuilder.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/AdaptiveCardBuilder.cs
@@ -7,7 +7,7 @@ namespace Fusion.Resources.Functions.Functions.Notifications;
 
 public class AdaptiveCardBuilder
 {
-    private readonly AdaptiveCard _adaptiveCard = new(new AdaptiveSchemaVersion(1, 0));
+    private readonly AdaptiveCard _adaptiveCard = new(new AdaptiveSchemaVersion(1, 2));
 
     public AdaptiveCardBuilder AddHeading(string text)
     {
@@ -18,53 +18,84 @@ public class AdaptiveCardBuilder
             HorizontalAlignment = AdaptiveHorizontalAlignment.Center,
             Separator = true,
             Size = AdaptiveTextSize.Large,
-            Weight = AdaptiveTextWeight.Bolder,
+            Weight = AdaptiveTextWeight.Bolder
         };
         _adaptiveCard.Body.Add(heading);
         return this;
     }
 
-    public AdaptiveCardBuilder AddColumnSet(params AdaptiveCardColumn[] columns)
+    public AdaptiveCardBuilder AddTextRow(string valueText, string headerText, string customText = "")
     {
-        var columnSet = new AdaptiveColumnSet
+        var container = new AdaptiveContainer()
         {
-            Columns = columns.Select(col => col.Column).ToList(),
-            Separator = true
+            Separator = true,
+            Items = new List<AdaptiveElement>()
+            {
+                new AdaptiveTextBlock
+                {
+                    Text = $"{valueText} {customText}",
+                    Wrap = true,
+                    HorizontalAlignment = AdaptiveHorizontalAlignment.Center,
+                    Size = AdaptiveTextSize.ExtraLarge
+                },
+                new AdaptiveTextBlock
+                {
+                    Text = headerText,
+                    Wrap = true,
+                    HorizontalAlignment = AdaptiveHorizontalAlignment.Center
+                }
+            }
         };
-        _adaptiveCard.Body.Add(columnSet);
+
+        _adaptiveCard.Body.Add(container);
         return this;
     }
 
-    public AdaptiveCardBuilder AddListContainer(string headerText, List<List<ListObject>> objectLists)
+    public AdaptiveCardBuilder AddListContainer(string headerText,
+        List<List<ListObject>> objectLists)
     {
         var listContainer = new AdaptiveContainer
         {
             Separator = true,
-            Items = new List<AdaptiveElement>
+        };
+
+        var header = new AdaptiveTextBlock
+        {
+            Weight = AdaptiveTextWeight.Bolder,
+            Text = headerText,
+            Wrap = true,
+            Size = AdaptiveTextSize.Large,
+            HorizontalAlignment = AdaptiveHorizontalAlignment.Center
+        };
+
+        var rows = new List<AdaptiveColumnSet>();
+
+        foreach (var listObject in objectLists)
+        {
+            var row = new AdaptiveColumnSet()
             {
-                new AdaptiveTextBlock
+                Columns = listObject.Select(o => new AdaptiveColumn()
                 {
-                    Weight = AdaptiveTextWeight.Bolder,
-                    Text = headerText,
-                    Wrap = true,
-                    Size = AdaptiveTextSize.Large,
-                },
-                new AdaptiveColumnSet
-                {
-                    Columns = new List<AdaptiveColumn>
+                    Width = AdaptiveColumnWidth.Stretch,
+                    Items = new List<AdaptiveElement>
                     {
-                        new()
+                        new AdaptiveTextBlock
                         {
-                            Width = AdaptiveColumnWidth.Stretch,
-                            Items = new List<AdaptiveElement>
-                            {
-                                new AdaptiveCardList(objectLists).List
-                            }
+                            Text = o.Value,
+                            Wrap = true,
+                            HorizontalAlignment = o.Alignment
                         }
                     }
-                }
-            }
-        };
+                }).ToList()
+            };
+
+            rows.Add(row);
+        }
+
+        listContainer.Items.Add(header);
+        listContainer.Items.AddRange(rows);
+
+
         _adaptiveCard.Body.Add(listContainer);
         return this;
     }
@@ -86,7 +117,7 @@ public class AdaptiveCardBuilder
     {
         var container = new AdaptiveContainer()
         {
-            Separator = true,
+            Separator = true
         };
 
         _adaptiveCard.Body.Add(container);
@@ -99,80 +130,10 @@ public class AdaptiveCardBuilder
         return _adaptiveCard;
     }
 
-    public class AdaptiveCardColumn
+
+    public class ListObject
     {
-        public AdaptiveColumn Column { get; }
-
-        public AdaptiveCardColumn(string numberText, string headerText, string? customText = null)
-        {
-            Column = new AdaptiveColumn
-            {
-                Width = AdaptiveColumnWidth.Stretch,
-                Separator = true,
-                Spacing = AdaptiveSpacing.Medium,
-                Items = new List<AdaptiveElement>
-                {
-                    new AdaptiveTextBlock
-                    {
-                        Text = $"{numberText} {customText ?? ""}",
-                        Wrap = true,
-                        HorizontalAlignment = AdaptiveHorizontalAlignment.Center,
-                        Size = AdaptiveTextSize.ExtraLarge
-                    },
-                    new AdaptiveTextBlock
-                    {
-                        Text = headerText,
-                        Wrap = true,
-                        HorizontalAlignment = AdaptiveHorizontalAlignment.Center
-                    }
-                }
-            };
-        }
+        public string Value { get; set; }
+        public AdaptiveHorizontalAlignment Alignment { get; set; }
     }
-
-    private class AdaptiveCardList
-    {
-        public AdaptiveContainer List { get; }
-
-        public AdaptiveCardList(List<List<ListObject>> objectLists)
-        {
-            var listItems = new List<AdaptiveElement>();
-            foreach (var objects in objectLists)
-            {
-                var columns = new List<AdaptiveColumn>();
-                foreach (var o in objects)
-                {
-                    var column = new AdaptiveColumn()
-                    {
-                        Width = AdaptiveColumnWidth.Stretch,
-                        Items = new List<AdaptiveElement>
-                        {
-                            new AdaptiveTextBlock
-                            {
-                                Text = $"{o.Value} ", Wrap = true,
-                                HorizontalAlignment = o.Alignment
-                            },
-                        }
-                    };
-                    columns.Add(column);
-                }
-
-                listItems.Add(new AdaptiveColumnSet()
-                {
-                    Columns = columns
-                });
-            }
-
-            List = new AdaptiveContainer
-            {
-                Items = listItems
-            };
-        }
-    }
-}
-
-public class ListObject
-{
-    public string Value { get; set; }
-    public AdaptiveHorizontalAlignment Alignment { get; set; }
 }

--- a/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Functions/Notifications/ResourceOwner/WeeklyReport/ScheduledReportContentBuilderFunction.cs
@@ -209,37 +209,36 @@ public class ScheduledReportContentBuilderFunction
         var averageTimeToHandleRequests = ResourceOwnerReportDataCreator.GetAverageTimeToHandleRequests(requests);
         var card = new AdaptiveCardBuilder()
             .AddHeading($"**Weekly summary - {departmentIdentifier}**")
-            .AddColumnSet(new AdaptiveCardColumn(
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetTotalNumberOfPersonnel(personnel).ToString(),
-                "Number of personnel (employees and external hire)"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Number of personnel (employees and external hire)")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetCapacityInUse(personnel).ToString(),
                 "Capacity in use",
-                "%"))
-            .AddColumnSet(
-                new AdaptiveCardColumn(
+                "%")
+            .AddTextRow(
                     ResourceOwnerReportDataCreator.GetNumberOfRequestsLastWeek(requests).ToString(),
-                    "New requests last week"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                    "New requests last week")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetNumberOfOpenRequests(requests).ToString(),
-                "Open requests"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Open requests")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetNumberOfRequestsStartingInLessThanThreeMonths(requests).ToString(),
-                "Requests with start date < 3 months"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Requests with start date < 3 months")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetNumberOfRequestsStartingInMoreThanThreeMonths(requests).ToString(),
-                "Requests with start date > 3 months"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Requests with start date > 3 months")
+            .AddTextRow(
                 averageTimeToHandleRequests > 0
                     ? averageTimeToHandleRequests + " day(s)"
                     : "Less than a day",
-                "Average time to handle request (last 12 months)"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Average time to handle request (last 12 months)")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.GetAllocationChangesAwaitingTaskOwnerAction(requests).ToString(),
-                "Allocation changes awaiting task owner action"))
-            .AddColumnSet(new AdaptiveCardColumn(
+                "Allocation changes awaiting task owner action")
+            .AddTextRow(
                 ResourceOwnerReportDataCreator.CalculateDepartmentChangesLastWeek(personnel).ToString(),
-                "Project changes last week affecting next 3 months"))
+                "Project changes last week affecting next 3 months")
             .AddListContainer("Allocations ending soon with no future allocation:", endingPositionsObjectList)
             .AddListContainer("Personnel with more than 100% workload:", personnelMoreThan100PercentObjectList)
             .AddNewLine()

--- a/src/backend/function/Fusion.Resources.Functions/Startup.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Startup.cs
@@ -17,7 +17,7 @@ namespace Fusion.Resources.Functions
                 opts.Secret = cfg.GetValue<string>("AzureAd_Secret");
                 opts.TenantId = cfg.GetValue<string>("AzureAd_TenantId");
             });
-            
+
             builder.Services.AddConfigServiceResolver();
             builder.Services.AddHttpClients();
         }

--- a/src/backend/function/Fusion.Resources.Functions/Startup.cs
+++ b/src/backend/function/Fusion.Resources.Functions/Startup.cs
@@ -17,7 +17,7 @@ namespace Fusion.Resources.Functions
                 opts.Secret = cfg.GetValue<string>("AzureAd_Secret");
                 opts.TenantId = cfg.GetValue<string>("AzureAd_TenantId");
             });
-
+            
             builder.Services.AddConfigServiceResolver();
             builder.Services.AddHttpClients();
         }


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**

[AB#54653](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/54653)

This PR rewrites the adaptive card code to make it look better. It also adds personnel-allocation app key to the notifcation. This means that if core adds a toggle for personnel allocation, then emails can be turned of for the app. https://github.com/equinor/fusion/issues/390

If we want to perfect the mail design then I believe we'll need to create a separate message and manually send it to the mail service. As I couldn't get the list values to show properly and I couldn't find a way to center the action button. See US https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_workitems/edit/55681

New design:
![image](https://github.com/user-attachments/assets/6ecb4297-f205-4073-a764-20386bcaef97)


Old design:
![image](https://github.com/user-attachments/assets/2e664e68-a524-4d8d-877e-baa1fd280345)


**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

