### PR TITLE
fix: Fixed invalid format for defaultMessageTimeToLive value

### DIFF
--- a/infrastructure/arm/environment.template.json
+++ b/infrastructure/arm/environment.template.json
@@ -196,7 +196,7 @@
             "properties": {
                 "maxSizeInMegabytes": 1024,
                 "duplicateDetectionHistoryTimeWindow": "P1D",
-                "defaultMessageTimeToLive": "P1H",
+                "defaultMessageTimeToLive": "P1D",
                 "deadLetteringOnMessageExpiration": true,
                 "maxDeliveryCount": 2
             }

--- a/infrastructure/arm/environment.template.json
+++ b/infrastructure/arm/environment.template.json
@@ -196,7 +196,7 @@
             "properties": {
                 "maxSizeInMegabytes": 1024,
                 "duplicateDetectionHistoryTimeWindow": "P1D",
-                "defaultMessageTimeToLive": "P1D",
+                "defaultMessageTimeToLive": "PH1",
                 "deadLetteringOnMessageExpiration": true,
                 "maxDeliveryCount": 2
             }

--- a/infrastructure/arm/environment.template.json
+++ b/infrastructure/arm/environment.template.json
@@ -196,7 +196,7 @@
             "properties": {
                 "maxSizeInMegabytes": 1024,
                 "duplicateDetectionHistoryTimeWindow": "P1D",
-                "defaultMessageTimeToLive": "PH1",
+                "defaultMessageTimeToLive": "PT1H",
                 "deadLetteringOnMessageExpiration": true,
                 "maxDeliveryCount": 2
             }


### PR DESCRIPTION
I was a bit quick to merge in the small queue change. I made a typo in defaultMessageTimeToLive timespan format which made it fail.

I should have tested in PR branch before merging in.