### PR TITLE
chore(iac): Disable resources connection string for PR env instead of soft deleting it

### DIFF
--- a/pipelines/environment-pipeline.yml
+++ b/pipelines/environment-pipeline.yml
@@ -51,18 +51,19 @@ stages:
               azureSubscription: 'FRA Automation Non-Prod'
               coreAzureSubscription: 'PROJECT_PORTAL (63b791ae-b2bc-41a1-ac66-806c4e69bffe)'
 
-          ## To get the pr slots to talk to the correct databases, we need to kill the key vault secret for connection string.
+          ## To get the pr slots to talk to the correct databases, we need to disable the key vault secret for connection string.
           ## The secret would override the direct env property used to target the correct db.
+          ## Cannot delete as this would only soft delete the secret and now allow subsequent deployment to create the secret again.
           - task: AzurePowerShell@5
-            displayName: 'Remove db connection string secret'
+            displayName: 'Disable db connection string secret'
             inputs:
               azureSubscription: 'PROJECT_PORTAL (63b791ae-b2bc-41a1-ac66-806c4e69bffe)'
               ScriptType: InlineScript
               FailOnStandardError: true
               azurePowerShellVersion: 'LatestVersion'
               Inline: |
-                Write-Host "Deleting secret @ kv-fap-resources-pr/ConnectionStrings--ResourcesDbContext"
-                Remove-AzKeyVaultSecret -VaultName kv-fap-resources-pr -Name ConnectionStrings--ResourcesDbContext -Force
+                Write-Host "Disabling secret @ kv-fap-resources-pr/ConnectionStrings--ResourcesDbContext"
+                Update-AzKeyVaultSecret -VaultName kv-fap-resources-pr -Name ConnectionStrings--ResourcesDbContext -Enable $False
 
 
 - stage: DeployQA


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

When deploying infra IAC the PR env would fail because it would soft delete the secret but not purge it. With this PR it will instead be disabled.

Example of a pipeline run that fails
https://statoil-proview.visualstudio.com/Fusion%20Resource%20Allocation/_build/results?buildId=131253&view=logs&j=013c5867-0d4e-5d8f-4115-5efe4ac203c0&t=bc5fcbcb-7453-5c1d-5540-a7bbd223bfa7&s=2741fbd7-98d1-5541-d761-9bcc81bce3d2

I've circumvented this earlier by **personally** purging the secret myself 😡

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->

Ran this pipeline and created a PR that ran resource api. Then tested that it could talk to the DB. TEST PR #720 

**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
