### PR TITLE
fix(resources): Ensure date's time component is set to 00:00:00 for proposed changes

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
@@ -53,31 +53,9 @@ namespace Fusion.Resources.Api.Controllers
                     .WithName("assignedDepartment")
                     .When(x => x.AssignedDepartment.HasValue && x.AssignedDepartment.Value != null);
 
-                RuleFor(x => x.ProposedChanges)
-                    .Custom((x, context) =>
-                    {
-                        if (x.HasValue && x.Value != null)
-                        {
-                            string[] allowedProperties = ["appliesFrom", "appliesTo", "location", "workload", "basePosition"];
-
-                            var isInvalid = false;
-                            foreach (var key in x.Value.Keys)
-                            {
-                                if (!allowedProperties.Any(p => string.Equals(p, key, StringComparison.OrdinalIgnoreCase)))
-                                {
-                                    context.AddFailure($"Key '{key}' is not valid");
-                                    isInvalid = true;
-                                }
-                            }
-
-                            if (isInvalid)
-                            {
-                                context.AddFailure($"Allowed keys are {string.Join(", ", allowedProperties.Select(p => p.ToLowerFirstChar()))}");
-                            }
-
-
-                        }
-                    });
+                RuleFor(x => x.ProposedChanges.Value)
+                    .BeValidProposedChanges()
+                    .When(x => x.ProposedChanges.HasValue && x.ProposedChanges.Value != null);
 
                 RuleFor(x => x.ProposalParameters.Value).SetValidator(new ProposalParametersRequest.Validator())
                     .OverridePropertyName(x => x.ProposalParameters)

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/PatchInternalRequestRequest.cs
@@ -54,7 +54,7 @@ namespace Fusion.Resources.Api.Controllers
                     .When(x => x.AssignedDepartment.HasValue && x.AssignedDepartment.Value != null);
 
                 RuleFor(x => x.ProposedChanges.Value)
-                    .BeValidProposedChanges()
+                    .BeValidProposedChanges(propertyName: nameof(ProposedChanges))
                     .When(x => x.ProposedChanges.HasValue && x.ProposedChanges.Value != null);
 
                 RuleFor(x => x.ProposalParameters.Value).SetValidator(new ProposalParametersRequest.Validator())

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/ProposalParametersRequest.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Requests/Requests/ProposalParametersRequest.cs
@@ -43,9 +43,19 @@ namespace Fusion.Resources.Api.Controllers
                     .WithMessage("To date cannot be before from date")
                     .When(x => x.ChangeDateFrom != null && x.ChangeDateTo != null);
 
+                RuleFor(x => x.ChangeDateTo)
+                    .Must(x => x!.Value.TimeOfDay == TimeSpan.Zero)
+                    .WithMessage("To date must be a date without time or time set to 00:00:00")
+                    .When(x => x.ChangeDateTo != null);
+
                 RuleFor(x => x.ChangeDateFrom)
                     .NotNull()
                     .WithMessage("From date must be defined when to date is specified")
+                    .When(x => x.ChangeDateTo != null);
+
+                RuleFor(x => x.ChangeDateFrom)
+                    .Must(x => x!.Value.TimeOfDay == TimeSpan.Zero)
+                    .WithMessage("From date must be a date without time or time set to 00:00:00")
                     .When(x => x.ChangeDateTo != null);
             }
         }

--- a/src/backend/api/Fusion.Resources.Api/Controllers/Validation/CustomValidatorExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Controllers/Validation/CustomValidatorExtensions.cs
@@ -89,25 +89,80 @@ namespace Fusion.Resources.Api.Controllers
 
         public static IRuleBuilderOptionsConditions<T, Dictionary<string, object>?> BeValidProposedChanges<T>(this IRuleBuilder<T, Dictionary<string, object>?> ruleBuilder)
         {
-            return ruleBuilder.Custom((prop, context) =>
+            return ruleBuilder.Custom((proposedChanges, context) =>
             {
-                if (prop is null)
+                if (proposedChanges is null)
                 {
                     context.AddFailure("Value not provided");
                     return;
                 }
 
-                var serialized = JsonConvert.SerializeObject(prop);
-                if (serialized.Length > 5000)
-                    context.AddFailure("Total size of change dictionary cannot be larger than 5000 characters");
-                
-                foreach (var k in prop.Keys.Where(k => k.Length > 100))
-                {
-                    context.AddFailure(new ValidationFailure($"{context.JsPropertyName()}.key",
-                        "Key cannot exceed 100 characters", k));
-                }
+                ValidateSerializedSize(proposedChanges, context);
+                ValidateKeyLengths(proposedChanges, context);
+                ValidateAllowedKeysAndValues(proposedChanges, context);
             });
         }
+
+        #region BeValidProposedChangesHelpers
+
+        private static void ValidateSerializedSize<T>(Dictionary<string, object> prop, ValidationContext<T> context)
+        {
+            var serialized = JsonConvert.SerializeObject(prop);
+            if (serialized.Length > 5000)
+            {
+                context.AddFailure("Total size of change dictionary cannot be larger than 5000 characters");
+            }
+        }
+
+        private static void ValidateKeyLengths<T>(Dictionary<string, object> prop, ValidationContext<T> context)
+        {
+            foreach (var key in prop.Keys.Where(k => k.Length > 100))
+            {
+                context.AddFailure(new ValidationFailure($"{context.JsPropertyName()}.key",
+                    "Key cannot exceed 100 characters", key));
+            }
+        }
+
+        private static void ValidateAllowedKeysAndValues<T>(Dictionary<string, object> prop, ValidationContext<T> context)
+        {
+            string[] allowedProperties = ["appliesFrom", "appliesTo", "location", "workload", "basePosition"];
+            var isInvalid = false;
+
+            foreach (var key in prop.Keys)
+            {
+                if (allowedProperties.Any(p => string.Equals(p, key, StringComparison.OrdinalIgnoreCase)))
+                {
+                    ValidateKeySpecificRules(key, prop[key], context);
+                }
+                else
+                {
+                    context.AddFailure($"Key '{key}' is not valid");
+                    isInvalid = true;
+                }
+            }
+
+            if (isInvalid)
+            {
+                context.AddFailure($"Allowed keys are {string.Join(", ", allowedProperties.Select(p => p.ToLowerFirstChar()))}");
+            }
+        }
+
+        private static void ValidateKeySpecificRules<T>(string key, object? value, ValidationContext<T> context)
+        {
+            if (key.Equals("appliesFrom", StringComparison.OrdinalIgnoreCase) || key.Equals("appliesTo", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!DateTime.TryParse(value?.ToString(), out var date))
+                {
+                    context.AddFailure($"Key '{key}' value must be a valid date");
+                }
+                else if (date.TimeOfDay != TimeSpan.Zero)
+                {
+                    context.AddFailure($"Key '{key}' value must be a date without time or time set to 00:00:00");
+                }
+            }
+        }
+
+        #endregion
 
         public static IRuleBuilderOptionsConditions<T, ApiPositionInstance?> BeValidPositionInstance<T>(this IRuleBuilder<T, ApiPositionInstance?> ruleBuilder)
         {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

[AB#62551](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/62551)

OrgService works with dates and the time component is uneeded. Avoid potential issues with timezones give the FE feedback immediately instead of later in the proviosning process

Frontend currently sends inccorect date time so https://github.com/equinor/fusion-resource-allocation-apps/pull/1079 needs to go out first

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
