### PR TITLE
fix: Direct requests assigned to incorrect org unit

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAllocationRequestStatus.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/ApiModels/ApiPersonAllocationRequestStatus.cs
@@ -2,7 +2,19 @@
 {
     public class ApiPersonAllocationRequestStatus
     {
+        /// <summary>
+        /// Should the request be auto approved?
+        /// </summary>
         public bool AutoApproval { get; set; }
+        
+        /// <summary>
+        /// Applicable manager for the user. This is based on who is set as manager in Entra ID.
+        /// </summary>
         public ApiPerson? Manager { get; set; }
+
+        /// <summary>
+        /// The relevant org unit requests should be assigned to.
+        /// </summary>
+        public Services.LineOrg.ApiModels.ApiOrgUnit? RequestOrgUnit { get; set; }
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/PersonController.cs
@@ -15,6 +15,7 @@ using Fusion.Integration.LineOrg;
 using Fusion.AspNetCore.OData;
 using Microsoft.VisualBasic;
 using NodaTime.TimeZones;
+using Fusion.Services.LineOrg.ApiModels;
 
 namespace Fusion.Resources.Api.Controllers
 {
@@ -327,10 +328,13 @@ namespace Fusion.Resources.Api.Controllers
             var autoApproval = await DispatchAsync(new Domain.Queries.GetPersonAutoApprovalStatus(user.azureId));
             var manager = await DispatchAsync(new Domain.Queries.GetResourceOwner(user.azureId));
 
+            var orgUnit = await DispatchAsync(new ResolveLineOrgUnit(user.fullDepartment));
+
             return new ApiPersonAllocationRequestStatus
             {
                 AutoApproval = autoApproval.GetValueOrDefault(false),
-                Manager = manager is not null ? new ApiPerson(manager) : null
+                Manager = manager is not null ? new ApiPerson(manager) : null,
+                RequestOrgUnit = orgUnit
             };
         }
 


### PR DESCRIPTION
- [x] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
After change to the departments for managers all direct requests are now added to incorrect org unit. This means the manager of the inteded manager is now getting notifications about requests.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

TBD


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

