### PR TITLE
fix(resources): Require location only for adjusment resource owner requests

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/InternalRequestsController.cs
@@ -247,10 +247,11 @@ namespace Fusion.Resources.Api.Controllers
             if (!assignedPersonProfile?.FullDepartment?.Equals(departmentString.FullDepartment, StringComparison.OrdinalIgnoreCase) == true)
                 return ApiErrors.InvalidInput($"The assigned resource does not belong to the department '{departmentString.FullDepartment}'");
 
-            // Verify the split has a location, or a non-null location is being proposed
-            if (LocationWillBeNull(
-                position.Instances.FirstOrDefault(i => i.Id == request.OrgPositionInstanceId)?.Location,
-                request.ProposedChanges))
+            // Verify the split has a location, or a non-null location is being proposed for adjustment requests.
+            if (request.SubType.Equals("Adjustment", StringComparison.OrdinalIgnoreCase) &&
+                LocationWillBeNull(
+                    position.Instances.FirstOrDefault(i => i.Id == request.OrgPositionInstanceId)?.Location,
+                    request.ProposedChanges))
             {
                 return ApiErrors.InvalidInput("Location is required");
             }
@@ -415,6 +416,10 @@ namespace Fusion.Resources.Api.Controllers
                 return ApiErrors.InvalidOperation("request-completed", "Cannot change a completed request.");
             if (HasChanged(request.AdditionalNote, item.AdditionalNote))
                 return ApiErrors.InvalidInput("Only task owners can modify additional notes.");
+            // Verify the split has a location, or a non-null location is being proposed for adjustment requests.
+            if (item.SubType?.Equals("Adjustment", StringComparison.OrdinalIgnoreCase) is true &&
+                LocationWillBeNull(item.OrgPosition!.Instances.FirstOrDefault(i => i.Id == item.OrgPositionInstanceId)?.Location, request.ProposedChanges?.Value))
+                return ApiErrors.InvalidInput("Location is required");
 
             #region Authorization
 


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
[AB#62391](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/62391)

Ensure that location is not null only for adjustment resource owner requests.

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [ ] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
