### PR TITLE
fix: api should not return null for project state

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/OrgProjectHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/OrgProjectHandler.cs
@@ -3,8 +3,6 @@ using Fusion.Integration.Org;
 using Fusion.Resources.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -61,7 +59,7 @@ namespace Fusion.Resources.Api
             {
                 existingProject.Name = orgProject.Name;
                 existingProject.DomainId = orgProject.DomainId;
-                existingProject.State = orgProject.State;
+                existingProject.State = orgProject.State ?? "ACTIVE";
 
                 await db.SaveChangesAsync(cancellationToken);
             }

--- a/src/backend/api/Fusion.Resources.Api/FusionEvents/OrgProjectHandler.cs
+++ b/src/backend/api/Fusion.Resources.Api/FusionEvents/OrgProjectHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Fusion.Events;
 using Fusion.Integration.Org;
 using Fusion.Resources.Database;
+using Fusion.Resources.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Threading;
@@ -59,7 +60,7 @@ namespace Fusion.Resources.Api
             {
                 existingProject.Name = orgProject.Name;
                 existingProject.DomainId = orgProject.DomainId;
-                existingProject.State = orgProject.State ?? "ACTIVE";
+                existingProject.State = orgProject.State.ResolveProjectState();
 
                 await db.SaveChangesAsync(cancellationToken);
             }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/BaseHandlers/ResponsibilityMatrixBaseHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/BaseHandlers/ResponsibilityMatrixBaseHandler.cs
@@ -46,7 +46,8 @@ namespace Fusion.Resources.Domain.Commands.BaseHandlers
                 Id = Guid.NewGuid(),
                 Name = orgProject.Name,
                 OrgProjectId = orgProject.ProjectId,
-                DomainId = orgProject.DomainId
+                DomainId = orgProject.DomainId,
+                State = orgProject.State ?? "ACTIVE",
             };
             return project;
         }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/BaseHandlers/ResponsibilityMatrixBaseHandler.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/BaseHandlers/ResponsibilityMatrixBaseHandler.cs
@@ -47,7 +47,7 @@ namespace Fusion.Resources.Domain.Commands.BaseHandlers
                 Name = orgProject.Name,
                 OrgProjectId = orgProject.ProjectId,
                 DomainId = orgProject.DomainId,
-                State = orgProject.State ?? "ACTIVE",
+                State = orgProject.State.ResolveProjectState(),
             };
             return project;
         }

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Projects/SyncProjectStates.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Projects/SyncProjectStates.cs
@@ -19,7 +19,7 @@ namespace Fusion.Resources.Domain.Commands
             OrgProjectIds = orgProjectIds;
             return this;
         }
-        
+
         public class Handler : IRequestHandler<SyncProjectStates>
         {
             private readonly ResourcesDbContext db;
@@ -43,7 +43,7 @@ namespace Fusion.Resources.Domain.Commands
 
                     if (orgProject is not null)
                     {
-                        project.State = orgProject.State;
+                        project.State = orgProject.State ?? "ACTIVE";
                     }
                 }
                 await db.SaveChangesAsync(cancellationToken);

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Projects/SyncProjectStates.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Projects/SyncProjectStates.cs
@@ -43,7 +43,7 @@ namespace Fusion.Resources.Domain.Commands
 
                     if (orgProject is not null)
                     {
-                        project.State = orgProject.State ?? "ACTIVE";
+                        project.State = orgProject.State.ResolveProjectState();
                     }
                 }
                 await db.SaveChangesAsync(cancellationToken);

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/CreateInternalRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/CreateInternalRequest.cs
@@ -209,7 +209,7 @@ namespace Fusion.Resources.Domain.Commands
                         Name = orgProject.Name,
                         OrgProjectId = orgProject.ProjectId,
                         DomainId = orgProject.DomainId,
-                        State = orgProject.State ?? "ACTIVE",
+                        State = orgProject.State.ResolveProjectState(),
                     };
 
                 return project;

--- a/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/CreateInternalRequest.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Commands/Requests/InternalRequests/CreateInternalRequest.cs
@@ -4,8 +4,6 @@ using Fusion.Integration.Org;
 using Fusion.Resources.Database;
 using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Domain.Queries;
-using Fusion.Services.LineOrg.ApiModels;
-using Fusion.Resources.Domain.Notifications.InternalRequests;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -94,7 +92,7 @@ namespace Fusion.Resources.Domain.Commands
                 var resolvedProject = await EnsureProjectAsync(request);
                 var position = await ResolveOrgPositionAsync(request);
                 var proposedPerson = await ResolveProposedPersonAsync(request);
-                
+
 
                 var instance = position.Instances.FirstOrDefault(i => i.Id == request.OrgPositionInstanceId);
                 if (instance is null)
@@ -210,7 +208,8 @@ namespace Fusion.Resources.Domain.Commands
                     {
                         Name = orgProject.Name,
                         OrgProjectId = orgProject.ProjectId,
-                        DomainId = orgProject.DomainId
+                        DomainId = orgProject.DomainId,
+                        State = orgProject.State ?? "ACTIVE",
                     };
 
                 return project;

--- a/src/backend/api/Fusion.Resources.Domain/Extensions/StringExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Extensions/StringExtensions.cs
@@ -1,0 +1,17 @@
+namespace Fusion.Resources.Domain
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Ensure the project state is valid. If the state is null or empty it should be set to active,
+        /// otherwise retain the passed in state.
+        /// </summary>
+        public static string ResolveProjectState(this string? state)
+        {
+            if (string.IsNullOrEmpty(state))
+                return "ACTIVE";
+
+            return state;
+        }
+    }
+}

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -29,6 +29,9 @@ namespace Fusion.Resources.Domain
         {
         }
 
+        /// This constructor will not treat state == null as the project's state being Active. The
+        /// project's data may be coming from sources other than the resources db and so resolving
+        /// the state is up to the callee.
         public QueryProjectRef(Guid orgId, string name, string domainId, string type, string? state)
         {
             OrgProjectId = orgId;

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -11,7 +11,7 @@ namespace Fusion.Resources.Domain
             Name = project.Name;
             DomainId = project.DomainId;
             OrgProjectId = project.OrgProjectId;
-            State = project.State ?? "ACTIVE";
+            State = project.State.ResolveProjectState();
         }
 
         public Guid Id { get; set; }
@@ -35,7 +35,7 @@ namespace Fusion.Resources.Domain
             Name = name;
             DomainId = domainId;
             Type = type;
-            State = state ?? "ACTIVE";
+            State = state.ResolveProjectState();
         }
         public string Name { get; set; }
         public string? DomainId { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -11,7 +11,7 @@ namespace Fusion.Resources.Domain
             Name = project.Name;
             DomainId = project.DomainId;
             OrgProjectId = project.OrgProjectId;
-            State = project.State;
+            State = project.State ?? "ACTIVE";
         }
 
         public Guid Id { get; set; }
@@ -35,7 +35,7 @@ namespace Fusion.Resources.Domain
             Name = name;
             DomainId = domainId;
             Type = type;
-            State = state;
+            State = state ?? "ACTIVE";
         }
         public string Name { get; set; }
         public string? DomainId { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Models/QueryProject.cs
@@ -35,7 +35,7 @@ namespace Fusion.Resources.Domain
             Name = name;
             DomainId = domainId;
             Type = type;
-            State = state.ResolveProjectState();
+            State = state;
         }
         public string Name { get; set; }
         public string? DomainId { get; set; }

--- a/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
+++ b/src/backend/api/Fusion.Resources.Domain/Queries/GetTBNPositions.cs
@@ -117,7 +117,7 @@ namespace Fusion.Resources.Domain.Queries
                     .Select(p => new { p.OrgProjectId, p.State })
                     .Where(p => orgProjectIds.Contains(p.OrgProjectId))
                     .AsNoTracking()
-                    .ToDictionaryAsync(p => p.OrgProjectId, p => p.State, cancellationToken: cancellationToken);
+                    .ToDictionaryAsync(p => p.OrgProjectId, p => p.State.ResolveProjectState(), cancellationToken: cancellationToken);
 
                 var apiModels = resp.Value.Select(p => new GetTbnPositionResult
                 {

--- a/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Responses/TestApiProjectReference.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/Helpers/Models/Responses/TestApiProjectReference.cs
@@ -8,6 +8,7 @@ namespace Fusion.Testing.Mocks
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = null!;
+        public string State { get; set; } = null!;
     }
 
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentRequestsTests.cs
@@ -64,7 +64,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
             testRequest = await adminClient.AssignRandomDepartmentAsync(testRequest.Id);
 
             // Should either create or fetch existing org unit.
-            assignedOrgUnit = fixture.AddOrgUnit(testRequest.AssignedDepartment); 
+            assignedOrgUnit = fixture.AddOrgUnit(testRequest.AssignedDepartment);
 
         }
 
@@ -154,6 +154,16 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 $"/departments/12312312399/resources/requests");
 
             response.Should().BeNotFound();
+        }
+
+        [Fact]
+        public async Task GetDepartmentRequests_ProjectsShouldHaveState()
+        {
+            using var adminScope = fixture.AdminScope();
+            var response = await Client.TestClientGetAsync<ApiCollection<TestApiInternalRequestModel>>(
+                $"/departments/{assignedOrgUnit.SapId}/resources/requests");
+            response.Should().BeSuccessfull();
+            response.Value.Value.All(request => request.Project.State.Length > 0).Should().BeTrue();
         }
 
         #endregion
@@ -517,7 +527,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         public async Task GetTimeline_ShouldSupportSAPId()
         {
             using var adminScope = fixture.AdminScope();
-           
+
             var timelineStart = new DateTime(2020, 03, 01);
             var timelineEnd = new DateTime(2020, 03, 31);
 
@@ -597,7 +607,8 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
                 .WithPositions(10, 50)
                 .AddToMockService();
 
-            var profile = fixture.AddProfile(s => {
+            var profile = fixture.AddProfile(s =>
+            {
                 s.WithFullDepartment(department);
                 s.WithPositions(project.Positions);
             });

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/InternalResourceAllocationRequestTests.cs
@@ -250,6 +250,14 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         }
 
         [Fact]
+        public async Task Get_ProjectRequest_ProjectState_ShouldNotBeNull()
+        {
+            using var adminScope = fixture.AdminScope();
+            var response = await Client.TestClientGetAsync<TestApiInternalRequestModel>($"/projects/{projectId}/requests/{normalRequest.Id}");
+            response.Value.Project.State.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
         public async Task CreateRequest_ShouldSet_AdditionalNote()
         {
             using var adminScope = fixture.AdminScope();


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

Link to work item: [AB#60951](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/60951)

Multi-pronged approach setting the project state to `"ACTIVE"` if it is null. This is done in the `QueryProject` and `QueryProjectRef` constructors when querying projects, when projects are added to the database, and when projects are synced with org. Over time all null values should be replaced in the database, and the check in the query layer will act as a failsafe.

Created a string extension to set the state correctly, this will also allow for adding checks in the future.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
