### PR TITLE
fix: only return existing departments when fetching responsibilities. 

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -137,13 +137,8 @@ namespace Fusion.Resources.Domain.Queries
                 // Add the current department if the user is resource owner in the department.
                 departmentsWithResponsibility.AddRange(userIsManagerFor);
 
-                // Add all departments the user has been delegated responsibility for.
-                var delegatedResponsibilities = db.DelegatedDepartmentResponsibles
-                    .Where(r => r.ResponsibleAzureObjectId == user.AzureUniqueId)
-                    .Where(r => r.DateFrom < DateTime.Now && r.DateTo > DateTime.Now)
-                    .Select(r => new QueryDepartmentResponsible(r));
-
-                departmentsWithResponsibility.AddRange(delegatedResponsibilities.Select(r => r.DepartmentId)!);
+                // Add departments the user has been delegated responsibility for.
+                departmentsWithResponsibility.AddRange(await ResolveDelegatedResponsibilities(user));
 
                 var roleAssignedDepartments = await rolesClient.GetRolesAsync(q => q
                     .WherePersonAzureId(user.AzureUniqueId!.Value)
@@ -176,6 +171,22 @@ namespace Fusion.Resources.Domain.Queries
                 var departments = await mediator.Send(new GetDepartments().InSector(sector));
                 return departments
                     .Select(dpt => dpt.FullDepartment);
+            }
+
+            // This method returns departments where the user has delegated responsibilities AND the department
+            // exists. The PIMS sync doesn't currently remove delegated responsibilities when a department has
+            // been removed.
+            private async Task<IEnumerable<string>> ResolveDelegatedResponsibilities(FusionFullPersonProfile user)
+            {
+                // Get all departments the user has been delegated responsibility for.
+                var delegatedResponsibilities = db.DelegatedDepartmentResponsibles
+                    .Where(r => r.ResponsibleAzureObjectId == user.AzureUniqueId)
+                    .Where(r => r.DateFrom < DateTime.Now && r.DateTo > DateTime.Now)
+                    .Select(r => r.DepartmentId);
+
+                // Only select responsibilities for existing departments
+                var validDepartments = await mediator.Send(new GetDepartments().ByIds(delegatedResponsibilities));
+                return validDepartments.Select(d => d.FullDepartment);
             }
         }
     }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetResourceOwnerProfile.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Fusion.Resources.Database;
-using Fusion.Resources.Domain.Models;
 
 namespace Fusion.Resources.Domain.Queries
 {
@@ -185,8 +184,13 @@ namespace Fusion.Resources.Domain.Queries
                     .Select(r => r.DepartmentId);
 
                 // Only select responsibilities for existing departments
-                var validDepartments = await mediator.Send(new GetDepartments().ByIds(delegatedResponsibilities));
-                return validDepartments.Select(d => d.FullDepartment);
+                if (delegatedResponsibilities.Any())
+                {
+                    var validDepartments = await mediator.Send(new GetDepartments().ByIds(delegatedResponsibilities));
+                    return validDepartments.Select(d => d.FullDepartment);
+                }
+
+                return delegatedResponsibilities;
             }
         }
     }

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -28,6 +28,12 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         /// </summary>
         private readonly ApiPersonProfileV3 testUser;
 
+        /// <summary>
+        /// GetProfile_ShouldBeEmpty_WhenUserHasNoDepartment often fails with isResourceOwner
+        /// being true when running with the testUser above. Information about the user appears
+        /// to be retained when multiple tests are run together. Using the below test user for
+        /// only that test fixes that issue.
+        /// </summary>
         private readonly ApiPersonProfileV3 singleTestUser;
 
         private FusionTestProjectBuilder testProject;
@@ -58,7 +64,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             using (var userScope = fixture.UserScope(singleTestUser))
             {
-                testUser.FullDepartment = null;
+                singleTestUser.FullDepartment = null;
                 var client = fixture.ApiFactory.CreateClient();
                 var resp = await client.TestClientGetAsync(
                     $"/persons/me/resources/profile",

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -28,6 +28,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         /// </summary>
         private readonly ApiPersonProfileV3 testUser;
 
+        private readonly ApiPersonProfileV3 singleTestUser;
+
         private FusionTestProjectBuilder testProject;
 
         public PersonControllerTests(ResourceApiFixture fixture, ITestOutputHelper output)
@@ -39,6 +41,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
 
             // Generate random test user
             testUser = fixture.AddProfile(FusionAccountType.Employee);
+
+            singleTestUser = fixture.AddProfile(FusionAccountType.Employee);
 
             testProject = new FusionTestProjectBuilder()
                 .WithPositions()
@@ -52,7 +56,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task GetProfile_ShouldBeEmpty_WhenUserHasNoDepartment()
         {
-            using (var userScope = fixture.UserScope(testUser))
+            using (var userScope = fixture.UserScope(singleTestUser))
             {
                 testUser.FullDepartment = null;
                 var client = fixture.ApiFactory.CreateClient();
@@ -97,17 +101,17 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .WithAccountType(FusionAccountType.Employee)
                 .WithManager(manager));
 
-      
-                var client = fixture.ApiFactory.CreateClient();
-                var resp = await client.TestClientGetAsync(
-                    $"/persons/{mainResourceOwner.AzureUniqueId}/resources/profile",
-                    new
-                    {
-                        fullDepartment = default(string),
-                        isResourceOwner = true,
-                        responsibilityInDepartments = Array.Empty<string>()
-                    }
-                );
+
+            var client = fixture.ApiFactory.CreateClient();
+            var resp = await client.TestClientGetAsync(
+                $"/persons/{mainResourceOwner.AzureUniqueId}/resources/profile",
+                new
+                {
+                    fullDepartment = default(string),
+                    isResourceOwner = true,
+                    responsibilityInDepartments = Array.Empty<string>()
+                }
+            );
 
             resp.Should().BeSuccessfull();
             resp.Value.responsibilityInDepartments.Count().Should().Be(2);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/PersonControllerTests.cs
@@ -28,13 +28,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         /// </summary>
         private readonly ApiPersonProfileV3 testUser;
 
-        /// <summary>
-        /// GetProfile_ShouldBeEmpty_WhenUserHasNoDepartment often fails with isResourceOwner
-        /// being true when running with the testUser above. Information about the user appears
-        /// to be retained when multiple tests are run together. Using the below test user for
-        /// only that test fixes that issue.
-        /// </summary>
-        private readonly ApiPersonProfileV3 singleTestUser;
 
         private FusionTestProjectBuilder testProject;
 
@@ -48,8 +41,6 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             // Generate random test user
             testUser = fixture.AddProfile(FusionAccountType.Employee);
 
-            singleTestUser = fixture.AddProfile(FusionAccountType.Employee);
-
             testProject = new FusionTestProjectBuilder()
                 .WithPositions()
                 .AddToMockService();
@@ -62,9 +53,9 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Fact]
         public async Task GetProfile_ShouldBeEmpty_WhenUserHasNoDepartment()
         {
-            using (var userScope = fixture.UserScope(singleTestUser))
+            using (var userScope = fixture.UserScope(testUser))
             {
-                singleTestUser.FullDepartment = null;
+                testUser.FullDepartment = null;
                 var client = fixture.ApiFactory.CreateClient();
                 var resp = await client.TestClientGetAsync(
                     $"/persons/me/resources/profile",


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
Work Item: [AB#60494](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/60494)

Added a check to ensure departments exist before adding to list of delegated responsibilities. This issue occurred because a department was removed with active delegated responsibles without removing them as well. This will ensure the api returns valid data, but the PIMS sync should remove the delegated responsibles.

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->
Unable to test with the current mock of the LineOrgService. There is no ability to remove departments. The existing tests do confirm that it is working correctly under normal circumstances. It has been/can be tested in swagger with the user that reported the bug.

**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
