### PR TITLE
fix (resources): do not include sibling department if user is departmentManager

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -70,7 +70,7 @@ namespace Fusion.Resources.Domain.Queries
 
                 QueryRelatedDepartments? lineOrgDepartmentProfile = null;
                 if (!string.IsNullOrEmpty(user.FullDepartment))
-                    lineOrgDepartmentProfile = await mediator.Send(new GetRelatedDepartments(user.FullDepartment), cancellationToken);
+                    lineOrgDepartmentProfile = await mediator.Send(new GetRelatedDepartments(user.FullDepartment, isDepartmentManager), cancellationToken);
                 else
                     logger.LogDebug("No department found for profile. Skipping related department check.");
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

[AB#59964](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/59964)

Because of leaders was moved one level up in the hierarchy due to workday changes, they now got access to all sibling units one level up in the hierarchy.

e.g Trude Vikse is leader in PDP DW DWCC MPL PL4 -- and should then have access to all units on MPL, but got access to all units on DWCC -- one level too much. 

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

<!--- Other comments --->
