### PR TITLE
chore(resources): Packages update

### DIFF
--- a/src/Fusion.Resources.Functions.Common/Fusion.Resources.Functions.Common.csproj
+++ b/src/Fusion.Resources.Functions.Common/Fusion.Resources.Functions.Common.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="AdaptiveCards" Version="3.1.0" />
         <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
-        <PackageReference Include="Fusion.Integration" Version="8.0.6"/>
+        <PackageReference Include="Fusion.Integration" Version="8.0.7"/>
         <PackageReference Include="Fusion.Events.Azure.Functions.Extensions" Version="6.0.5"/>
         <PackageReference Include="Fusion.Events.Services" Version="8.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>

--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2"/>
-		<PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
+		<PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
         <PackageReference Include="Fusion.AspNetCore.FluentAuthorization" Version="8.0.0" />
 		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.0.5"/>
 		<PackageReference Include="Fusion.Integration" Version="8.0.6"/>

--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -13,35 +13,33 @@
     
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2"/>
 		<PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
         <PackageReference Include="Fusion.AspNetCore.FluentAuthorization" Version="8.0.0" />
-		<PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
 		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.0.5"/>
-		<PackageReference Include="Fusion.Integration" Version="8.0.0" />
-		<PackageReference Include="Fusion.Integration.Authorization" Version="8.0.0" />
-		<PackageReference Include="MediatR" Version="12.3.0" />
+		<PackageReference Include="Fusion.Integration" Version="8.0.6"/>
+		<PackageReference Include="MediatR" Version="12.4.0"/>
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8"/>
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8"/>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1"/>
 		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -15,12 +15,12 @@
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
-		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2"/>
-		<PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
-        <PackageReference Include="Fusion.AspNetCore.FluentAuthorization" Version="8.0.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
+        <PackageReference Include="Fusion.AspNetCore.FluentAuthorization" Version="8.0.1"/>
 		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.0.5"/>
-		<PackageReference Include="Fusion.Integration" Version="8.0.6"/>
-		<PackageReference Include="MediatR" Version="12.4.0"/>
+        <PackageReference Include="Fusion.Integration" Version="8.0.7"/>
+        <PackageReference Include="MediatR" Version="12.4.1"/>
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8"/>
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8"/>

--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8"/>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1"/>
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">

--- a/src/Fusion.Summary.Api/Program.cs
+++ b/src/Fusion.Summary.Api/Program.cs
@@ -23,11 +23,11 @@ if (Environment.GetEnvironmentVariable("INTEGRATION_TEST_RUN") != "true")
     builder.AddKeyVault();
 }
 
-var azureAdClientId = builder.Configuration["AzureAd:ClientId"];
+var azureAdClientId = builder.Configuration["AzureAd:ClientId"] ?? throw new InvalidOperationException("Missing AzureAd:ClientId");
 var azureAdClientSecret = builder.Configuration["AzureAd:ClientSecret"];
 var certThumbprint = builder.Configuration["Config:CertThumbprint"];
-var environment = builder.Configuration["Environment"];
-var fusionEnvironment = builder.Configuration["FUSION_ENVIRONMENT"];
+var environment = builder.Configuration["Environment"] ?? "Development";
+var fusionEnvironment = builder.Configuration["FUSION_ENVIRONMENT"] ?? "ci";
 var databaseConnectionString = builder.Configuration.GetConnectionString(nameof(SummaryDbContext))!;
 
 builder.Services.AddControllers();
@@ -62,10 +62,10 @@ builder.Services.AddFusionIntegration(f =>
 {
     f.AddFusionAuthorization();
     f.UseServiceInformation("Fusion.Summary.Api", environment);
-    f.UseDefaultEndpointResolver(fusionEnvironment ?? "ci");
+    f.UseDefaultEndpointResolver(fusionEnvironment);
     f.UseDefaultTokenProvider(opts =>
     {
-        opts.ClientId = azureAdClientId ?? throw new InvalidOperationException("Missing AzureAd:ClientId");
+        opts.ClientId = azureAdClientId;
         opts.ClientSecret = azureAdClientSecret;
         opts.CertificateThumbprint = certThumbprint;
     });

--- a/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
+++ b/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
@@ -13,7 +13,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.0" />
+    <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\api\Fusion.Resources.Database\Fusion.Resources.Database.csproj" />

--- a/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
+++ b/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
@@ -12,6 +12,7 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
   </ItemGroup>

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -7,12 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fusion.AspNetCore" Version="7.0.1"/>
-        <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.0"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
+        <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
+        <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>
-        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.6.2"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.6.2"/>
+        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.7.1"/>
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.7.1"/>
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.7.1"/>
     </ItemGroup>
     
 

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
         <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -11,9 +11,9 @@
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
         <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>
-        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.7.1"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.7.1"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.7.1"/>
+        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.7.3" />
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.7.3" />
     </ItemGroup>
     
 

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="7.0.1"/>
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
         <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fusion.AspNetCore" Version="7.0.1"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
         <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.6"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Personnel/InternalPersonnelController.cs
@@ -18,6 +18,7 @@ namespace Fusion.Resources.Api.Controllers
     [ApiController]
     [ApiVersion("1.0-preview")]
     [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
     public partial class InternalPersonnelController : ResourceControllerBase
     {
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
@@ -14,6 +14,7 @@ namespace Fusion.Resources.Api.Controllers
 {
     [ApiVersion("1.0-preview")]
     [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
     [Authorize]
     [ApiController]
     public class AnalyticsController : ResourceControllerBase

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/AnalyticsController.cs
@@ -45,6 +45,7 @@ namespace Fusion.Resources.Api.Controllers
             return collection;
         }
 
+        [MapToApiVersion("1.0")]
         [HttpGet("/analytics/absence/internal")]
         public async Task<ActionResult<ApiCollection<ApiPersonAbsenceForAnalytics>>> GetPersonsAbsence([FromQuery] ODataQueryParams query)
         {

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -38,6 +38,7 @@
     </PackageReference>
     <PackageReference Include="TimePeriodCore" Version="1.0.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\Fusion.Resources.Infrastructure\Fusion.Resources.Infrastructure.csproj"/><ProjectReference Include="..\..\Fusion.Resources.Authorization\Fusion.Resources.Authorization.csproj" />
     <ProjectReference Include="..\Fusion.Resources.Application\Fusion.Resources.Application.csproj" />

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -18,9 +18,9 @@
   
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
-    <PackageReference Include="Bogus" Version="35.6.0"/>
+    <PackageReference Include="Bogus" Version="35.6.1"/>
     <PackageReference Include="Fusion.Infrastructure.MediatR" Version="8.0.2"/>
-    <PackageReference Include="Fusion.Integration" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration" Version="8.0.7"/>
     <PackageReference Include="Fusion.Events.Client" Version="8.1.1"/>
     <PackageReference Include="Fusion.Events.Server" Version="8.0.4"/>
     <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -11,9 +11,11 @@
   <ItemGroup>
     <None Remove="Data\personnel-import-template.xlsx" />
   </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="Data\personnel-import-template.xlsx" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
     <PackageReference Include="Bogus" Version="35.6.0"/>

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -15,30 +15,24 @@
     <EmbeddedResource Include="Data\personnel-import-template.xlsx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-    <PackageReference Include="Bogus" Version="35.5.1" />
-    <PackageReference Include="Fusion.Infrastructure.MediatR" Version="7.0.0" />
-    <PackageReference Include="Fusion.Integration" Version="8.0.0" />
-    <PackageReference Include="Fusion.Events.Client" Version="8.0.2" />
-    <PackageReference Include="Fusion.Events.Server" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.Org" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.Roles" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.Notification" Version="8.0.0" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
+    <PackageReference Include="Bogus" Version="35.6.0"/>
+    <PackageReference Include="Fusion.Infrastructure.MediatR" Version="8.0.2"/>
+    <PackageReference Include="Fusion.Integration" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Events.Client" Version="8.1.1"/>
+    <PackageReference Include="Fusion.Events.Server" Version="8.0.4"/>
+    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.Org" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.Roles" Version="8.0.8"/>
+    <PackageReference Include="Fusion.Integration.Notification" Version="8.0.7"/>
+    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="JSM.FluentValidation.AspNet.AsyncFilter" Version="2.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8"/>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-    <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
-    <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
-    <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.6.2" />
     <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8"/>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.6" />
+    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using SixLabors.ImageSharp;
 using System.Reflection;
+using Fusion.AspNetCore.Versioning;
 
 namespace Fusion.Resources.Api
 {
@@ -58,7 +59,7 @@ namespace Fusion.Resources.Api
                 s.ReportApiVersions = true;
                 s.AssumeDefaultVersionWhenUnspecified = true;
                 s.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
-                s.ApiVersionReader = new Fusion.AspNetCore.Mvc.Versioning.HeaderOrQueryVersionReader("api-version");
+                s.ApiVersionReader = new HeaderOrQueryVersionReader("api-version");
             });
 
             services.AddHttpContextAccessor();

--- a/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
+++ b/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Fusion.Integration.Profile" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1"/>
+    <PackageReference Include="Fusion.Integration.Profile" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 

--- a/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
+++ b/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
@@ -7,13 +7,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Notification" Version="8.0.7" />
     <PackageReference Include="MediatR" Version="12.4.0"/>
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
+    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1"/>
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6"/>

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Notification" Version="8.0.7" />
-    <PackageReference Include="MediatR" Version="12.4.0"/>
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
+    <PackageReference Include="MediatR" Version="12.4.1"/>
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6"/>

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Notification" Version="8.0.7" />
     <PackageReference Include="MediatR" Version="12.4.0"/>
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1"/>
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6"/>

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -6,15 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="3.0.0" />
-    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.LineOrg.Abstractions" Version="8.0.0" />
-    <PackageReference Include="MediatR" Version="12.3.0" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.Notification" Version="8.0.7" />
+    <PackageReference Include="MediatR" Version="12.4.0"/>
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4"/>
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1"/>
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="7.0.4" />
-    <PackageReference Include="Fusion.Integration.Roles.Abstractions" Version="7.0.4" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Integration.Roles.Abstractions" Version="8.0.8"/>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
 
     <PackageReference Include="TimePeriodCore" Version="1.0.0" />

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
@@ -22,9 +22,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
@@ -14,10 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Fusion.Resources.Functions.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Fusion.Resources.Functions.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1"/>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/backend/tests/Fusion.Resources.Functions.Tests/Fusion.Resources.Functions.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Functions.Tests/Fusion.Resources.Functions.Tests.csproj
@@ -11,10 +11,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
@@ -11,9 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
+++ b/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
 	<PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Bogus" Version="35.5.1" />
+    <PackageReference Include="Bogus" Version="35.6.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
+++ b/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Bogus" Version="35.6.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+      <PackageReference Include="FluentAssertions" Version="6.12.1"/>
+      <PackageReference Include="Bogus" Version="35.6.1"/>
+      <PackageReference Include="Moq" Version="4.20.72"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
+++ b/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
 
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="7.0.4" />
-    <PackageReference Include="Fusion.ApiClients.People" Version="2.0.0-preview-1" />
-    <PackageReference Include="Fusion.Infrastructure.Authentication" Version="7.0.0" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Fusion.ApiClients.People" Version="8.0.1" />
+    <PackageReference Include="Fusion.Infrastructure.Authentication" Version="8.0.4" />
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
+++ b/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />-->
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+      <PackageReference Include="FluentAssertions" Version="6.12.1"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />

--- a/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
+++ b/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="7.0.4" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
-    <PackageReference Include="Fusion.Integration.Context" Version="7.0.4" />
-    <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="7.0.4" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="7.0.0" />
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
+    <PackageReference Include="Fusion.Integration.Context" Version="8.0.6" />
+    <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
+    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
     <PackageReference Include="Fusion.Integration.Context" Version="8.0.6" />
     <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
     <PackageReference Include="Fusion.Integration.Context" Version="8.0.6" />
     <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
     <PackageReference Include="Fusion.Integration.Context" Version="8.0.6" />
     <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />

--- a/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
@@ -6,9 +6,9 @@
 
 
 	<ItemGroup>
-    <PackageReference Include="Bogus" Version="35.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Bogus" Version="35.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
 	</ItemGroup>
 
 

--- a/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
@@ -6,7 +6,7 @@
 
 
 	<ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.0" />
+        <PackageReference Include="Bogus" Version="35.6.1"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
 	</ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.0" />
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="7.0.4" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.0" />
+      <PackageReference Include="Bogus" Version="35.6.1"/>
     <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
   </ItemGroup>
   
 </Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
+    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
   </ItemGroup>
   
 </Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
   </ItemGroup>
   
 </Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.5.1" />
-    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="7.0.4" />
+    <PackageReference Include="Bogus" Version="35.6.0" />
+    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="7.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="7.0.0" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
   </ItemGroup>
   
 </Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Api/PersonsController.cs
@@ -16,6 +16,8 @@ namespace Fusion.Testing.Mocks.ProfileService.Api
 {
     [ApiController]
     [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    [ApiVersion("3.0")]
     public class PersonsController : ControllerBase
     {
         [MapToApiVersion("3.0")]

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.5" />
 
   </ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -6,12 +6,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.5.1" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="7.0.4" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
+    <PackageReference Include="Bogus" Version="35.6.0" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.5" />
 
   </ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -6,12 +6,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.0" />
+      <PackageReference Include="Bogus" Version="35.6.1"/>
     <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.5"/>
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.5" />
 
   </ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.4" />
+    <PackageReference Include="Fusion.AspNetCore" Version="7.0.1" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.5" />
 
   </ItemGroup>

--- a/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
+++ b/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
@@ -31,10 +31,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6"/>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-		<PackageReference Include="xunit" Version="2.8.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
+++ b/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Fusion.Testing" Version="8.0.0"/>
+        <PackageReference Include="Fusion.Testing" Version="8.0.1"/>
 		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,7 +32,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
 		<PackageReference Include="xunit" Version="2.9.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
[AB#55718](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/55718)

This updates all packages to the latest version. ~excluding Fusion.AspNetCore. Fusion.AspNetCore version above 7.0.1 causes the PatchModelBinder to fail to parse PatchProperty<ApiPropertiesCollection?> properties in patch requests.~

~Where PatchProperty with ApiPropertiesCollection will always be empty. I have created an issue for this: https://github.com/equinor/fusion/issues/400~

Issue has been closed and I've added the newest Fusion.AspNetCore version to this PR

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing



**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

