### PR TITLE
feat(summary): Add synthetic periodEnd property

### DIFF
--- a/src/Fusion.Summary.Api/Controllers/ApiModels/ApiReportMetaData.cs
+++ b/src/Fusion.Summary.Api/Controllers/ApiModels/ApiReportMetaData.cs
@@ -6,13 +6,16 @@ public class ApiReportMetaData
 {
     public Guid Id { get; set; }
     public DateTime Period { get; set; }
+    public DateTime PeriodEnd { get; set; }
+
 
     public static ApiReportMetaData FromQueryReportMetaData(QueryReportMetaData queryReportMetaData)
     {
         return new ApiReportMetaData
         {
             Id = queryReportMetaData.Id,
-            Period = queryReportMetaData.Period
+            Period = queryReportMetaData.Period,
+            PeriodEnd = queryReportMetaData.PeriodEnd
         };
     }
 }

--- a/src/Fusion.Summary.Api/Controllers/ApiModels/ApiWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Controllers/ApiModels/ApiWeeklySummaryReport.cs
@@ -8,6 +8,7 @@ public class ApiWeeklySummaryReport
     public required Guid Id { get; set; }
     public required string DepartmentSapId { get; set; }
     public required DateTime Period { get; set; }
+    public required DateTime PeriodEnd { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
@@ -33,6 +34,7 @@ public class ApiWeeklySummaryReport
             Id = queryWeeklySummaryReport.Id,
             DepartmentSapId = queryWeeklySummaryReport.DepartmentSapId,
             Period = queryWeeklySummaryReport.Period,
+            PeriodEnd = queryWeeklySummaryReport.PeriodEnd,
             NumberOfPersonnel = queryWeeklySummaryReport.NumberOfPersonnel,
             CapacityInUse = queryWeeklySummaryReport.CapacityInUse,
             NumberOfRequestsLastPeriod = queryWeeklySummaryReport.NumberOfRequestsLastPeriod,

--- a/src/Fusion.Summary.Api/Domain/Models/QueryReportMetaData.cs
+++ b/src/Fusion.Summary.Api/Domain/Models/QueryReportMetaData.cs
@@ -6,8 +6,10 @@ public class QueryReportMetaData
     {
         Id = id;
         Period = period;
+        PeriodEnd = period.AddDays(7);
     }
 
     public Guid Id { get; init; }
     public DateTime Period { get; init; }
+    public DateTime PeriodEnd { get; init; }
 }

--- a/src/Fusion.Summary.Api/Domain/Models/QueryWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Domain/Models/QueryWeeklySummaryReport.cs
@@ -7,6 +7,7 @@ public class QueryWeeklySummaryReport
     public required Guid Id { get; set; }
     public required string DepartmentSapId { get; set; }
     public required DateTime Period { get; set; }
+    public required DateTime PeriodEnd { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
@@ -28,6 +29,7 @@ public class QueryWeeklySummaryReport
             Id = dbWeeklySummaryReport.Id,
             DepartmentSapId = dbWeeklySummaryReport.DepartmentSapId,
             Period = dbWeeklySummaryReport.Period,
+            PeriodEnd = dbWeeklySummaryReport.Period.AddDays(7),
             NumberOfPersonnel = dbWeeklySummaryReport.NumberOfPersonnel,
             CapacityInUse = dbWeeklySummaryReport.CapacityInUse,
             NumberOfRequestsLastPeriod = dbWeeklySummaryReport.NumberOfRequestsLastPeriod,


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

To make it less confusing what period means on the resource owner report, a new propery PeriodEnd has been added. This is calculated during query instead of being stored in db,

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
