### PR TITLE
fix(resources): Allow location to be null when patching a request

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -1778,9 +1778,11 @@ namespace Fusion.Resources.Api.Controllers
             return false;
         }
 
-        // When a resource owner makes a proposal for a request or creates a change request the resulting position instance
-        // must have a location. The position is optional when creating a request, so we need to check that a location either
-        // was set when creating the request and the proposal does not remove it, or that the proposal adds a location.
+        /// <summary>
+        ///     When a resource owner makes a proposal for a request or creates a change request the resulting position instance
+        ///     must have a location. The position is optional when creating a request and saving a request, so we need to check
+        ///     that a location either was set when creating the request and the proposal does not remove it, or that the proposal adds a location.
+        /// </summary>
         private static bool LocationWillBeNull(ApiPositionLocationV2? existingLocation, Dictionary<string, object>? proposedChanges)
         {
             var isProposingLocation = proposedChanges?.ContainsKey("location") ?? false;

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -1778,11 +1778,9 @@ namespace Fusion.Resources.Api.Controllers
             return false;
         }
 
-        /// <summary>
-        ///     When a resource owner makes a proposal for a request or creates a change request the resulting position instance
-        ///     must have a location. The position is optional when creating a request and saving a request, so we need to check
-        ///     that a location either was set when creating the request and the proposal does not remove it, or that the proposal adds a location.
-        /// </summary>
+        // When a resource owner makes a proposal for a request or creates a change request the resulting position instance
+        // must have a location. The position is optional when creating a request, so we need to check that a location either
+        // was set when creating the request and the proposal does not remove it, or that the proposal adds a location.
         private static bool LocationWillBeNull(ApiPositionLocationV2? existingLocation, Dictionary<string, object>? proposedChanges)
         {
             var isProposingLocation = proposedChanges?.ContainsKey("location") ?? false;

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
 using static Fusion.Resources.Logic.Commands.ResourceAllocationRequest;
 
@@ -1797,6 +1798,14 @@ namespace Fusion.Resources.Api.Controllers
                     if (locationDict.TryGetValue("name", out var name))
                     {
                         return name == null || locationWillNotBeSet;
+                    }
+                }
+                // When running tests this is the type of data we get
+                else if (locationData is JsonElement locationJson)
+                {
+                    if (locationJson.TryGetProperty("name", out var name))
+                    {
+                        return name.ValueKind == JsonValueKind.Null || locationWillNotBeSet;
                     }
                 }
 

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -1040,9 +1040,12 @@ namespace Fusion.Resources.Api.Controllers
             if (result == null)
                 return ApiErrors.NotFound("Could not locate request", $"{requestId}");
 
+            if (result.OrgPosition is null)
+                return ApiErrors.InvalidOperation("InvalidStateTransition", "Request Org Position no longer exists");
+
             // Verify the split has a location, or a non-null location is being proposed
-            if (LocationWillBeNull(result.OrgPosition!.Instances.FirstOrDefault(i => i.Id == result.OrgPositionInstanceId)?.Location, result.ProposedChanges))
-                return ApiErrors.InvalidOperation("InvalidStateTransition", "Cannot move request to state proposed when no person is proposed");
+            if (LocationWillBeNull(result.OrgPosition.Instances.FirstOrDefault(i => i.Id == result.OrgPositionInstanceId)?.Location, result.ProposedChanges))
+                return ApiErrors.InvalidOperation("InvalidStateTransition", "Cannot move request to state proposed when no location is set");
 
             if (result.ProposedPerson is null)
                 return ApiErrors.InvalidOperation("InvalidStateTransition", "Cannot move request to state proposed when no person is proposed. If the request has more than one candidate, please propose only one of them.");

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -414,9 +414,6 @@ namespace Fusion.Resources.Api.Controllers
                 return ApiErrors.InvalidOperation("request-completed", "Cannot change a completed request.");
             if (HasChanged(request.AdditionalNote, item.AdditionalNote))
                 return ApiErrors.InvalidInput("Only task owners can modify additional notes.");
-            // Verify the split has a location, or a non-null location is being proposed
-            if (LocationWillBeNull(item.OrgPosition!.Instances.FirstOrDefault(i => i.Id == item.OrgPositionInstanceId)?.Location, request.ProposedChanges?.Value))
-                return ApiErrors.InvalidInput("Location is required");
 
             #region Authorization
 
@@ -1042,6 +1039,10 @@ namespace Fusion.Resources.Api.Controllers
 
             if (result == null)
                 return ApiErrors.NotFound("Could not locate request", $"{requestId}");
+
+            // Verify the split has a location, or a non-null location is being proposed
+            if (LocationWillBeNull(result.OrgPosition!.Instances.FirstOrDefault(i => i.Id == result.OrgPositionInstanceId)?.Location, result.ProposedChanges))
+                return ApiErrors.InvalidOperation("InvalidStateTransition", "Cannot move request to state proposed when no person is proposed");
 
             if (result.ProposedPerson is null)
                 return ApiErrors.InvalidOperation("InvalidStateTransition", "Cannot move request to state proposed when no person is proposed. If the request has more than one candidate, please propose only one of them.");


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
[AB#61687](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/61687)

Seems it was a bit too strict to check for location when patching a request. Now instead of ensuring a location is set when patching a request, it is instead ensured when the request is proposed from the resource owner side.

As with many of these endpoints, there is some business logic placed in the frontend and backend...

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
