### PR TITLE
chore: Department filter configuration for az function

### DIFF
--- a/pipelines/templates/deploy-summary-function-pr-template.yml
+++ b/pipelines/templates/deploy-summary-function-pr-template.yml
@@ -49,6 +49,7 @@ steps:
 
       $settings = @{
           clientId = "${{ parameters.clientId }}"
+          departmentFilter = "PRD"
           secretIds = @{
               clientSecret = "https://$envVaultName.vault.azure.net:443/secrets/AzureAd--ClientSecret"
               serviceBus = "https://$envVaultName.vault.azure.net:443/secrets/Connectionstrings--ServiceBus"

--- a/src/Fusion.Summary.Functions/Deployment/function.template.json
+++ b/src/Fusion.Summary.Functions/Deployment/function.template.json
@@ -13,6 +13,7 @@
           "clientSecret": "",
           "serviceBus": ""
         },
+        "department_filter": "PRD",
         "endpoints": {
           "lineorg": "https://fusion-s-lineorg-ci.azurewebsites.net",
           "org": "https://fusion-s-org-ci.azurewebsites.net",
@@ -168,6 +169,10 @@
             {
               "name": "department_summary_weekly_queue",
               "value": "[parameters('settings').queues.departmentSummaryWeeklyQueue]"
+            },
+            {
+              "name": "department_filter",
+              "value": "[parameters('settings').department_filter]"
             }
           ]
         }

--- a/src/Fusion.Summary.Functions/Deployment/function.template.json
+++ b/src/Fusion.Summary.Functions/Deployment/function.template.json
@@ -9,11 +9,11 @@
       "type": "object",
       "defaultValue": {
         "clientId": "",
+        "departmentFilter": "",
         "secretIds": {
           "clientSecret": "",
           "serviceBus": ""
         },
-        "department_filter": "PRD",
         "endpoints": {
           "lineorg": "https://fusion-s-lineorg-ci.azurewebsites.net",
           "org": "https://fusion-s-org-ci.azurewebsites.net",
@@ -171,8 +171,8 @@
               "value": "[parameters('settings').queues.departmentSummaryWeeklyQueue]"
             },
             {
-              "name": "department_filter",
-              "value": "[parameters('settings').department_filter]"
+              "name": "departmentFilter",
+              "value": "[parameters('settings').departmentFilter]"
             }
           ]
         }

--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -53,7 +53,7 @@ public class DepartmentResourceOwnerSync
     {
         _serviceBusConnectionString = configuration["AzureWebJobsServiceBus"];
         _weeklySummaryQueueName = configuration["department_summary_weekly_queue"];
-        _departmentFilter = configuration["departmentFilter"]?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
+        _departmentFilter = configuration["departmentFilter"]?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? ["PRD"];
 
         var client = new ServiceBusClient(_serviceBusConnectionString);
         var sender = client.CreateSender(_weeklySummaryQueueName);

--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -53,7 +53,7 @@ public class DepartmentResourceOwnerSync
     {
         _serviceBusConnectionString = configuration["AzureWebJobsServiceBus"];
         _weeklySummaryQueueName = configuration["department_summary_weekly_queue"];
-        _departmentFilter = configuration["department_filter"]?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
+        _departmentFilter = configuration["departmentFilter"]?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
 
         var client = new ServiceBusClient(_serviceBusConnectionString);
         var sender = client.CreateSender(_weeklySummaryQueueName);

--- a/src/Fusion.Summary.Functions/local.settings.template.json
+++ b/src/Fusion.Summary.Functions/local.settings.template.json
@@ -8,7 +8,7 @@
     "AzureAd_Secret": "[REPLACE WITH SECRET]",
     "department_summary_weekly_queue": "department-summary-weekly-queue-[REPLACE WITH DEV QUEUE]",
     "AzureWebJobsServiceBus": "[REPLACE WITH SB CONNECTION STRING]",
-    "department_filter": "PRD",
+    "departmentFilter": "PRD",
     "Endpoints_lineorg": "https://fusion-s-lineorg-ci.azurewebsites.net",
     "Endpoints_people": "https://fusion-s-people-ci.azurewebsites.net",
     "Endpoints_org": "https://fusion-s-org-ci.azurewebsites.net",

--- a/src/Fusion.Summary.Functions/local.settings.template.json
+++ b/src/Fusion.Summary.Functions/local.settings.template.json
@@ -8,6 +8,7 @@
     "AzureAd_Secret": "[REPLACE WITH SECRET]",
     "department_summary_weekly_queue": "department-summary-weekly-queue-[REPLACE WITH DEV QUEUE]",
     "AzureWebJobsServiceBus": "[REPLACE WITH SB CONNECTION STRING]",
+    "department_filter": "PRD",
     "Endpoints_lineorg": "https://fusion-s-lineorg-ci.azurewebsites.net",
     "Endpoints_people": "https://fusion-s-people-ci.azurewebsites.net",
     "Endpoints_org": "https://fusion-s-org-ci.azurewebsites.net",


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
[AB#55979](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/55979)

This adds a new setting to the function specifying what departments should be synced and receive reports. The configuration value is a comma separated string. So to only allow departments that contain PRD and TDI => "PRD,TDI".

White space is trimmed and empty values are removed

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

