### PR TITLE
chore(resources): Archive DelegatedResourceOwners when org unit is deleted

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/HostedServices/ExpiredDelegatedRolesHostedService.cs
+++ b/src/backend/api/Fusion.Resources.Api/HostedServices/ExpiredDelegatedRolesHostedService.cs
@@ -90,19 +90,7 @@ namespace Fusion.Resources.Api.HostedServices
 
             db.DelegatedDepartmentResponsibles.RemoveRange(toExpire);
 
-            var expiredRecords = toExpire.Select(x => new DbDelegatedDepartmentResponsibleHistory
-            {
-                Id = Guid.NewGuid(),
-                Archived = DateTimeOffset.UtcNow,
-                DateTo = x.DateTo,
-                DepartmentId = x.DepartmentId,
-                ResponsibleAzureObjectId = x.ResponsibleAzureObjectId,
-                DateCreated = x.DateCreated,
-                DateFrom = x.DateFrom,
-                DateUpdated = x.DateUpdated,
-                Reason = x.Reason,
-                UpdatedBy = x.UpdatedBy
-            });
+            var expiredRecords = toExpire.Select(x => new DbDelegatedDepartmentResponsibleHistory(x));
             await db.DelegatedDepartmentResponsiblesHistory.AddRangeAsync(expiredRecords);
             await db.SaveChangesAsync();
         }

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbDelegatedDepartmentResponsibleHistory.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbDelegatedDepartmentResponsibleHistory.cs
@@ -7,8 +7,7 @@ namespace Fusion.Resources.Database.Entities;
 public class DbDelegatedDepartmentResponsibleHistory
 {
     public Guid Id { get; set; }
-    [MaxLength(200)]
-    public string DepartmentId { get; set; } = null!;
+    [MaxLength(200)] public string DepartmentId { get; set; } = null!;
     public Guid ResponsibleAzureObjectId { get; set; }
     public DateTimeOffset DateFrom { get; set; }
     public DateTimeOffset DateTo { get; set; }
@@ -17,6 +16,24 @@ public class DbDelegatedDepartmentResponsibleHistory
     public DateTimeOffset Archived { get; set; }
     public Guid? UpdatedBy { get; set; }
     public string? Reason { get; set; }
+
+    public DbDelegatedDepartmentResponsibleHistory()
+    {
+    }
+
+    public DbDelegatedDepartmentResponsibleHistory(DbDelegatedDepartmentResponsible dbDelegatedDepartmentResponsible)
+    {
+        Id = Guid.NewGuid();
+        Archived = DateTimeOffset.UtcNow;
+        DepartmentId = dbDelegatedDepartmentResponsible.DepartmentId;
+        ResponsibleAzureObjectId = dbDelegatedDepartmentResponsible.ResponsibleAzureObjectId;
+        DateFrom = dbDelegatedDepartmentResponsible.DateFrom;
+        DateTo = dbDelegatedDepartmentResponsible.DateTo;
+        DateCreated = dbDelegatedDepartmentResponsible.DateCreated;
+        DateUpdated = dbDelegatedDepartmentResponsible.DateUpdated;
+        UpdatedBy = dbDelegatedDepartmentResponsible.UpdatedBy;
+        Reason = dbDelegatedDepartmentResponsible.Reason;
+    }
 
 
     internal static void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/backend/api/Fusion.Resources.Database/Entities/DbDelegatedDepartmentResponsibleHistory.cs
+++ b/src/backend/api/Fusion.Resources.Database/Entities/DbDelegatedDepartmentResponsibleHistory.cs
@@ -7,7 +7,8 @@ namespace Fusion.Resources.Database.Entities;
 public class DbDelegatedDepartmentResponsibleHistory
 {
     public Guid Id { get; set; }
-    [MaxLength(200)] public string DepartmentId { get; set; } = null!;
+    [MaxLength(200)]
+    public string DepartmentId { get; set; } = null!;
     public Guid ResponsibleAzureObjectId { get; set; }
     public DateTimeOffset DateFrom { get; set; }
     public DateTimeOffset DateTo { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Departments/ArchiveDelegatedResourceOwners.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Departments/ArchiveDelegatedResourceOwners.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Integration.Profile;
+using Fusion.Integration.Roles;
+using Fusion.Resources.Database;
+using Fusion.Resources.Database.Entities;
+using Fusion.Resources.Domain.Notifications.System;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Fusion.Resources.Domain.Commands.Departments;
+
+public class ArchiveDelegatedResourceOwners : TrackableRequest
+{
+    public LineOrgId DepartmentId { get; private init; }
+    public ICollection<Guid>? ResourceOwnersToArchive { get; private set; }
+
+
+    public ArchiveDelegatedResourceOwners(LineOrgId departmentId)
+    {
+        DepartmentId = departmentId;
+    }
+
+    public ArchiveDelegatedResourceOwners WhenResourceOwners(ICollection<Guid> resourceOwners)
+    {
+        ArgumentNullException.ThrowIfNull(resourceOwners);
+        ResourceOwnersToArchive = resourceOwners;
+        return this;
+    }
+
+
+    public class ArchiveDelegatedResourceOwnersHandler : IRequestHandler<ArchiveDelegatedResourceOwners>
+    {
+        private readonly ILogger<ArchiveDelegatedResourceOwnersHandler> logger;
+        private readonly ResourcesDbContext db;
+        private readonly IFusionRolesClient rolesClient;
+
+
+        public ArchiveDelegatedResourceOwnersHandler(ILogger<ArchiveDelegatedResourceOwnersHandler> logger, ResourcesDbContext db, IFusionRolesClient rolesClient)
+        {
+            this.logger = logger;
+            this.db = db;
+            this.rolesClient = rolesClient;
+        }
+
+        public async Task Handle(ArchiveDelegatedResourceOwners request, CancellationToken cancellationToken)
+        {
+            var delegatedResourceOwnersToArchive = await db.DelegatedDepartmentResponsibles
+                .Where(r => r.DepartmentId == request.DepartmentId.FullDepartment)
+                .Where(r => request.ResourceOwnersToArchive == null || request.ResourceOwnersToArchive.Contains(r.ResponsibleAzureObjectId))
+                .ToListAsync(cancellationToken);
+
+            if (delegatedResourceOwnersToArchive.Count == 0)
+                return;
+
+            foreach (var resourceOwner in delegatedResourceOwnersToArchive)
+            {
+                try
+                {
+                    await rolesClient.DeleteRolesAsync(
+                        new PersonIdentifier(resourceOwner.ResponsibleAzureObjectId),
+                        q => q.WhereRoleName(AccessRoles.ResourceOwner).WhereScopeValue(request.DepartmentId.FullDepartment)
+                    );
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Failed to delete role for delegated resource owner {AzureUniqueId} in department {FullDepartment}",
+                        resourceOwner.ResponsibleAzureObjectId, request.DepartmentId.FullDepartment);
+                    // TODO: Should we stop the execution here? Use transactions?
+                    // throw;
+                }
+            }
+
+
+            db.DelegatedDepartmentResponsibles.RemoveRange(delegatedResourceOwnersToArchive);
+
+            var archivedDelegateResourceOwners = delegatedResourceOwnersToArchive
+                .Select(res => new DbDelegatedDepartmentResponsibleHistory(res));
+
+            db.DelegatedDepartmentResponsiblesHistory.AddRange(archivedDelegateResourceOwners);
+
+            await db.SaveChangesAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Departments/ArchiveDelegatedResourceOwners.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Departments/ArchiveDelegatedResourceOwners.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Fusion.Resources.Domain.Commands.Departments;
 
+/// Archive delegated resource owners for the department and remove their roles.
 public class ArchiveDelegatedResourceOwners : TrackableRequest
 {
     public LineOrgId DepartmentId { get; private init; }
@@ -25,7 +26,8 @@ public class ArchiveDelegatedResourceOwners : TrackableRequest
         DepartmentId = departmentId;
     }
 
-    public ArchiveDelegatedResourceOwners WhenResourceOwners(ICollection<Guid> resourceOwners)
+    /// Only archive the resource owners with the provided Azure Object Ids
+    public ArchiveDelegatedResourceOwners WhereResourceOwnersAzureId(ICollection<Guid> resourceOwners)
     {
         ArgumentNullException.ThrowIfNull(resourceOwners);
         ResourceOwnersToArchive = resourceOwners;

--- a/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.ArchiveDelegatedResourceOwnersHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Notifications/System/OrgUnitDeleted.ArchiveDelegatedResourceOwnersHandler.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Fusion.Resources.Database;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fusion.Integration.Profile;
+using Fusion.Integration.Roles;
+using Fusion.Resources.Database.Entities;
+
+namespace Fusion.Resources.Domain.Notifications.System;
+
+public partial class OrgUnitDeleted
+{
+    /// <summary>
+    ///     Archive all delegated resource owners for the deleted department and remove their roles.
+    /// </summary>
+    public class ArchiveDelegatedResourceOwnersHandler : INotificationHandler<OrgUnitDeleted>
+    {
+        private readonly ILogger<ArchiveDelegatedResourceOwnersHandler> logger;
+        private readonly ResourcesDbContext db;
+        private readonly IFusionRolesClient rolesClient;
+
+
+        public ArchiveDelegatedResourceOwnersHandler(ILogger<ArchiveDelegatedResourceOwnersHandler> logger, ResourcesDbContext db, IFusionRolesClient rolesClient)
+        {
+            this.logger = logger;
+            this.db = db;
+            this.rolesClient = rolesClient;
+        }
+
+        public async Task Handle(OrgUnitDeleted notification, CancellationToken cancellationToken)
+        {
+            var delegatedResourceOwners = await db.DelegatedDepartmentResponsibles
+                .Where(r => r.DepartmentId == notification.FullDepartment)
+                .ToListAsync(cancellationToken);
+
+            if (delegatedResourceOwners.Count == 0)
+                return;
+
+            logger.LogInformation("Archiving {Count} delegated resource owners for deleted department {FullDepartment}", delegatedResourceOwners.Count, notification.FullDepartment);
+
+
+            foreach (var resourceOwner in delegatedResourceOwners)
+            {
+                try
+                {
+                    await rolesClient.DeleteRolesAsync(
+                        new PersonIdentifier(resourceOwner.ResponsibleAzureObjectId),
+                        q => q.WhereRoleName(AccessRoles.ResourceOwner).WhereScopeValue(notification.FullDepartment)
+                    );
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Failed to delete role for delegated resource owner {AzureUniqueId} in department {FullDepartment}", resourceOwner.ResponsibleAzureObjectId, notification.FullDepartment);
+                    // TODO: Should we stop the execution here? Use transactions?
+                    // throw;
+                }
+            }
+
+
+            db.DelegatedDepartmentResponsibles.RemoveRange(delegatedResourceOwners);
+
+            var archivedDelegateResourceOwners = delegatedResourceOwners
+                .Select(res => new DbDelegatedDepartmentResponsibleHistory(res));
+
+            db.DelegatedDepartmentResponsiblesHistory.AddRange(archivedDelegateResourceOwners);
+
+            await db.SaveChangesAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Domain.Tests/DepartmentTests.cs
+++ b/src/backend/tests/Fusion.Resources.Domain.Tests/DepartmentTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Fusion.Resources.Database;
+using Fusion.Resources.Domain.Commands.Departments;
+using Fusion.Resources.Test.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Fusion.Resources.Domain.Tests;
+
+public class DepartmentTests : DbTestFixture
+{
+    [Fact]
+    public async Task ArchiveDelegatedResourceOwners_ShouldArchiveResourceOwners()
+    {
+        var mediator = serviceProvider.GetRequiredService<IMediator>();
+        var db = serviceProvider.GetRequiredService<ResourcesDbContext>();
+
+        var departmentId = new LineOrgId()
+        {
+            FullDepartment = "PRD TDI",
+            SapId = "123456"
+        };
+        var toBeArchivedResourceOwner = CreateTestPerson("toBeArchivedResourceOwner");
+        var resourceOwner = CreateTestPerson("resourceOwner");
+
+        var createCommand = new AddDelegatedResourceOwner(departmentId, toBeArchivedResourceOwner.AzureUniqueId)
+        {
+            Reason = "Test",
+            DateFrom = DateTimeOffset.Now,
+            DateTo = DateTimeOffset.Now.AddMonths(1)
+        };
+
+
+        var createCommand2 = new AddDelegatedResourceOwner(departmentId, resourceOwner.AzureUniqueId)
+        {
+            Reason = "Test2",
+            DateFrom = DateTimeOffset.Now,
+            DateTo = DateTimeOffset.Now.AddMonths(1)
+        };
+
+        await mediator.Send(createCommand);
+        await mediator.Send(createCommand2);
+
+        var command = new ArchiveDelegatedResourceOwners(departmentId).WhereResourceOwnersAzureId([toBeArchivedResourceOwner.AzureUniqueId]);
+
+        await mediator.Send(command);
+
+        var remainingResourceOwners = await db.DelegatedDepartmentResponsibles
+            .Where(r => r.DepartmentId == departmentId.FullDepartment)
+            .ToListAsync();
+
+        remainingResourceOwners.Should().HaveCount(1);
+        remainingResourceOwners.Should().ContainSingle(r => r.ResponsibleAzureObjectId == resourceOwner.AzureUniqueId);
+
+        var archivedResourceOwners = await db.DelegatedDepartmentResponsiblesHistory.ToListAsync();
+
+        archivedResourceOwners.Should().HaveCount(1);
+        archivedResourceOwners.Should().ContainSingle(r => r.ResponsibleAzureObjectId == toBeArchivedResourceOwner.AzureUniqueId);
+    }
+}

--- a/src/backend/tests/Fusion.Resources.Test.Core/DbTestFixture.cs
+++ b/src/backend/tests/Fusion.Resources.Test.Core/DbTestFixture.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Fusion.Integration.Roles;
 
 namespace Fusion.Resources.Test.Core
 {
@@ -50,6 +51,7 @@ namespace Fusion.Resources.Test.Core
             services.AddSingleton(new Mock<IProjectOrgResolver>(MockBehavior.Loose).Object);
             services.AddSingleton(new Mock<IFusionProfileResolver>(MockBehavior.Loose).Object);
             services.AddSingleton(new Mock<IOrgApiClientFactory>(MockBehavior.Loose).Object);
+            services.AddSingleton(new Mock<IFusionRolesClient>(MockBehavior.Loose).Object);
 
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TestTrackableRequestBehaviour<,>));
 


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
[AB#55599](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/55599)

- Adds the command ArchiveDelegatedResourceOwners that archives and removes roles of the specified delegated resource owners

- Adds a new event handler for when an org unit is deleted which calls the new command


**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

Wrote a unit test for the command. Tested by creating and executing a temporary admin endpoint which calls the archive command.

**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

