### PR TITLE
feat(resources): Added option to propose another basePosition for an allocation request

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
@@ -58,14 +58,12 @@ namespace Fusion.Resources.Api.Controllers
                     {
                         if (x.HasValue && x.Value != null)
                         {
-                            var t = typeof(ApiClients.Org.ApiPositionInstanceV2);
-                            var allowedProperties = t.GetProperties();
+                            string[] allowedProperties = ["appliesFrom", "appliesTo", "location", "workload", "basePosition"];
 
                             var isInvalid = false;
                             foreach (var key in x.Value.Keys)
                             {
-
-                                if (!allowedProperties.Any(p => string.Equals(p.Name, key, StringComparison.OrdinalIgnoreCase)))
+                                if (!allowedProperties.Any(p => string.Equals(p, key, StringComparison.OrdinalIgnoreCase)))
                                 {
                                     context.AddFailure($"Key '{key}' is not valid");
                                     isInvalid = true;
@@ -74,7 +72,7 @@ namespace Fusion.Resources.Api.Controllers
 
                             if (isInvalid)
                             {
-                                context.AddFailure($"Allowed keys are {string.Join(", ", allowedProperties.Select(p => p.Name.ToLowerFirstChar()))}");
+                                context.AddFailure($"Allowed keys are {string.Join(", ", allowedProperties.Select(p => p.ToLowerFirstChar()))}");
                             }
 
 

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -133,8 +133,8 @@ namespace Fusion.Resources.Logic.Commands
 
                         try
                         {
-                            if (proposedChanges.TryGetValue("basePositionId", StringComparison.InvariantCultureIgnoreCase, out var basePositionId))
-                                positionPatchRequest["basePosition"] = new JObject() { { "id", basePositionId } };
+                            if (proposedChanges.TryGetValue("basePosition", StringComparison.InvariantCultureIgnoreCase, out var basePosition) && basePosition.Type != JTokenType.Null)
+                                positionPatchRequest.SetPropertyValue<ApiPositionV2>(p => p.BasePosition, basePosition.ToObject<ApiBasePositionV2>()!);
                         }
                         catch (Exception ex)
                         {

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Allocation/ProvisionAllocationRequest.cs
@@ -55,7 +55,7 @@ namespace Fusion.Resources.Logic.Commands
                         var draft = await CreateProvisionDraftAsync(dbRequest);
                         await EnsureDraftInitializedAsync(dbRequest, draft.Id);
 
-                        await HandleRequestPositionChangeAsync(dbRequest, draft, position);
+                        await AllocateRequestPositionChangesAsync(dbRequest, draft, position);
                         await AllocateRequestInstanceAsync(dbRequest, draft, position);
 
                         await client.PublishAndWaitAsync(draft);
@@ -122,8 +122,7 @@ namespace Fusion.Resources.Logic.Commands
                             $"Provisioning of request [{dbRequest.Id}] to position [{dbRequest.OrgPositionId}/{dbRequest.OrgPositionInstance.Id}]");
                     }
 
-                    // TODO: Decide on name for this method
-                    private async Task HandleRequestPositionChangeAsync(DbResourceAllocationRequest dbRequest, ApiDraftV2 draft, ApiPositionV2 position)
+                    private async Task AllocateRequestPositionChangesAsync(DbResourceAllocationRequest dbRequest, ApiDraftV2 draft, ApiPositionV2 position)
                     {
                         var positionPatchRequest = new JObject();
                         var proposedChanges = new JObject();


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

[AB#54170](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/54170)

Connected frontend PR: https://github.com/equinor/fusion-resource-allocation-apps/pull/862

- Now possible for a resource owner to propose a different base position for the allocation request

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->

Added a test cases for proposed changes. Also did testing through PR frontend connected to this PR

**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
