### PR TITLE
chore: expose x-trace-id in response headers

### DIFF
--- a/src/Fusion.Summary.Api/Program.cs
+++ b/src/Fusion.Summary.Api/Program.cs
@@ -81,7 +81,7 @@ app.UseCors(opts => opts
     .AllowAnyOrigin()
     .AllowAnyMethod()
     .AllowAnyHeader()
-    .WithExposedHeaders("Allow", "x-fusion-retriable"));
+    .WithExposedHeaders("Allow", "x-fusion-retriable", "x-trace-id"));
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -176,7 +176,7 @@ namespace Fusion.Resources.Api
                 .AllowAnyOrigin()
                 .AllowAnyMethod()
                 .AllowAnyHeader()
-                .WithExposedHeaders("Allow", "x-fusion-retriable"));
+                .WithExposedHeaders("Allow", "x-fusion-retriable", "x-trace-id"));
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
Frontend are showing the x-trace-id available from response headers in a api request, but as the resources and summary services did not expose the x-trace-id it was shown as null. 

[AB#56897](https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_boards/board/t/Fusion%20Resource%20Allocation%20Team/Stories/?workitem=56897)

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

Can be tested manually by looking at the response headers from any requests to the resources or summary api (absence request on landing page) and verifying that x-trace-id is under the access-control-expose-headers like this

access-control-expose-headers: Allow,x-fusion-retriable,x-trace-id

**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

