### PR TITLE
chore(deps): Update dependencies in Summary api and Resources Api

### DIFF
--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -14,7 +14,6 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0"/>
-		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0"/>
 		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.1.0"/>
         <PackageReference Include="MediatR" Version="12.4.1"/>
@@ -23,6 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.13"/>
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2"/>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2"/>
+		<PackageReference Include="SharpGrip.FluentValidation.AutoValidation.Mvc" Version="1.5.0"/>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
+++ b/src/Fusion.Summary.Api/Fusion.Summary.Api.csproj
@@ -13,33 +13,17 @@
     
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2"/>
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0"/>
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0"/>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0"/>
-        <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
-        <PackageReference Include="Fusion.AspNetCore.FluentAuthorization" Version="8.0.1"/>
-		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.0.6"/>
-		<PackageReference Include="Fusion.Integration" Version="8.0.8"/>
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0"/>
+		<PackageReference Include="Fusion.Infrastructure.Database" Version="8.1.0"/>
         <PackageReference Include="MediatR" Version="12.4.1"/>
-		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0"/>
-		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.13"/>
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0"/>
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.13"/>
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Fusion.Summary.Api/Program.cs
+++ b/src/Fusion.Summary.Api/Program.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using FluentValidation;
-using FluentValidation.AspNetCore;
 using Fusion.AspNetCore.Versioning;
 using Fusion.Resources.Api.Middleware;
 using Fusion.Summary.Api;
@@ -11,6 +10,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SharpGrip.FluentValidation.AutoValidation.Mvc.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +30,11 @@ var environment = builder.Configuration["Environment"] ?? "Development";
 var fusionEnvironment = builder.Configuration["FUSION_ENVIRONMENT"] ?? "ci";
 var databaseConnectionString = builder.Configuration.GetConnectionString(nameof(SummaryDbContext))!;
 
+builder.Services.AddFluentValidationAutoValidation(c =>
+{
+    c.EnablePathBindingSourceAutomaticValidation = true;
+    c.EnableFormBindingSourceAutomaticValidation = true;
+});
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddHealthChecks()
@@ -74,7 +79,13 @@ builder.Services.AddSqlDbContext<SummaryDbContext>(databaseConnectionString)
     .AddSqlTokenProvider<SqlTokenProvider>()
     .AddAccessTokenSupport();
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
-builder.Services.AddFluentValidationAutoValidation().AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.AddFluentValidationAutoValidation(c =>
+{
+    c.EnablePathBindingSourceAutomaticValidation = true;
+    c.EnableFormBindingSourceAutomaticValidation = true;
+});
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
 
 var app = builder.Build();
 app.UseCors(opts => opts

--- a/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
+++ b/src/backend/Fusion.Resources.Authorization/Fusion.Resources.Authorization.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.10"/>
+    <PackageReference Include="Fusion.Integration.Authorization" Version="8.2.3"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\api\Fusion.Resources.Database\Fusion.Resources.Database.csproj" />

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
-        <PackageReference Include="Fusion.Integration.Authorization" Version="8.0.10"/>
+        <PackageReference Include="Fusion.Integration.Authorization" Version="8.3.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>
-        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="6.9.0"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="6.9.0"/>
-        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="6.9.0"/>
+        <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="7.3.1"/>
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1"/>
+        <PackageReference Include="swashbuckle.AspNetCore.SwaggerUi" Version="7.3.1"/>
     </ItemGroup>
     
 

--- a/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
+++ b/src/backend/Fusion.Resources.Infrastructure/Fusion.Resources.Infrastructure.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
         <PackageReference Include="Fusion.AspNetCore.Versioning" Version="8.1.0"/>
-        <PackageReference Include="Fusion.Integration.Authorization" Version="8.3.0"/>
+        <PackageReference Include="Fusion.Integration.Authorization" Version="8.2.3"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2"/>
         <PackageReference Include="swashbuckle.AspNetCore.Swagger" Version="7.3.1"/>
         <PackageReference Include="swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1"/>

--- a/src/backend/api/Fusion.Resources.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Configuration/IServiceCollectionExtensions.cs
@@ -44,28 +44,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
         }
-
-        public static IServiceCollection AddLineOrgHttpClient(this IServiceCollection services)
-        {
-            services.AddFusionIntegrationHttpClient("lineorg", o =>
-            {
-                o.EndpointResolver = (sp) =>
-                {
-                    var intgConfig = sp.GetRequiredService<IOptions<FusionIntegrationOptions>>();
-                    var fusionEnv = intgConfig.Value.ServiceDiscovery?.Environment ?? "ci";
-                    
-                    if (fusionEnv.Equals("fprd", StringComparison.OrdinalIgnoreCase))
-                        return Task.FromResult("https://lineorg.api.fusion.equinor.com");
-                    return Task.FromResult($"https://lineorg.{fusionEnv}.api.fusion-dev.net");
-                };
-
-                // Bug, must be specified
-                o.Uri = new Uri("https://fusion-s-lineorg-.azurewebsits.net");
-
-                //o.Resource 
-            });
-
-            return services;
-        }
+        
     }
 }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Utilities/UtilitiesController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Utilities/UtilitiesController.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Fusion.Resources.Api.Controllers.Utilities
 {
@@ -21,13 +22,15 @@ namespace Fusion.Resources.Api.Controllers.Utilities
         private readonly IHttpClientFactory httpClientFactory;
         private readonly IFusionTokenProvider tokenProvider;
         private readonly IOptions<FusionIntegrationOptions> fusionOptions;
+        private readonly string clientId;
 
         public UtilitiesController(IHttpClientFactory httpClientFactory, IFusionTokenProvider tokenProvider,
-            IOptions<FusionIntegrationOptions> fusionOptions)
+            IOptions<FusionIntegrationOptions> fusionOptions, IConfiguration configuration)
         {
             this.httpClientFactory = httpClientFactory;
             this.tokenProvider = tokenProvider;
             this.fusionOptions = fusionOptions;
+            clientId = configuration["AzureAd:ClientId"]!;
         }
 
         [HttpPost("/utilities/parse-spreadsheet")]
@@ -38,7 +41,7 @@ namespace Fusion.Resources.Api.Controllers.Utilities
                 return FusionApiError.InvalidOperation("MissingBody", "Could not locate any body payload");
 
             var url = $"https://pro-f-utility-{fusionOptions.Value.ServiceDiscovery.Environment}.azurewebsites.net";
-            var token = await tokenProvider.GetApplicationTokenAsync();
+            var token = await tokenProvider.GetApplicationTokenAsync(clientId);
             var client = httpClientFactory.CreateClient();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
             client.BaseAddress = new Uri(url);

--- a/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
+++ b/src/backend/api/Fusion.Resources.Api/Fusion.Resources.Api.csproj
@@ -18,27 +18,15 @@
   
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
-    <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Fusion.Infrastructure.MediatR" Version="8.0.4" />
-    <PackageReference Include="Fusion.Integration" Version="8.0.8" />
-    <PackageReference Include="Fusion.Events.Client" Version="8.1.1" />
-    <PackageReference Include="Fusion.Events.Server" Version="8.0.4" />
-    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.7" />
-    <PackageReference Include="Fusion.Integration.Org" Version="8.0.9" />
-    <PackageReference Include="Fusion.Integration.Roles" Version="8.0.9" />
-    <PackageReference Include="Fusion.Integration.Notification" Version="8.0.8" />
-    <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="JSM.FluentValidation.AspNet.AsyncFilter" Version="2.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0"/>
+    <PackageReference Include="Fusion.Infrastructure.MediatR" Version="8.1.2"/>
+    <PackageReference Include="Fusion.Events.Client" Version="8.1.2"/>
+    <PackageReference Include="Fusion.Events.Server" Version="8.0.7"/>
+    <PackageReference Include="Fusion.Integration.Roles" Version="8.2.2"/>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.13"/>
+    <PackageReference Include="SharpGrip.FluentValidation.AutoValidation.Mvc" Version="1.5.0"/>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="TimePeriodCore" Version="1.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using FluentValidation.AspNetCore;
 using Fusion.Events;
 using Fusion.Integration.Authentication;
 using Fusion.Integration.LineOrg;
@@ -8,10 +7,7 @@ using Fusion.Resources.Api.Authentication;
 using Fusion.Resources.Api.HostedServices;
 using Fusion.Resources.Api.Middleware;
 using Fusion.Resources.Domain;
-using Fusion.Resources.Domain.Commands;
 using Fusion.Resources.Logic;
-using JSM.FluentValidation.AspNet.AsyncFilter;
-using MediatR;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -21,9 +17,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using SixLabors.ImageSharp;
-using System.Reflection;
 using Fusion.AspNetCore.Versioning;
+using SharpGrip.FluentValidation.AutoValidation.Mvc.Extensions;
 
 namespace Fusion.Resources.Api
 {
@@ -117,9 +112,14 @@ namespace Fusion.Resources.Api
 
             services.AddOrgApiClient(OrgConstants.HttpClients.Application, OrgConstants.HttpClients.Delegate);
 
-            services.AddControllers()
-                .AddModelValidationAsyncActionFilter();
-            
+            services.AddFluentValidationAutoValidation(c =>
+            {
+                c.EnablePathBindingSourceAutomaticValidation = true;
+                c.EnableFormBindingSourceAutomaticValidation = true;
+            });
+
+            services.AddControllers();
+
             // Keeping for reference - The validator is not added to the .net core validation pipeline. This is due to limitations in running async 
             // validators. This is required to validate against external requirements, e.g. position exists.
             // The validation is executed by an action attribute filter, added by ".AddModelValidationAsyncActionFilter()". 

--- a/src/backend/api/Fusion.Resources.Api/Startup.cs
+++ b/src/backend/api/Fusion.Resources.Api/Startup.cs
@@ -120,20 +120,6 @@ namespace Fusion.Resources.Api
 
             services.AddControllers();
 
-            // Keeping for reference - The validator is not added to the .net core validation pipeline. This is due to limitations in running async 
-            // validators. This is required to validate against external requirements, e.g. position exists.
-            // The validation is executed by an action attribute filter, added by ".AddModelValidationAsyncActionFilter()". 
-            // This logic is provided by the nuget library 'JSM.FluentValidation.AspNet.AsyncFilter'.
-
-            //.AddFluentValidation(c =>
-            //{
-            //    c.RegisterValidatorsFromAssemblyContaining<Startup>();
-            //    // Domain project
-            //    c.RegisterValidatorsFromAssemblyContaining<PersonId>();
-            //    // Logic project, where ResourceAllocationRequest having validators
-            //    c.RegisterValidatorsFromAssemblyContaining<Logic.Commands.ResourceAllocationRequest>();
-            //});
-
             services.AddValidatorsFromAssemblyContaining<Startup>(ServiceLifetime.Transient);
             services.AddValidatorsFromAssemblyContaining<PersonId>(ServiceLifetime.Transient);
             services.AddValidatorsFromAssemblyContaining<Logic.Commands.ResourceAllocationRequest>(ServiceLifetime.Transient);

--- a/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
+++ b/src/backend/api/Fusion.Resources.Application/Fusion.Resources.Application.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2"/>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.4"/>
     <PackageReference Include="Fusion.Integration.Profile" Version="8.0.7"/>
     <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.7"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.2"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2"/>
 
   </ItemGroup>
 

--- a/src/backend/api/Fusion.Resources.Application/LineOrg/LineOrgClient.cs
+++ b/src/backend/api/Fusion.Resources.Application/LineOrg/LineOrgClient.cs
@@ -56,7 +56,7 @@ namespace Fusion.Resources.Application.LineOrg
             }
 
             var json = await resp.Content.ReadAsStringAsync();
-            var orgUnits = JsonConvert.DeserializeAnonymousType(json, new { value = new List<ApiOrgUnit>() });
+            var orgUnits = JsonConvert.DeserializeAnonymousType(json, new { value = new List<ApiOrgUnit>() })!;
 
             memoryCache.Set(OrgUnitsMemCacheKey, orgUnits.value, TimeSpan.FromMinutes(60));
 

--- a/src/backend/api/Fusion.Resources.Database/Authentication/AzureTokenAuthenticationManager.cs
+++ b/src/backend/api/Fusion.Resources.Database/Authentication/AzureTokenAuthenticationManager.cs
@@ -25,7 +25,8 @@ namespace Fusion.Resources.Database.Authentication
             this.tokenProvider = tokenProvider;
             this.configuration = configuration;
 
-            this.connectionString = configuration.GetConnectionString(nameof(ResourcesDbContext));
+            this.connectionString = configuration.GetConnectionString(nameof(ResourcesDbContext))
+                                    ?? throw new InvalidOperationException($"Missing connection string for {nameof(ResourcesDbContext)}");
 
             if (!Enum.TryParse<ConnectionMode>(configuration["Database:ConnectionMode"], true, out ConnectionMode mode))
                 mode = ConnectionMode.Default;

--- a/src/backend/api/Fusion.Resources.Database/Configuration/DatabaseConfigurationExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Database/Configuration/DatabaseConfigurationExtensions.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddResourceDatabase<TTokenProvider>(this IServiceCollection services, IConfiguration configuration)
             where TTokenProvider : class, ISqlTokenProvider
         {
-            var connectionString = configuration.GetConnectionString(nameof(ResourcesDbContext));
-
             string migrationAssemblyName = Assembly.GetExecutingAssembly().FullName!;
 
             services.AddDbContext<ResourcesDbContext>(options => {
@@ -37,12 +35,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ISqlTokenProvider, TTokenProvider>();
 
             return services;
-        }
-
-        public static DbContextOptionsBuilder UseSqlServer(this DbContextOptionsBuilder optionsBuilder, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
-        {
-            sqlServerOptionsAction?.Invoke(new SqlServerDbContextOptionsBuilder(optionsBuilder));
-            return optionsBuilder;
         }
     }
 }

--- a/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
+++ b/src/backend/api/Fusion.Resources.Database/Fusion.Resources.Database.csproj
@@ -7,14 +7,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2"/>
   </ItemGroup>
 
 </Project>

--- a/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
+++ b/src/backend/api/Fusion.Resources.Domain/Fusion.Resources.Domain.csproj
@@ -6,15 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fusion.Integration.LineOrg" Version="8.0.7"/>
-    <PackageReference Include="Fusion.Integration.Notification" Version="8.0.8"/>
+    <PackageReference Include="Fusion.Integration.Notification" Version="8.3.0"/>
     <PackageReference Include="MediatR" Version="12.4.1"/>
-    <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
+    <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
     <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4"/>
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
-    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.8"/>
-    <PackageReference Include="Fusion.Integration.Roles.Abstractions" Version="8.0.9"/>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Fusion.Integration.Org" Version="8.2.2"/>
+    <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.1.0"/>
+    <PackageReference Include="Fusion.Integration.Roles.Abstractions" Version="8.2.1"/>
 
     <PackageReference Include="TimePeriodCore" Version="1.0.0" />
 

--- a/src/backend/api/Fusion.Resources.Logic/Fusion.Resources.Logic.csproj
+++ b/src/backend/api/Fusion.Resources.Logic/Fusion.Resources.Logic.csproj
@@ -11,9 +11,5 @@
     <ProjectReference Include="..\Fusion.Resources.Database\Fusion.Resources.Database.csproj" />
     <ProjectReference Include="..\Fusion.Resources.Domain\Fusion.Resources.Domain.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Configuration\" />
-  </ItemGroup>
 
 </Project>

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Fusion.Resources.Api.Tests.csproj
@@ -21,18 +21,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-      <PackageReference Include="xunit" Version="2.9.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageReference Include="xunit" Version="2.9.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10"/>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/EventNotificationClientMock.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/FusionMocks/EventNotificationClientMock.cs
@@ -10,8 +10,7 @@ using System.Threading.Tasks;
 
 namespace Fusion.Resources.Api.Tests.FusionMocks
 {
-
-    public class FakeNotificationTransaction : IEventNotificationTransaction
+    public sealed class FakeNotificationTransaction : IEventNotificationTransaction
     {
         public Task CommitAsync(CancellationToken cancellationToken = default)
         {
@@ -32,6 +31,10 @@ namespace Fusion.Resources.Api.Tests.FusionMocks
         {
             return Task.CompletedTask;
         }
+
+        public void Dispose()
+        {
+        }
     }
 
     public class EventNotificationClientMock : IEventNotificationClient
@@ -51,10 +54,31 @@ namespace Fusion.Resources.Api.Tests.FusionMocks
 
         public Task<IEventNotificationTransaction> BeginTransactionAsync() => Task.FromResult<IEventNotificationTransaction>(new FakeNotificationTransaction());
 
+        public Task SendScheduledNotificationAsync<T>(FusionEventType type, T payload, string eventId, TimeSpan? delay = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task SendNotificationAsync<T>(FusionEventType type, T payload) => SendNotificationAsync(type, payload, $"{Guid.NewGuid()}");
+
+        public Task SendScheduledNotificationAsync<T>(FusionEventType type, T payload, TimeSpan? delay = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task SendNotificationAsync<T>(FusionEventType type, T payload, string eventId) => DispatchNotification(type, null, payload, null, eventId);
 
         public Task SendNotificationAsync<T>(FusionEvent<T> @event) => DispatchNotification(@event.Type, @event.Category, @event.Payload, @event.AppContext, @event.EventId);
+
+        public Task SendScheduledNotificationAsync<T>(FusionEvent<T> @event, TimeSpan? delay = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SendScheduledNotificationAsync(IEnumerable<FusionEvent> events, TimeSpan? delay = null)
+        {
+            throw new NotImplementedException();
+        }
 
         public Task SendNotificationAsync<T>(FusionEventType type, T payload, Action<FusionEvent<T>> setup)
         {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationNotificationTests.cs
@@ -9,6 +9,7 @@ using Fusion.Integration.Profile;
 using Fusion.Integration.Profile.ApiClient;
 using Fusion.Resources.Api.Tests.Fixture;
 using Fusion.Resources.Api.Tests.FusionMocks;
+using Fusion.Resources.Domain;
 using Fusion.Testing;
 using Fusion.Testing.Mocks;
 using Fusion.Testing.Mocks.LineOrgService;
@@ -33,6 +34,9 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         ///     Will be generated new for each test
         /// </summary>
         private ApiPersonProfileV3 testUser = null!;
+
+        private ApiPersonProfileV3 testProposedUser = null!;
+        
         private readonly ApiPersonProfileV3 resourceOwnerPerson;
         private readonly ApiPersonProfileV3 requestAssignedPerson;
         private ApiPositionV2 taskOwnerPosition = null!;
@@ -68,6 +72,14 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         {
             // Mock profile
             testUser = fixture.AddResourceOwner(TestDepartmentId);
+            testProposedUser = fixture.AddProfile(person =>
+            {
+                var d = new DepartmentPath(TestDepartmentId);
+
+                person.WithFullDepartment(d);
+                person.WithDepartment(d.GetShortName());
+                person.WithAccountType(FusionAccountType.Employee);
+            });
 
             // Mock project
             testProject = new FusionTestProjectBuilder()
@@ -99,7 +111,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             var request = await Client.CreateRequestAsync(ProjectId, r => r
                 .AsTypeNormal()
                 .WithPosition(requestPosition)
-                .WithAssignedDepartment(testUser.FullDepartment!));
+                .WithAssignedDepartment(testProposedUser.FullDepartment!));
 
             await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{ProjectId}/requests/{request.Id}/start", null);
             await Client.TestClientDeleteAsync($"/resources/requests/internal/{request.Id}");
@@ -107,9 +119,9 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             TestLogger.TryLog($"{JsonConvert.SerializeObject(new { request })}");
             DumpNotificationsToLog(NotificationClientMock.SentMessages);
             var notificationsForRequest = NotificationClientMock.SentMessages.GetNotificationsForRequestId(request.Id);
-            notificationsForRequest.Count.Should().BeGreaterOrEqualTo(1);
+            notificationsForRequest.Count(x => x.PersonIdentifier == testUser.AzureUniqueId.ToString()).Should().BeGreaterOrEqualTo(1);
         }
-       
+
         [Fact]
         public async Task DirectRequest_StartWorkFlow_ShouldNotify()
         {
@@ -118,8 +130,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .AsTypeDirect()
                 .WithAdditionalNote("se separate description of tasks and skills for US IDM position.  The position should be an expatriate position until a suitable local candidate is available.   Task for US IDM.  Building an information management culture for wind projects in the US sector​  Establish new routines for information handling for new contract models, including handover to operations​  Establish a best practice for handling information and communication from stakeholders​  Networking to get to know American requirements, work culture and stakeholder management​  Ensure alignment and correct handling of information from permitting, stakeholder management and commercial disciplines​  Close collaboration with legal discipline to ensure correct handling of information with regards to local requirements​  Establish local IDM work processes for projects and operations​  Alignment with REN BD US​   Skillset .  Proven leadership experience and international experience​  Strong multi-discipline understanding​  Strong ability to identify the need for new processes, define requirements and, together with stakeholders, establish efficient solutions​  Methodical, analytical and structured problem solving​  Strong understanding of risk picture in the project and how this effects IDM deliveries​  Highly experienced in IDM​  Strong cultural collaboration skills​  Strong focus on good team collaboration and communication both with site team and home team​   Task on behalf of IDM home team.  Implement and follow-up information security and information management routines​  Solving ad-hoc issues regarding information security and information handling​  Emergency access management ​  Ensure alignment with the home team and PDC​  Ensure correct handling of authority communications​  Responsibility for follow up of site specific contract issues​  Training of internal and external personnel​  Hire and train local IDM resources​  Establish and maintain an archive for paper originals​  Leading by example​  Multi-discipline approach to the tasks​  ")
                 .WithPosition(requestPosition)
-                .WithProposedPerson(testUser)
-                .WithAssignedDepartment(testUser.FullDepartment!));
+                .WithProposedPerson(testProposedUser)
+                .WithAssignedDepartment(TestDepartmentId!));
 
 
             var response = await Client.TestClientPostAsync<TestApiInternalRequestModel>($"/projects/{ProjectId}/requests/{directRequest.Id}/start", null);

--- a/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Domain.Tests/Fusion.Resources.Domain.Tests.csproj
@@ -13,15 +13,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
-      <PackageReference Include="xunit" Version="2.9.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
+++ b/src/backend/tests/Fusion.Resources.Logic.Tests/Fusion.Resources.Logic.Tests.csproj
@@ -11,13 +11,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-      <PackageReference Include="xunit" Version="2.9.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+    <PackageReference Include="xunit" Version="2.9.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
+++ b/src/backend/tests/Fusion.Resources.Test.Core/Fusion.Resources.Test.Core.csproj
@@ -5,9 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.12.1"/>
       <PackageReference Include="Bogus" Version="35.6.1"/>
       <PackageReference Include="Moq" Version="4.20.72"/>
+
+      <!--   Due to license changes we cannot update past 7.x.x   -->
+      <PackageReference Include="FluentAssertions" Version="[6.12.2]" allowedVersions="[6.12.2]"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
+++ b/src/backend/tests/Fusion.Testing.Authentication/Fusion.Testing.Authentication.csproj
@@ -6,10 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.2.1"/>
     <PackageReference Include="Fusion.ApiClients.People" Version="8.0.1" />
-      <PackageReference Include="Fusion.Infrastructure.Authentication" Version="8.0.6"/>
+    <PackageReference Include="Fusion.Infrastructure.Authentication" Version="8.1.0"/>
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
+++ b/src/backend/tests/Fusion.Testing.Core/Fusion.Testing.Core.csproj
@@ -5,11 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />-->
-      <PackageReference Include="FluentAssertions" Version="6.12.1"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2"/>
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.2.1"/>
+
+    <!--   Due to license changes we cannot update past 7.x.x. Version 8.x.x and up requires paid license   -->
+    <PackageReference Include="FluentAssertions" Version="[6.12.2]" allowedVersions="[6.12.2]"/>
 
   </ItemGroup>
 

--- a/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ContextService/Fusion.Testing.Mocks.ContextService.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
-      <PackageReference Include="Fusion.Integration.Context" Version="8.0.7"/>
-      <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.0.7"/>
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
+      <PackageReference Include="Fusion.Integration.Context" Version="8.2.1"/>
+      <PackageReference Include="Fusion.Integration.Context.Abstractions" Version="8.1.0"/>
       <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4"/>
 
   </ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
@@ -7,6 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.2"/>
+		<PackageReference Include="Fusion.Events.Core" Version="8.0.2"/>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0"/>
 	</ItemGroup>

--- a/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/Fusion.Testing.Mocks.LineOrgService.csproj
@@ -6,9 +6,9 @@
 
 
 	<ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+		<PackageReference Include="Bogus" Version="35.6.2"/>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0"/>
 	</ItemGroup>
 
 

--- a/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/LineOrgServiceMock.cs
+++ b/src/backend/tests/Fusion.Testing.Mocks.LineOrgService/LineOrgServiceMock.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Net.Http;
+using Fusion.Hashing;
 using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
 namespace Fusion.Testing.Mocks.LineOrgService

--- a/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.OrgService/Fusion.Testing.Mocks.OrgService.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="Data\BasePositions.csv" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Remove="Data\BasePositions.csv"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Data\BasePositions.csv" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Data\BasePositions.csv"/>
+    </ItemGroup>
 
-  <ItemGroup>
-      <PackageReference Include="Bogus" Version="35.6.1"/>
-      <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.0.8"/>
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-      <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4"/>
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6"/>
-  </ItemGroup>
-  
+    <ItemGroup>
+        <PackageReference Include="Bogus" Version="35.6.2"/>
+        <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4"/>
+        <PackageReference Include="Fusion.Integration.Org.Abstractions" Version="8.1.0"/>
+        <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.2.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0"/>
+        <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
+    </ItemGroup>
+
 </Project>

--- a/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
+++ b/src/backend/tests/Fusion.Testing.Mocks.ProfileService/Fusion.Testing.Mocks.ProfileService.csproj
@@ -6,12 +6,12 @@
 
 
   <ItemGroup>
-      <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.0.6" />
-      <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.4" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+      <PackageReference Include="Bogus" Version="35.6.2"/>
+      <PackageReference Include="Fusion.ApiClients.Org" Version="8.0.5"/>
+      <PackageReference Include="Fusion.Integration.Profile.Abstractions" Version="8.2.1"/>
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-      <PackageReference Include="Fusion.AspNetCore" Version="8.0.6" />
+      <PackageReference Include="Fusion.AspNetCore" Version="8.0.8"/>
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.5" />
     <PackageReference Include="NetStandardHashLib" Version="1.0.0" />
 

--- a/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
+++ b/src/tests/Fusion.Summary.Api.Tests/Fusion.Summary.Api.Tests.csproj
@@ -22,8 +22,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Fusion.Testing" Version="8.0.1"/>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="Fusion.Testing" Version="8.0.2"/>
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -31,10 +31,11 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2"/>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
+		<PackageReference Include="xunit" Version="2.9.3"/>
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/tests/Fusion.Summary.Api.Tests/IntegrationTests/DepartmentTests.cs
+++ b/src/tests/Fusion.Summary.Api.Tests/IntegrationTests/DepartmentTests.cs
@@ -43,6 +43,22 @@ public class DepartmentTests : TestBase
         response.Should().BeSuccessfull();
     }
 
+    [Fact]
+    public async Task PutDepartment_EmptyName_ShouldBeBadRequest()
+    {
+        using var adminScope = _fixture.AdminScope();
+        var testUser = _fixture.Fusion.CreateUser().AsEmployee().AzureUniqueId!.Value;
+
+        var response = await _client.TestClientPutAsync<dynamic>($"departments/123124", new
+        {
+            resourceOwnersAzureUniqueId = new[] { testUser },
+            delegateResourceOwnersAzureUniqueId = new string[0],
+            fullDepartmentName = ""
+        });
+
+        response.Should().BeBadRequest();
+    }
+
 
     [Fact]
     public async Task PutDepartment_Then_UpdateOwner_ShouldBeSuccess()


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

Updates most dependencies to their latest version. Some werent updated due to not supporting .net 8. Fusion.Integration.Org (and Fusion.Integration.Authorization) was also held back as going to the latest version means deprecating our IOrgApiClient and updating our api models. This is a bigger task that should be done as a separate pr, but should be much easier now with these changes.

I've also tried to removed duplicate package references when possible.

**Testing:**
- [ ] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->

Tested that async fluent validators still works and are automatically run in mvc pipeline. I've also tested all steps of the request workflow except the actual provision step as that step is done by the az funcs.

Checked logs for PR instance in azure and no issues were found. Will also need to check logs in ci

To test in CI:

- Distributed events, event handlers
- provisioning step
- Resource owner and Task owner report summary notifications


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
