### PR TITLE
fix(common): Duplicate schemaId error during swagger gen

### DIFF
--- a/src/backend/Fusion.Resources.Infrastructure/Swagger/SwaggerSetup.cs
+++ b/src/backend/Fusion.Resources.Infrastructure/Swagger/SwaggerSetup.cs
@@ -42,6 +42,15 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 setupBuilder.SetupAction?.Invoke(c);
 
+                c.CustomSchemaIds(type =>
+                {
+                    // To fix this swagger gen error
+                    // System.InvalidOperationException: Can't use schemaId "$ApiPerson" for type "$Fusion.Services.LineOrg.ApiModels.ApiPerson". The same schemaId is already used for type "$Fusion.Resources.Api.Controllers.ApiPerson"
+                    if (type == typeof(Fusion.Services.LineOrg.ApiModels.ApiPerson))
+                        return $"{nameof(Fusion.Services.LineOrg.ApiModels.ApiPerson)}_LingOrg";
+                    return type.ToString();
+                });
+
                 // Only add endpoints that belongs to the version spec
                 c.DocInclusionPredicate((version, desc) =>
                 {

--- a/src/backend/Fusion.Resources.Infrastructure/Swagger/SwaggerSetup.cs
+++ b/src/backend/Fusion.Resources.Infrastructure/Swagger/SwaggerSetup.cs
@@ -42,14 +42,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 setupBuilder.SetupAction?.Invoke(c);
 
-                c.CustomSchemaIds(type =>
-                {
-                    // To fix this swagger gen error
-                    // System.InvalidOperationException: Can't use schemaId "$ApiPerson" for type "$Fusion.Services.LineOrg.ApiModels.ApiPerson". The same schemaId is already used for type "$Fusion.Resources.Api.Controllers.ApiPerson"
-                    if (type == typeof(Fusion.Services.LineOrg.ApiModels.ApiPerson))
-                        return $"{nameof(Fusion.Services.LineOrg.ApiModels.ApiPerson)}_LingOrg";
-                    return type.ToString();
-                });
+                // To fix this swagger gen error
+                // System.InvalidOperationException: Can't use schemaId "$ApiPerson" for type "$Fusion.Services.LineOrg.ApiModels.ApiPerson". The same schemaId is already used for type "$Fusion.Resources.Api.Controllers.ApiPerson"
+                // TODO: This is a quick fix, makes the schema models have very long name, for example: Fusion.AspNetCore.Api.PatchProperty`1[Fusion.Resources.Api.Controllers.ApiPropertiesCollection]
+                c.CustomSchemaIds(type => type.ToString());
 
                 // Only add endpoints that belongs to the version spec
                 c.DocInclusionPredicate((version, desc) =>


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
To fix this swagger gen error
System.InvalidOperationException: Can't use schemaId "$ApiPerson" for type "$Fusion.Services.LineOrg.ApiModels.ApiPerson". The same schemaId is already used for type "$Fusion.Resources.Api.Controllers.ApiPerson"

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
