### PR TITLE
feat: Allow disabling of only WeeklyTaskOwnerReportSender

### DIFF
--- a/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
@@ -288,7 +288,7 @@ public class WeeklyTaskOwnerReportSender
                 }
             }, new GoToAction()
             {
-                Title = "Go to position overview",
+                Title = "Go to positions listing view",
                 Url = $"{fusionUri}/apps/org-admin/{contextId}/edit-positions/listing-view"
             })
             .AddGrid("TBN positions with start date next 3 months", "(Please create a resource request or update the position start-date)", new List<GridColumn>()
@@ -315,7 +315,7 @@ public class WeeklyTaskOwnerReportSender
                 }
             }, new GoToAction()
             {
-                Title = "Go to position overview",
+                Title = "Go to positions listing view",
                 Url = $"{fusionUri}/apps/org-admin/{contextId}/edit-positions/listing-view?filter=tbn-pos-3m"
             })
             .Build();

--- a/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
@@ -289,7 +289,7 @@ public class WeeklyTaskOwnerReportSender
             }, new GoToAction()
             {
                 Title = "Go to positions listing view",
-                Url = $"{fusionUri}/apps/org-admin/{contextId}/edit-positions/listing-view"
+                Url = $"{fusionUri}/apps/org-admin/{contextId}/edit-positions/listing-view?filter=allocations-exp-3m"
             })
             .AddGrid("TBN positions with start date next 3 months", "(Please create a resource request or update the position start-date)", new List<GridColumn>()
             {

--- a/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
+++ b/src/Fusion.Summary.Functions/Functions/TaskOwnerReports/WeeklyTaskOwnerReportSender.cs
@@ -28,6 +28,9 @@ public class WeeklyTaskOwnerReportSender
     private readonly bool sendingNotificationEnabled = true; // Default to true so that we don't accidentally disable sending notifications
     private readonly string fusionUri;
 
+    private const string IsSendingNotificationEnabledKey = "WeeklyTaskOwnerReport_IsSendingNotificationEnabled";
+    private const string FunctionName = "weekly-task-owner-report-sender";
+
     public WeeklyTaskOwnerReportSender(ILogger<WeeklyTaskOwnerReportSender> logger, IConfiguration configuration, ISummaryApiClient summaryApiClient, IMailApiClient mailApiClient, IPeopleApiClient peopleApiClient, IContextApiClient contextApiClient)
     {
         this.logger = logger;
@@ -39,13 +42,11 @@ public class WeeklyTaskOwnerReportSender
         fusionUri = (configuration["Endpoints_portal"] ?? "https://fusion.equinor.com/").TrimEnd('/');
 
         // Need to explicitly add the configuration key to the app settings to disable sending of notifications
-        if (int.TryParse(configuration["isSendingNotificationEnabled"], out var enabled))
+        if (int.TryParse(configuration[IsSendingNotificationEnabledKey], out var enabled))
             sendingNotificationEnabled = enabled == 1;
-        else if (bool.TryParse(configuration["isSendingNotificationEnabled"], out var enabledBool))
+        else if (bool.TryParse(configuration[IsSendingNotificationEnabledKey], out var enabledBool))
             sendingNotificationEnabled = enabledBool;
     }
-
-    private const string FunctionName = "weekly-task-owner-report-sender";
 
     [FunctionName(FunctionName)]
     public async Task RunAsync([TimerTrigger("0 0 5 * * MON", RunOnStartup = false)] TimerInfo timerInfo, CancellationToken cancellationToken = default)


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

Allow for disabling sending of notification for **only** weekly task owner sender. This will allow us to test it without sending the report

**Testing:**
- [x] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->

Ran pipeline with this PR. Did a dry run in prod

**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
