### PR TITLE
feat: auto approve direct requests where resource owner sets location

### DIFF
--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Approve.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Approve.cs
@@ -10,6 +10,7 @@ using Fusion.Resources.Database.Entities;
 using Fusion.Resources.Domain;
 using Fusion.Resources.Domain.Notifications.InternalRequests;
 using Newtonsoft.Json.Linq;
+using System.Linq;
 
 namespace Fusion.Resources.Logic.Commands
 {
@@ -71,8 +72,8 @@ namespace Fusion.Resources.Logic.Commands
                     if (!string.Equals(dbRequest.State.State, WorkflowDefinition.APPROVAL, StringComparison.OrdinalIgnoreCase))
                         return;
 
-                    // For a direct allocation, we can auto complete the request if no changes has been proposed.
-                    if (workflow is AllocationDirectWorkflowV1 directWorkflow && AnyProposedChanges(dbRequest) == false)
+                    // For a direct allocation, we can auto complete the request if no changes have been proposed that require approval from the task.
+                    if (workflow is AllocationDirectWorkflowV1 directWorkflow && !AnyProposedChanges(dbRequest))
                     {
                         var systemAccount = await profileService.EnsureSystemAccountAsync();
                         currentStep = directWorkflow.AutoAcceptedUnchangedRequest(systemAccount);
@@ -95,7 +96,7 @@ namespace Fusion.Resources.Logic.Commands
                 }
 
                 /// <summary>
-                ///     AnyProposedChanges for a direct allocation
+                ///     AnyProposedChanges for a direct allocation that require task approval
                 /// </summary>
                 private static bool AnyProposedChanges(DbResourceAllocationRequest dbRequest)
                 {
@@ -114,8 +115,21 @@ namespace Fusion.Resources.Logic.Commands
                     bool hasProposedChanges;
                     try
                     {
-                        hasProposedChanges = !string.IsNullOrWhiteSpace(dbRequest.ProposedChanges) &&
-                                             JObject.Parse(dbRequest.ProposedChanges).HasValues;
+                        var proposedChanges = JObject.Parse(dbRequest.ProposedChanges ?? "");
+                        // if the task did not set any location, it can be ignored in terms of proposed changes.
+                        if (dbRequest.OrgPositionInstance.LocationId is null)
+                        {
+                            var changesCount = proposedChanges.Children().Count();
+                            var containsLocation = proposedChanges.ContainsKey("location");
+                            var changesRequireApproval = containsLocation ? changesCount > 1 : changesCount > 0;
+                            hasProposedChanges = !string.IsNullOrWhiteSpace(dbRequest.ProposedChanges) &&
+                                                 changesRequireApproval;
+                        }
+                        else
+                        {
+                            hasProposedChanges = !string.IsNullOrWhiteSpace(dbRequest.ProposedChanges) &&
+                                                 proposedChanges.HasValues;
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Approve.cs
+++ b/src/backend/api/Fusion.Resources.Logic/Requests/Commands/ResourceAllocationRequest/Approve.cs
@@ -123,7 +123,6 @@ namespace Fusion.Resources.Logic.Commands
                             {
                                 var changesCount = proposedChanges.Children().Count();
                                 var containsLocation = proposedChanges.ContainsKey("location");
-                                var changesRequireApproval = containsLocation ? changesCount > 1 : changesCount > 0;
                                 hasProposedChanges = containsLocation
                                     // proposed changes other than setting the location
                                     ? changesCount > 1


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

If a resource owner sets the location for a direct request, and the project had left it empty, the project should not have to
approve the location change. 

Updated the logic in `AnyProposedChanges` in Approve.cs to reflect this.

[AB#62464](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/62464)

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
