### PR TITLE
feat(resources): Allow resource owners to assign delegated resource owners in sibling departments

### DIFF
--- a/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
+++ b/src/backend/api/Fusion.Resources.Api/Authorization/Extensions/RequirementsBuilderExtensions.cs
@@ -162,7 +162,10 @@ namespace Fusion.Resources.Api.Controllers
         }
         public static IAuthorizationRequirementRule CanDelegateAccessToDepartment(this IAuthorizationRequirementRule builder, string department)
         {
-            builder.BeResourceOwnerForDepartment(department, includeParents: true, includeDelegatedResourceOwners: false);
+            var departmentPath = new DepartmentPath(department);
+            builder.BeResourceOwnerForDepartment(department, includeDelegatedResourceOwners: false);
+            builder.BeResourceOwnerForDepartment(departmentPath.Parent(), includeDelegatedResourceOwners: false);
+            builder.BeSiblingResourceOwner(departmentPath, includeDelegatedResourceOwners: false);
             return builder;
         }
 

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -433,12 +433,13 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Theory]
         [InlineData("AAA BBB", false)]
         [InlineData("AAA BBB CCC", false)]
+        [InlineData("AAA BBB CCC YYY", true)]
         [InlineData("AAA BBB CCC XXX", true)] //<- ResourceOwner for this department
         [InlineData("AAA BBB CCC XXX EEE", true)]
-        [InlineData("AAA BBB CCC XXX EEE FFF", true)]
+        [InlineData("AAA BBB CCC XXX EEE FFF", false)]
         public async Task OptionsDepartmentResponsible_CanDelegateAccessToCurrentAndSiblingsAndDirectChildren_WhenResourceOwner(string fullDepartment, bool expectingAccess)
         {
-            var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF" };
+            var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF", "AAA BBB CCC YYY" };
             foreach (var dep in departmentsToTest)
                 fixture.EnsureDepartment(dep);
 
@@ -479,7 +480,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [InlineData("AAA BBB CCC XXX", true)] //<- ResourceOwner for this department
         [InlineData("AAA BBB CCC XXX EEE", true)]
         [InlineData("AAA BBB CCC XXX EEE FFF", false)]
-        public async Task PostDepartmentResponsible_CanDelegateAccessToCurrentAndDownwards_WhenResourceOwner(string fullDepartment, bool expectingAccess)
+        public async Task PostDepartmentResponsible_CanDelegateAccessToCurrentAndSiblingsAndDirectChildren_WhenResourceOwner(string fullDepartment, bool expectingAccess)
         {
             var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF", "AAA BBB CCC YYY" };
             foreach (var dep in departmentsToTest)

--- a/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
+++ b/src/backend/tests/Fusion.Resources.Api.Tests/IntegrationTests/DepartmentsControllerTests.cs
@@ -436,7 +436,7 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [InlineData("AAA BBB CCC XXX", true)] //<- ResourceOwner for this department
         [InlineData("AAA BBB CCC XXX EEE", true)]
         [InlineData("AAA BBB CCC XXX EEE FFF", true)]
-        public async Task OptionsDepartmentResponsible_CanDelegateAccessToCurrentAndDownwards_WhenResourceOwner(string fullDepartment, bool expectingAccess)
+        public async Task OptionsDepartmentResponsible_CanDelegateAccessToCurrentAndSiblingsAndDirectChildren_WhenResourceOwner(string fullDepartment, bool expectingAccess)
         {
             var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF" };
             foreach (var dep in departmentsToTest)
@@ -475,12 +475,13 @@ namespace Fusion.Resources.Api.Tests.IntegrationTests
         [Theory]
         [InlineData("AAA BBB", false)]
         [InlineData("AAA BBB CCC", false)]
+        [InlineData("AAA BBB CCC YYY", true)]
         [InlineData("AAA BBB CCC XXX", true)] //<- ResourceOwner for this department
         [InlineData("AAA BBB CCC XXX EEE", true)]
-        [InlineData("AAA BBB CCC XXX EEE FFF", true)]
+        [InlineData("AAA BBB CCC XXX EEE FFF", false)]
         public async Task PostDepartmentResponsible_CanDelegateAccessToCurrentAndDownwards_WhenResourceOwner(string fullDepartment, bool expectingAccess)
         {
-            var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF" };
+            var departmentsToTest = new List<string> { "AAA BBB", "AAA BBB CCC", "AAA BBB CCC XXX", "AAA BBB CCC XXX EEE", "AAA BBB CCC XXX EEE FFF", "AAA BBB CCC YYY" };
             foreach (var dep in departmentsToTest)
                 fixture.EnsureDepartment(dep);
 


### PR DESCRIPTION
- [x] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->
[AB#62509](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/62509)

Allow resource owners to only assign delegated resource owners in current, sibling and direct child departments. 

**Testing:**
- [x] Can be tested
- [x] Automatic tests created / updated
- [x] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [x] Considered automated tests
- [x] Considered updating specification / documentation
- [x] Considered work items 
- [x] Considered security
- [x] Performed developer testing
- [x] Checklist finalized / ready for review

<!--- Other comments --->
