### PR TITLE
feat: Filter out product positions from GetPersonnelAllocation

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonnelAllocation.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetPersonnelAllocation.cs
@@ -34,7 +34,7 @@ namespace Fusion.Resources.Domain
             private readonly IHttpClientFactory httpClientFactory;
             private readonly IMediator mediator;
             private readonly IFusionProfileResolver profileResolver;
-            
+
             public Handler(ILogger<Handler> logger, ResourcesDbContext db, IHttpClientFactory httpClientFactory, IMediator mediator, IFusionProfileResolver profileResolver)
             {
                 this.logger = logger;
@@ -64,12 +64,18 @@ namespace Fusion.Resources.Domain
 
                 personWithAllocations.Absence = absence.Select(a => new QueryPersonAbsenceBasic(a)).ToList();
 
+                personWithAllocations.PositionInstances = personWithAllocations.PositionInstances
+                    .Where(instance => instance.BasePosition != null
+                                        && instance.BasePosition.ProjectType != null
+                                        && !instance.BasePosition.ProjectType.Equals("Product"))
+                    .ToList();
+
                 if (!request.includeCurrentAllocations)
                     return personWithAllocations;
 
                 personWithAllocations.PositionInstances = personWithAllocations.PositionInstances
-                                                                               .Where(instance => instance.AppliesTo >= DateTime.Now && instance.AppliesFrom <= DateTime.Now)
-                                                                               .ToList();
+                    .Where(instance => instance.AppliesTo >= DateTime.Now && instance.AppliesFrom <= DateTime.Now)
+                    .ToList();
 
                 personWithAllocations.Absence = personWithAllocations.Absence
                                                                      .Where(instance => (instance.AppliesTo == null || instance.AppliesTo >= DateTime.Now) && instance.AppliesFrom <= DateTime.Now)


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
We don't want product positions (instances) to show up in the list over all allocations in Personnel Allocation, and therefore we need to filter out all these positions.


[AB#55286](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/55286)
[AB#53017](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/53017)

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

Can be tested with using endpoint:
https://resources-api-pr-686.fusion-dev.net/departments/{departmentString}/resources/personnel/{personId}?api-version=1.0

Change departmentString with the department you want to check and change personId to a person you want to check. Example "PDP PRD PMC PCA PCA4".
There should be several persons with product positions assigned to them, but these should not be shown when searching for them here.

Should get all other positions for personnel.

**Checklist:**
- [x] Considered automated tests
- [ ] ~~Considered updating specification / documentation~~
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

