### PR TITLE
feat(resources): Allow resource owners to delete invalid requests in assgined and child departments

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -900,6 +900,7 @@ namespace Fusion.Resources.Api.Controllers
                                 new DepartmentPath(result.AssignedDepartment),
                                 includeParents: true
                             );
+                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(result.AssignedDepartment), AccessRoles.ResourceOwner);
                         }
                     }
 
@@ -1499,6 +1500,7 @@ namespace Fusion.Resources.Api.Controllers
                                 new DepartmentPath(item.AssignedDepartment),
                                 includeParents: true
                             );
+                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
                         }
 
                     }
@@ -1641,6 +1643,7 @@ namespace Fusion.Resources.Api.Controllers
                                 new DepartmentPath(item.AssignedDepartment),
                                 includeParents: true
                             );
+                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
                         }
                     }
                 });

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -880,7 +880,7 @@ namespace Fusion.Resources.Api.Controllers
 
             #region Authorization
 
-            var isRequestInvalid = await IsInvalidAllocationRequestAsync(result);
+            var isRequestInvalid = await IsRequestInvalidAsync(result);
             var authResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
@@ -892,16 +892,15 @@ namespace Fusion.Resources.Api.Controllers
                     {
                         if (result.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
+                    }
 
-
-                        if (isRequestInvalid && result.AssignedDepartment is not null)
-                        {
-                            or.BeResourceOwnerForDepartment(
-                                new DepartmentPath(result.AssignedDepartment),
-                                includeParents: true
-                            );
-                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(result.AssignedDepartment), AccessRoles.ResourceOwner);
-                        }
+                    if (isRequestInvalid && result.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(result.AssignedDepartment),
+                            includeParents: true
+                        );
+                        or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(result.AssignedDepartment), AccessRoles.ResourceOwner);
                     }
 
                 });
@@ -1481,7 +1480,7 @@ namespace Fusion.Resources.Api.Controllers
             });
             if (patchResult.Success) allowedVerbs.Add("PATCH");
 
-            var isRequestInvalid = await IsInvalidAllocationRequestAsync(item);
+            var isRequestInvalid = await IsRequestInvalidAsync(item);
             var deleteResult = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
@@ -1493,16 +1492,15 @@ namespace Fusion.Resources.Api.Controllers
 
                         if (item.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
+                    }
 
-                        if (isRequestInvalid && item.AssignedDepartment is not null)
-                        {
-                            or.BeResourceOwnerForDepartment(
-                                new DepartmentPath(item.AssignedDepartment),
-                                includeParents: true
-                            );
-                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
-                        }
-
+                    if (isRequestInvalid && item.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(item.AssignedDepartment),
+                            includeParents: true
+                        );
+                        or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
                     }
                 });
             });
@@ -1624,7 +1622,7 @@ namespace Fusion.Resources.Api.Controllers
             });
             if (getAuth.Success) allowedVerbs.Add("GET");
 
-            var isRequestInvalid = await IsInvalidAllocationRequestAsync(item);
+            var isRequestInvalid = await IsRequestInvalidAsync(item);
             var deleteAuth = await Request.RequireAuthorizationAsync(r =>
             {
                 r.AlwaysAccessWhen().FullControl().FullControlInternal();
@@ -1636,15 +1634,15 @@ namespace Fusion.Resources.Api.Controllers
 
                         if (item.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
+                    }
 
-                        if (isRequestInvalid && item.AssignedDepartment is not null)
-                        {
-                            or.BeResourceOwnerForDepartment(
-                                new DepartmentPath(item.AssignedDepartment),
-                                includeParents: true
-                            );
-                            or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
-                        }
+                    if (isRequestInvalid && item.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(item.AssignedDepartment),
+                            includeParents: true
+                        );
+                        or.HaveOrgUnitScopedRole(DepartmentId.FromFullPath(item.AssignedDepartment), AccessRoles.ResourceOwner);
                     }
                 });
             });
@@ -1743,11 +1741,8 @@ namespace Fusion.Resources.Api.Controllers
                 && !patchValue.Value!.Equals(originalValue);
         }
 
-        private async Task<bool> IsInvalidAllocationRequestAsync(QueryResourceAllocationRequest request)
+        private async Task<bool> IsRequestInvalidAsync(QueryResourceAllocationRequest request)
         {
-            if (request.Type != InternalRequestType.Allocation)
-                return false;
-
             if (request.OrgPositionId == null)
                 return true;
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -892,6 +892,14 @@ namespace Fusion.Resources.Api.Controllers
                         if (result.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(result.Project.OrgProjectId, result.OrgPositionId.Value);
                     }
+
+                    if (result.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(result.AssignedDepartment).Parent(),
+                            includeParents: true
+                        );
+                    }
                 });
             });
 
@@ -1481,6 +1489,14 @@ namespace Fusion.Resources.Api.Controllers
                         if (item.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
                     }
+
+                    if (item.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(item.AssignedDepartment).Parent(),
+                            includeParents: true
+                        );
+                    }
                 });
             });
 
@@ -1612,6 +1628,14 @@ namespace Fusion.Resources.Api.Controllers
 
                         if (item.OrgPositionId.HasValue)
                             or.OrgChartPositionWriteAccess(item.Project.OrgProjectId, item.OrgPositionId.Value);
+                    }
+
+                    if (item.AssignedDepartment is not null)
+                    {
+                        or.BeResourceOwnerForDepartment(
+                            new DepartmentPath(item.AssignedDepartment).Parent(),
+                            includeParents: true
+                        );
                     }
                 });
             });

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -137,9 +137,9 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData(ManagerRoleType.ResourceOwner, SiblingDepartment, false)]
         [InlineData(ManagerRoleType.ResourceOwner, ParentDepartment, true)]
         [InlineData(ManagerRoleType.ResourceOwner, SameL2Department, false)]
-        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, false)]
-        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, false, true)]
-        [InlineData(ManagerRoleType.DelegatedResourceOwner, WildcardScope, false)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, true)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, true, true)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, WildcardScope, true)]
         [InlineData(ManagerRoleType.DelegatedResourceOwner, UnrelatedScope, false)]
         [InlineData(ManagerRoleType.None, TestDepartment, false)]
         public async Task CanDeleteInvalidAllocationRequestAssignedToDepartment(ManagerRoleType role, string department, bool shouldBeAllowed, bool removeInstanceInstead = false)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -142,7 +142,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData(ManagerRoleType.DelegatedResourceOwner, WildcardScope, true)]
         [InlineData(ManagerRoleType.DelegatedResourceOwner, UnrelatedScope, false)]
         [InlineData(ManagerRoleType.None, TestDepartment, false)]
-        public async Task CanDeleteInvalidAllocationRequestAssignedToDepartment(ManagerRoleType role, string department, bool shouldBeAllowed, bool removeInstanceInstead = false)
+        public async Task CanDeleteInvalidRequestAssignedToDepartment(ManagerRoleType role, string department, bool shouldBeAllowed, bool removeInstanceInstead = false)
         {
             var request = await CreateAndStartRequest();
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -17,6 +17,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -125,6 +126,41 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var client = fixture.ApiFactory.CreateClient();
             var result = await client.TestClientDeleteAsync<dynamic>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
+
+            if (shouldBeAllowed) result.Should().BeSuccessfull();
+            else result.Should().BeUnauthorized();
+        }
+
+        [Theory]
+        [InlineData(ManagerRoleType.ResourceOwner, TestDepartment, true)]
+        [InlineData(ManagerRoleType.ResourceOwner, TestDepartment, true, true)]
+        [InlineData(ManagerRoleType.ResourceOwner, SiblingDepartment, false)]
+        [InlineData(ManagerRoleType.ResourceOwner, ParentDepartment, true)]
+        [InlineData(ManagerRoleType.ResourceOwner, SameL2Department, false)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, false)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, ExactScope, false, true)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, WildcardScope, false)]
+        [InlineData(ManagerRoleType.DelegatedResourceOwner, UnrelatedScope, false)]
+        [InlineData(ManagerRoleType.None, TestDepartment, false)]
+        public async Task CanDeleteInvalidAllocationRequestAssignedToDepartment(ManagerRoleType role, string department, bool shouldBeAllowed, bool removeInstanceInstead = false)
+        {
+            var request = await CreateAndStartRequest();
+
+            var actor = fixture.AddProfile(FusionAccountType.Employee);
+            SetupManagerRole(role, actor, department);
+
+            using var userScope = fixture.UserScope(actor);
+
+            InvalidateRequest(request, removeInstance: removeInstanceInstead);
+
+            var client = fixture.ApiFactory.CreateClient();
+
+            var result = await client.TestClientOptionsAsync($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
+
+            if (shouldBeAllowed) result.Should().HaveAllowHeaders(HttpMethod.Delete);
+            else result.Should().NotHaveAllowHeaders(HttpMethod.Delete);
+
+            result = await client.TestClientDeleteAsync<dynamic>($"/projects/{testProject.Project.ProjectId}/requests/{request.Id}");
 
             if (shouldBeAllowed) result.Should().BeSuccessfull();
             else result.Should().BeUnauthorized();
@@ -940,6 +976,16 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
         private Task<TestApiInternalRequestModel> CreateAndStartRequest()
             => CreateAndStartRequest(testPosition);
+
+        private void InvalidateRequest(TestApiInternalRequestModel request, bool removeInstance)
+        {
+            var id = (removeInstance ? request.OrgPositionInstanceId : request.OrgPositionId)!.Value;
+
+            if (removeInstance)
+                OrgServiceMock.RemoveInstance(id);
+            else
+                OrgServiceMock.RemovePosition(id);
+        }
         private async Task<TestApiInternalRequestModel> CreateAndStartRequest(ApiPositionV2 position)
         {
             var creatorClient = fixture.ApiFactory.CreateClient()


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
[AB#60124](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/60124)

Resource owners and users with scoped resource owner role (DelegatedResourceOwner), can now delete requests that are invalid. Invalid in that the position or position instance that the request is targeting, has has been deleted.

See WorkItem comments for more details

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
