### PR TITLE
feat(k8s): Update ingress class name for pre-prod-cluster

### DIFF
--- a/src/Fusion.Summary.Api/Deployment/k8s/deployment-ingress-test.yml
+++ b/src/Fusion.Summary.Api/Deployment/k8s/deployment-ingress-test.yml
@@ -4,14 +4,14 @@ metadata:
   name: summary-api-fusiondev-ingress
   annotations:
     kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: ingress-nginx-fusiondev
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.org/client-max-body-size: "50m"
     nginx.ingress.kubernetes.io/client-max-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
 spec:
-  ingressClassName: nginx
+  ingressClassName: ingress-nginx-fusiondev
   tls:
     - hosts:
         - fra-summary.{{ENVNAME}}.api.fusion-dev.net

--- a/src/Fusion.Summary.Api/Deployment/k8s/pr-deployment-env.yml
+++ b/src/Fusion.Summary.Api/Deployment/k8s/pr-deployment-env.yml
@@ -127,7 +127,7 @@ metadata:
     fusion-health/application: 'Fusion Summary'
     fusion-health/url: /_health/ready
 spec:
-  ingressClassName: nginx
+  ingressClassName: ingress-nginx-fusiondev
   tls:
   - hosts:
     - fra-summary-{{prNumber}}.pr.api.fusion-dev.net

--- a/src/backend/api/Fusion.Resources.Api/Deployment/k8s/deployment-ingress-test.yml
+++ b/src/backend/api/Fusion.Resources.Api/Deployment/k8s/deployment-ingress-test.yml
@@ -4,14 +4,14 @@ metadata:
   name: resources-api-fusion-ingress
   annotations:
     kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: ingress-nginx-fusiondev
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.org/client-max-body-size: "50m"
     nginx.ingress.kubernetes.io/client-max-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
 spec:
-  ingressClassName: nginx
+  ingressClassName: ingress-nginx-fusiondev
   tls:
     - hosts:
         - fra-resources.{{ENVNAME}}.api.fusion-dev.net

--- a/src/backend/api/Fusion.Resources.Api/Deployment/k8s/pr-deployment-env.yml
+++ b/src/backend/api/Fusion.Resources.Api/Deployment/k8s/pr-deployment-env.yml
@@ -126,7 +126,7 @@ metadata:
     fusion-health/application: 'Fusion Resources'
     fusion-health/url: /_health/ready
 spec:
-  ingressClassName: nginx
+  ingressClassName: ingress-nginx-fusiondev
   tls:
   - hosts:
     - fra-resources-{{prNumber}}.pr.api.fusion-dev.net


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
The ingress class name in pre-prod cluster is now ingress-nginx-fusiondev

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

