### PR TITLE
feat: Fetch org unit personnel based on sap id

### DIFF
--- a/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/Departments/GetDepartmentPersonnel.cs
@@ -210,21 +210,21 @@ namespace Fusion.Resources.Domain
                 // Copied from line org for now. Might want to decorate the profiles in the search index with the department property so the query is simple
                 // Will be too many round-trips to ask line org for 
 
-                var managers = orgUnit?.Management?.Persons?
-                    .Where(m => string.Equals(m.FullDepartment, orgUnit.FullDepartment, StringComparison.OrdinalIgnoreCase))
-                    .Select(m => m.AzureUniqueId)
-                    .ToList() ?? new List<Guid>();
+                //var managers = orgUnit?.Management?.Persons?
+                //    .Where(m => string.Equals(m.FullDepartment, orgUnit.FullDepartment, StringComparison.OrdinalIgnoreCase))
+                //    .Select(m => m.AzureUniqueId)
+                //    .ToList() ?? new List<Guid>();
 
-                var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
-                var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
+                //var removeManagerQuery = string.Join(" and ", managers.Select(m => $"azureUniqueId ne '{m}'"));
+                //var queryString = (managers.Any() ? removeManagerQuery + " and " : "") + $"fullDepartment eq '{fullDepartmentString}' and isExpired eq false";
 
 
-                if (managers.Any())
-                    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}' and isResourceOwner eq true"));
+                //if (managers.Any())
+                //    queryString += " or " + string.Join(" or ", managers.Select(m => $"managerAzureId eq '{m}' and isResourceOwner eq true"));
 
                 var peopleClient = httpClientFactory.CreateClient(HttpClientNames.ApplicationPeople);
 
-                var personnel = await PeopleSearchUtils.GetFromSearchIndexAsync(peopleClient, queryString, requests: requests);
+                var personnel = await PeopleSearchUtils.GetFromSearchIndexAsync(peopleClient, $"orgUnitId eq '{orgUnit?.SapId}'", requests: requests);
 
 
                 return personnel;


### PR DESCRIPTION
- [x] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
Currently we are fetching org unit personnel based on manager in the search index. This works most of the time, however is not a correct picture. 
Core team has added sap id to the search index, so we can now query on this attribute instead. Should give us a more correct answer, regardless of who is manager/acting etc etc.

Risk: Could give a different picture, so where the "incorrect result" has become a "feature", it could lead to error reports.


**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing



**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

