### PR TITLE
feat: require location in validation for other tasks

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/CreatePersonAbsenceRequest.cs
@@ -22,7 +22,7 @@ namespace Fusion.Resources.Api.Controllers
         public void LoadCommand(CreatePersonAbsence command)
         {
             DateTime.SpecifyKind(AppliesFrom, DateTimeKind.Utc);
-            if(AppliesTo.HasValue) DateTime.SpecifyKind(AppliesTo.Value, DateTimeKind.Utc);
+            if (AppliesTo.HasValue) DateTime.SpecifyKind(AppliesTo.Value, DateTimeKind.Utc);
 
             command.Comment = NullIfEmpty(Comment);
             command.AppliesFrom = AppliesFrom;
@@ -60,11 +60,16 @@ namespace Fusion.Resources.Api.Controllers
                    .NotEmpty()
                    .When(x => x.TaskDetails is not null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
                    .WithMessage("Either role name or base position must be set.");
+                RuleFor(x => x.TaskDetails!.Location)
+                    .NotNull()
+                    .NotEmpty()
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks)
+                    .WithMessage("Location must be set when type is 'other tasks'.");
             }
         }
 
         #endregion
-    
+
         public static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Person/Requests/UpdatePersonAbsenceRequest.cs
@@ -55,6 +55,12 @@ namespace Fusion.Resources.Api.Controllers
                     .NotEmpty()
                     .When(x => x.TaskDetails is not null && x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks && !x.TaskDetails!.BasePositionId.HasValue)
                     .WithMessage("Either role name or base position must be set.");
+
+                RuleFor(x => x.TaskDetails!.Location)
+                    .NotNull()
+                    .NotEmpty()
+                    .When(x => x.Type == ApiPersonAbsence.ApiAbsenceType.OtherTasks)
+                    .WithMessage("Location must be set when type is 'other tasks'.");
             }
 
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -404,6 +404,8 @@ namespace Fusion.Resources.Api.Controllers
                 return ApiErrors.InvalidOperation("request-completed", "Cannot change a completed request.");
             if (HasChanged(request.AdditionalNote, item.AdditionalNote))
                 return ApiErrors.InvalidInput("Only task owners can modify additional notes.");
+            if (item?.OrgPositionInstance?.Location is null && !(request.ProposedChanges.Value?.ContainsKey("location") ?? false))
+                return ApiErrors.InvalidInput("Location is required.");
 
             #region Authorization
 
@@ -671,7 +673,7 @@ namespace Fusion.Resources.Api.Controllers
 
         [HttpGet("/resources/requests/internal/{requestId}")]
         [HttpGet("/departments/{departmentString}/resources/requests/{requestId}")]
-        public async Task<ActionResult<ApiResourceAllocationRequest>> GetResourceAllocationRequest([FromRoute]RequestIdentifier requestId, [FromQuery] ODataQueryParams query)
+        public async Task<ActionResult<ApiResourceAllocationRequest>> GetResourceAllocationRequest([FromRoute] RequestIdentifier requestId, [FromQuery] ODataQueryParams query)
         {
             if (!requestId.Exists)
                 return requestId.NotFoundResult();

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -244,6 +244,15 @@ namespace Fusion.Resources.Api.Controllers
             if (!assignedPersonProfile?.FullDepartment?.Equals(departmentString.FullDepartment, StringComparison.OrdinalIgnoreCase) == true)
                 return ApiErrors.InvalidInput($"The assigned resource does not belong to the department '{departmentString.FullDepartment}'");
 
+            // Verify the split has a location, or a non-null location is being proposed
+            var hasExistingLocation = position.Instances
+                .FirstOrDefault(i => i.Id == request.OrgPositionInstanceId)
+                ?.Location != null;
+            var isProposingLocation = request.ProposedChanges?.ContainsKey("location") ?? false;
+            var proposingNullLocation = isProposingLocation ? request.ProposedChanges?["location"] == null : false;
+            if ((!hasExistingLocation && !isProposingLocation) || proposingNullLocation)
+                return ApiErrors.InvalidInput("Location is required");
+
             // Check if change requests are disabled.
             // This is mainly relevant when there is a mix of projects synced FROM pims and some TO pims.
             // Change requests are only enabled on projects that have pims write sync enabled for now.
@@ -404,8 +413,14 @@ namespace Fusion.Resources.Api.Controllers
                 return ApiErrors.InvalidOperation("request-completed", "Cannot change a completed request.");
             if (HasChanged(request.AdditionalNote, item.AdditionalNote))
                 return ApiErrors.InvalidInput("Only task owners can modify additional notes.");
-            if (item?.OrgPositionInstance?.Location is null && !(request.ProposedChanges.Value?.ContainsKey("location") ?? false))
-                return ApiErrors.InvalidInput("Location is required.");
+            // Verify the split has a location, or a non-null location is being proposed
+            var hasExistingLocation = item.OrgPosition!.Instances
+                .FirstOrDefault(i => i.Id == item.OrgPositionInstanceId)
+                ?.Location != null;
+            var isProposingLocation = request.ProposedChanges.Value?.ContainsKey("location") ?? false;
+            var proposingNullLocation = isProposingLocation ? request.ProposedChanges.Value?["location"] == null : false;
+            if ((!hasExistingLocation && !isProposingLocation) || proposingNullLocation)
+                return ApiErrors.InvalidInput("Location is required");
 
             #region Authorization
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -453,7 +453,7 @@ namespace Fusion.Resources.Api.Controllers
 
                 if (request.AdditionalNote.HasValue) updateCommand.AdditionalNote = request.AdditionalNote.Value;
                 if (request.AssignedDepartment.HasValue) updateCommand.AssignedDepartment = request.AssignedDepartment.Value;
-                if (request.ProposedChanges?.HasValue ?? false) updateCommand.ProposedChanges = request.ProposedChanges.Value;
+                if (request.ProposedChanges.HasValue) updateCommand.ProposedChanges = request.ProposedChanges.Value;
                 if (request.Properties.HasValue) updateCommand.Properties = request.Properties.Value;
 
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -144,7 +144,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var actor = fixture.AddProfile(FusionAccountType.Employee);
             SetupManagerRole(role, actor, department);
-            
+
             using var userScope = fixture.UserScope(actor);
 
             var client = fixture.ApiFactory.CreateClient();
@@ -168,7 +168,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var actor = fixture.AddProfile(FusionAccountType.Employee);
             SetupManagerRole(role, actor, department);
-            
+
             using var userScope = fixture.UserScope(actor);
 
             var client = fixture.ApiFactory.CreateClient();
@@ -494,7 +494,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
         [InlineData(ActorType.Manager, ManagerRoleType.ResourceOwner, ParentDepartment, true)]
         [InlineData(ActorType.Manager, ManagerRoleType.ResourceOwner, SameL2Department, true)]
         // This should be reconsidered. Just being the creator should not give you any additional access, as roles can be changed.
-        [InlineData(ActorType.RequestCreator, ManagerRoleType.None, TestDepartment, true)]  
+        [InlineData(ActorType.RequestCreator, ManagerRoleType.None, TestDepartment, true)]
         [InlineData(ActorType.TaskOwner, ManagerRoleType.None, TestDepartment, false)]
         [InlineData(ActorType.Manager, ManagerRoleType.DelegatedResourceOwner, ExactScope, true)]
         [InlineData(ActorType.Manager, ManagerRoleType.DelegatedResourceOwner, WildcardScope, true)]
@@ -516,7 +516,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             {
                 ActorType.Manager => fixture.AddProfile(FusionAccountType.Employee),
                 ActorType.TaskOwner => Users["taskOwner"],
-                ActorType.RequestCreator=> Users["resourceOwnerCreator"],
+                ActorType.RequestCreator => Users["resourceOwnerCreator"],
                 _ => throw new NotSupportedException("Unsupported actor type")
             };
             SetupManagerRole(role, actor, department);
@@ -549,7 +549,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             // Create the actor we want to confirm permissions for
             var testUser = fixture.AddProfile(FusionAccountType.Employee);
             SetupManagerRole(role, testUser, department);
-            
+
             using var userScope = fixture.UserScope(testUser);
 
             var result = await client.TestClientPostAsync<TestAbsence>(
@@ -658,7 +658,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
             else result.Should().BeUnauthorized();
         }
 
-        public enum AbsenceAccessLevel{ None, All, Limited, OtherTasksOnly }
+        public enum AbsenceAccessLevel { None, All, Limited, OtherTasksOnly }
         [Theory]
         [InlineData(FusionAccountType.Employee, ManagerRoleType.ResourceOwner, TestDepartment, AbsenceAccessLevel.All)]
         [InlineData(FusionAccountType.Employee, ManagerRoleType.ResourceOwner, SiblingDepartment, AbsenceAccessLevel.All)]
@@ -836,7 +836,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
 
             var actor = fixture.AddProfile(FusionAccountType.Employee);
             SetupManagerRole(role, actor, department);
-            
+
             using var userScope = fixture.UserScope(actor);
             var client = fixture.ApiFactory.CreateClient();
 
@@ -863,7 +863,8 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 appliesTo = DateTime.Today.AddDays(10),
                 comment = "A comment",
                 type = "absence",
-                absencePercentage = 100
+                absencePercentage = 100,
+                // TaskDetails = new TestTaskDetails() { Location = "Top secret location", TaskName = "Top secret task name" }
             });
 
             return result.Value;
@@ -886,7 +887,8 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 comment = "A comment",
                 type = "otherTasks",
                 absencePercentage = 100,
-                isPrivate = isPrivate
+                isPrivate = isPrivate,
+                TaskDetails = new TestTaskDetails() { Location = "Top secret location", RoleName = "Top secret role name" },
             });
 
             return result.Value;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/AuthorizationTests/SecurityMatrixTests.cs
@@ -863,8 +863,7 @@ namespace Fusion.Resources.Api.Tests.AuthorizationTests
                 appliesTo = DateTime.Today.AddDays(10),
                 comment = "A comment",
                 type = "absence",
-                absencePercentage = 100,
-                // TaskDetails = new TestTaskDetails() { Location = "Top secret location", TaskName = "Top secret task name" }
+                absencePercentage = 100
             });
 
             return result.Value;

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/ApiHelpers.cs
@@ -287,6 +287,7 @@ namespace Fusion.Resources.Api.Tests
             payload.TaskDetails = new Faker<TestTaskDetails>()
                 .RuleFor(x => x.TaskName, f => f.Company.CatchPhrase())
                 .RuleFor(x => x.RoleName, f => f.Company.CatchPhrase())
+                .RuleFor(x => x.Location, f => f.Address.City())
                 .Generate();
 
             setup?.Invoke(payload);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Fusion.Services.LineOrg.ApiModels;
+using Newtonsoft.Json.Linq;
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
@@ -927,6 +928,39 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var result = response.Value.value.FirstOrDefault(x => x.azureUniquePersonId == user.AzureUniqueId);
             result.Should().NotBeNull();
             result!.pendingRequests.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task CreateChangeRequest_ShouldFail_WhenRemovingLocation()
+        {
+            using var adminScope = fixture.AdminScope();
+            var request = await Client.CreateDefaultRequestAsync(testProject, positionSetup: pos => pos.WithInstances(x =>
+            {
+                x.AddInstance(new DateTime(2020, 03, 02), TimeSpan.FromDays(15));
+            }));
+            await Client.AssignDepartmentAsync(request.Id, user.FullDepartment);
+            await Client.ProposePersonAsync(request.Id, user);
+            await Client.StartProjectRequestAsync(testProject, request.Id);
+
+            await Client.ResourceOwnerApproveAsync(user.Department, request.Id);
+            await Client.TaskOwnerApproveAsync(testProject, request.Id);
+            await Client.ProvisionRequestAsync(request.Id);
+
+            var payload = JObject.FromObject(new
+            {
+                type = "ResourceOwnerChange",
+                subtype = "adjustment",
+                orgPositionId = request.OrgPositionId,
+                orgPositionInstanceId = request.OrgPositionInstanceId,
+                proposedChanges = new Dictionary<string, object>
+                {
+                    ["location"] = null
+                }
+            });
+
+            var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>(
+                    $"departments/{user.FullDepartment}/resources/requests", payload);
+            response.Should().BeBadRequest();
         }
 
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -64,7 +64,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             testRequest = await adminClient.AssignRandomDepartmentAsync(testRequest.Id);
 
             // Should either create or fetch existing org unit.
-            assignedOrgUnit = fixture.AddOrgUnit(testRequest.AssignedDepartment); 
+            assignedOrgUnit = fixture.AddOrgUnit(testRequest.AssignedDepartment);
 
         }
 
@@ -494,6 +494,11 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             {
                 x.AppliesFrom = new DateTime(2020, 03, 01);
                 x.AppliesTo = new DateTime(2020, 04, 15);
+                x.TaskDetails = new TestTaskDetails()
+                {
+                    RoleName = "TestRole",
+                    Location = "Norway",
+                };
             });
             var absence = absenceResp.Value;
 
@@ -517,7 +522,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task GetTimeline_ShouldSupportSAPId()
         {
             using var adminScope = fixture.AdminScope();
-           
+
             var timelineStart = new DateTime(2020, 03, 01);
             var timelineEnd = new DateTime(2020, 03, 31);
 
@@ -556,7 +561,13 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                     x.AppliesFrom = new DateTime(2020, 03, 01);
                     x.AppliesTo = new DateTime(2020, 04, 15);
                     x.IsPrivate = true;
+                    x.TaskDetails = new TestTaskDetails()
+                    {
+                        RoleName = "TestRole",
+                        Location = "Norway",
+                    };
                 });
+                absenceResp.Should().BeSuccessfull();
                 absence = absenceResp.Value;
             }
 
@@ -597,7 +608,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .WithPositions(10, 50)
                 .AddToMockService();
 
-            var profile = fixture.AddProfile(s => {
+            var profile = fixture.AddProfile(s =>
+            {
                 s.WithFullDepartment(department);
                 s.WithPositions(project.Positions);
             });
@@ -627,6 +639,11 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                                           {
                                               x.AppliesFrom = new DateTime(2021, 08, 06);
                                               x.AppliesTo = new DateTime(2021, 09, 03);
+                                              x.TaskDetails = new TestTaskDetails()
+                                              {
+                                                  RoleName = "TestRole",
+                                                  Location = "Norway",
+                                              };
                                           });
 
             var timelineStart = new DateTime(2022, 04, 01);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
@@ -17,7 +17,7 @@ using Fusion.Testing.Mocks.ProfileService;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
-#nullable enable 
+#nullable enable
 
 namespace Fusion.Resources.Api.Tests.IntegrationTests
 {
@@ -74,7 +74,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .AddToMockService();
 
             taskOwnerPosition = testProject.AddPosition().WithAssignedPerson(testUser);
-            requestPosition = testProject.AddPosition().WithAssignedPerson(requestAssignedPerson).WithTaskOwner(taskOwnerPosition.Id);
+            requestPosition = testProject.AddPosition().WithAssignedPerson(requestAssignedPerson).WithTaskOwner(taskOwnerPosition.Id).WithLocation();
             testProject.SetTaskOwner(requestPosition.Id, taskOwnerPosition.Id);
             // Prepare context resolver.
             fixture.ContextResolver
@@ -109,7 +109,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var notificationsForRequest = NotificationClientMock.SentMessages.GetNotificationsForRequestId(request.Id);
             notificationsForRequest.Count.Should().BeGreaterOrEqualTo(1);
         }
-       
+
         [Fact]
         public async Task DirectRequest_StartWorkFlow_ShouldNotify()
         {
@@ -184,7 +184,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var creator = response.Value.CreatedBy.AzureUniquePersonId.ToString();
             var taskOwner = normalRequest.TaskOwner!.Persons!.First().AzureUniquePersonId.ToString();
 
-            TestLogger.TryLog($"{JsonConvert.SerializeObject(new { creator, taskOwner, response.Value})}");
+            TestLogger.TryLog($"{JsonConvert.SerializeObject(new { creator, taskOwner, response.Value })}");
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
 
             var notificationsForRequest = NotificationClientMock.SentMessages.GetNotificationsForRequestId(normalRequest.Id);

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -844,7 +844,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             {
                 proposedChanges = new Dictionary<string, object>
                 {
-                    ["location"] = "Top Secret Location"
+                    ["location"] = new { name = "Top Secret Location" },
                 }
             });
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -820,6 +821,35 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             response.Should().BeSuccessfull();
             NotificationClientMock.SentMessages.Count.Should().BeGreaterThan(0);
             NotificationClientMock.SentMessages.Count(x => x.PersonIdentifier == $"{fakeResourceOwner.AzureUniqueId}").Should().Be(1);
+        }
+
+        [Fact]
+        public async Task UpdateRequest_ShouldFail_WhenNoLocationOnInstanceOrProsposedChanges()
+        {
+            const string department = "JHA HRA BAR";
+            using var adminScope = fixture.AdminScope();
+            var request = await Client.CreateDefaultRequestAsync(testProject, null, position => position.Instances.ForEach(instance => instance.Location = null));
+            var payload = new JObject { { "assignedDepartment", JToken.FromObject(department) } };
+
+            var response = await Client.TestClientPatchAsync<JObject>($"/resources/requests/internal/{request.Id}", payload);
+            response.Should().BeBadRequest();
+        }
+
+        [Fact]
+        public async Task UpdateRequest_ShouldSucceed_WhenLocationOnlyOnProposedChanges()
+        {
+            using var adminScope = fixture.AdminScope();
+            var request = await Client.CreateDefaultRequestAsync(testProject, null, position => position.Instances.ForEach(instance => instance.Location = null));
+            var payload = JObject.FromObject(new
+            {
+                proposedChanges = new Dictionary<string, object>
+                {
+                    ["location"] = "Top Secret Location"
+                }
+            });
+
+            var response = await Client.TestClientPatchAsync<TestApiInternalRequestModel>($"/resources/requests/internal/{request.Id}", payload);
+            response.Should().BeSuccessfull();
         }
 
         [Theory]

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/ApiPositionV2Extensions.cs
@@ -141,6 +141,18 @@ namespace Fusion.Testing.Mocks.OrgService
             position.Instances.ForEach(i => i.AddTaskOwner(parentPoisitionId));
             return position;
         }
+
+        public static ApiPositionV2 WithLocation(this ApiPositionV2 position)
+        {
+            var faker = new Bogus.Faker();
+            position.Instances.ForEach(i => i.Location = new ApiPositionLocationV2
+            {
+                Name = faker.Address.City(),
+                Country = faker.Address.Country(),
+                Code = faker.Address.CountryCode()
+            });
+            return position;
+        }
     }
 
 }

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/PositionInstanceBuilder.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Helpers/PositionInstanceBuilder.cs
@@ -65,7 +65,14 @@ namespace Fusion.Testing.Mocks.OrgService
                 .RuleFor(i => i.Id, f => Guid.NewGuid())
                 .RuleFor(i => i.ExternalId, f => f.Random.AlphaNumeric(3))
                 .RuleFor(i => i.Calendar, f => "Normal")
-                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100));
+                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100))
+                .RuleFor(i => i.Location, f => new ApiPositionLocationV2()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = f.Address.City(),
+                    Country = f.Address.Country(),
+                    Code = f.Address.CountryCode()
+                });
 
             var instances = faker.Generate(count);
 
@@ -92,7 +99,14 @@ namespace Fusion.Testing.Mocks.OrgService
                 .RuleFor(i => i.Id, f => Guid.NewGuid())
                 .RuleFor(i => i.ExternalId, f => f.Random.AlphaNumeric(3))
                 .RuleFor(i => i.Calendar, f => "Normal")
-                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100));
+                .RuleFor(i => i.Workload, f => f.Random.Double(0, 100))
+                .RuleFor(i => i.Location, f => new ApiPositionLocationV2()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = f.Address.City(),
+                    Country = f.Address.Country(),
+                    Code = f.Address.CountryCode()
+                });
         }
 
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**

Added location requirement to validation of CreatePersonAbsenceRequest and UpdatePersonAbsenceRequest for absences of type `OtherTasks`.

Added the method `LocationWillBeNull` to the `InternalRequestsController` class to check that a location will be set for the following endpoints:
- [HttpPost("/departments/{departmentString}/resources/requests")]
- [HttpPatch("/resources/requests/internal/{requestId}")]
- [HttpPatch("/departments/{departmentString}/resources/requests/{requestId}")]

The logic is a little complicated, it needs to ensure that after changes will have been applied the request will have a valid location. It needs to take into account whether the request already has a position, if a location is being proposed, and that the proposed location isn't null, i.e. removing an existing location. 

Tests were updated to have a location by default to not cause errors in other existing tests, and tests for the changes were added.

Work Item: [AB#61121](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/61121)

See frontend pr: https://github.com/equinor/fusion-resource-allocation-apps/pull/897

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
