### PR TITLE
chore: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+- [ ] New feature
+- [ ] Bug fix
+- [ ] High impact
+
+**Description of work:**
+<!--- Please give a description of the work --->
+
+
+**Testing:**
+- [ ] Can be tested
+- [ ] Automatic tests created / updated
+- [ ] Local tests are passing
+
+<!--- Please give a description of how this can be tested --->
+
+
+**Checklist:**
+- [ ] Considered automated tests
+- [ ] Considered updating specification / documentation
+- [ ] Considered work items 
+- [ ] Considered security
+- [ ] Performed developer testing
+- [ ] Checklist finalized / ready for review
+
+<!--- Other comments --->


### PR DESCRIPTION
Not everyone uses fdev to create PRs, same template as in services repo