### PR TITLE
fix: Add logging and increased default parallelism for weekly department sender

### DIFF
--- a/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
+++ b/src/Fusion.Summary.Functions/Functions/DepartmentResourceOwnerSync.cs
@@ -89,6 +89,8 @@ public class DepartmentResourceOwnerSync
         // Set up parallelism
         var threadCount = 2;
 
+        logger.LogInformation("Running sync with {ThreadCount} parallel tasks", threadCount);
+
         await Parallel.ForEachAsync(departments, new ParallelOptions { MaxDegreeOfParallelism = threadCount }, async (orgUnit, cancellationToken) =>
         {
             var resourceOwners = orgUnit.Management.Persons

--- a/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
@@ -33,7 +33,7 @@ public class WeeklyDepartmentSummarySender
         this.logger = logger;
         this.configuration = configuration;
 
-        _maxDegreeOfParallelism = int.TryParse(configuration["weekly-department-summary-sender-parallelism"], out var result) ? result : 1;
+        _maxDegreeOfParallelism = int.TryParse(configuration["weekly-department-summary-sender-parallelism"], out var result) ? result : 2;
         _departmentFilter = configuration["departmentFilter"]?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? ["PRD"];
 
         // Need to explicitly add the configuration key to the app settings to disable sending of notifications
@@ -85,6 +85,8 @@ public class WeeklyDepartmentSummarySender
         {
             MaxDegreeOfParallelism = _maxDegreeOfParallelism
         };
+
+        logger.LogInformation("Running sender with {MaxDegreeOfParallelism} parallel tasks", _maxDegreeOfParallelism);
 
         // Use Parallel.ForEachAsync to easily limit the number of parallel requests
         await Parallel.ForEachAsync(departments, options, async (department, _) => await CreateAndSendNotificationsAsync(department));


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

[AB#61612](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/61612)

Bandaid fix for az func timing out. A resource owner is not getting the report because the azure func times out before being able to send the report...

Should consider reworking or optimizing the architecture surrounding summary reports

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
