### PR TITLE
Fix/summary/update open requests filtering and total workload

### DIFF
--- a/src/Fusion.Resources.Functions.Common/ApiClients/ISummaryApiClient.cs
+++ b/src/Fusion.Resources.Functions.Common/ApiClients/ISummaryApiClient.cs
@@ -76,6 +76,7 @@ public record ApiWeeklySummaryReport
     public DateTime Period { get; set; }
     public string NumberOfPersonnel { get; set; } = MissingValue;
     public string CapacityInUse { get; set; } = MissingValue;
+    public string OpenRequestsWorkload { get; set; } = MissingValue;
     public string NumberOfRequestsLastPeriod { get; set; } = MissingValue;
     public string NumberOfOpenRequests { get; set; } = MissingValue;
     public string NumberOfRequestsStartingInLessThanThreeMonths { get; set; } = MissingValue;

--- a/src/Fusion.Summary.Api/Controllers/ApiModels/ApiWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Controllers/ApiModels/ApiWeeklySummaryReport.cs
@@ -11,6 +11,7 @@ public class ApiWeeklySummaryReport
     public required DateTime PeriodEnd { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
+    public required string OpenRequestsWorkload { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
     public required string NumberOfOpenRequests { get; set; }
     public required string NumberOfRequestsStartingInLessThanThreeMonths { get; set; }
@@ -37,6 +38,7 @@ public class ApiWeeklySummaryReport
             PeriodEnd = queryWeeklySummaryReport.PeriodEnd,
             NumberOfPersonnel = queryWeeklySummaryReport.NumberOfPersonnel,
             CapacityInUse = queryWeeklySummaryReport.CapacityInUse,
+            OpenRequestsWorkload = queryWeeklySummaryReport.OpenRequestsWorkload,
             NumberOfRequestsLastPeriod = queryWeeklySummaryReport.NumberOfRequestsLastPeriod,
             NumberOfOpenRequests = queryWeeklySummaryReport.NumberOfOpenRequests,
             NumberOfRequestsStartingInLessThanThreeMonths =

--- a/src/Fusion.Summary.Api/Controllers/Requests/PutWeeklySummaryReportRequest.cs
+++ b/src/Fusion.Summary.Api/Controllers/Requests/PutWeeklySummaryReportRequest.cs
@@ -8,6 +8,7 @@ public class PutWeeklySummaryReportRequest
     public required DateTime Period { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
+    public required string OpenRequestsWorkload { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
     public required string NumberOfOpenRequests { get; set; }
     public required string NumberOfRequestsStartingInLessThanThreeMonths { get; set; }

--- a/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.Designer.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.Designer.cs
@@ -4,6 +4,7 @@ using Fusion.Summary.Api.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Fusion.Summary.Api.Database.Migrations
 {
     [DbContext(typeof(SummaryDbContext))]
-    partial class SummaryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250730120409_OpenRequestsWorkload_to_db_column")]
+    partial class OpenRequestsWorkload_to_db_column
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.cs
@@ -15,7 +15,7 @@ namespace Fusion.Summary.Api.Database.Migrations
                 table: "WeeklySummaryReports",
                 type: "nvarchar(max)",
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "N/A");
         }
 
         /// <inheritdoc />

--- a/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.cs
+++ b/src/Fusion.Summary.Api/Database/Migrations/20250730120409_OpenRequestsWorkload_to_db_column.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fusion.Summary.Api.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class OpenRequestsWorkload_to_db_column : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OpenRequestsWorkload",
+                table: "WeeklySummaryReports",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OpenRequestsWorkload",
+                table: "WeeklySummaryReports");
+        }
+    }
+}

--- a/src/Fusion.Summary.Api/Database/Models/DbWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Database/Models/DbWeeklySummaryReport.cs
@@ -11,6 +11,7 @@ public class DbWeeklySummaryReport
     public required DateTime Period { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
+    public required string OpenRequestsWorkload { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
     public required string NumberOfOpenRequests { get; set; }
     public required string NumberOfRequestsStartingInLessThanThreeMonths { get; set; }

--- a/src/Fusion.Summary.Api/Domain/Commands/PutWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Domain/Commands/PutWeeklySummaryReport.cs
@@ -53,6 +53,7 @@ public class PutWeeklySummaryReport : IRequest<bool>
                 Period = request.WeeklySummaryReport.Period.Date,
                 NumberOfPersonnel = request.WeeklySummaryReport.NumberOfPersonnel,
                 CapacityInUse = request.WeeklySummaryReport.CapacityInUse,
+                OpenRequestsWorkload = request.WeeklySummaryReport.OpenRequestsWorkload,
                 NumberOfRequestsLastPeriod = request.WeeklySummaryReport.NumberOfRequestsLastPeriod,
                 NumberOfOpenRequests = request.WeeklySummaryReport.NumberOfOpenRequests,
                 NumberOfRequestsStartingInLessThanThreeMonths =

--- a/src/Fusion.Summary.Api/Domain/Models/QueryWeeklySummaryReport.cs
+++ b/src/Fusion.Summary.Api/Domain/Models/QueryWeeklySummaryReport.cs
@@ -10,6 +10,7 @@ public class QueryWeeklySummaryReport
     public required DateTime PeriodEnd { get; set; }
     public required string NumberOfPersonnel { get; set; }
     public required string CapacityInUse { get; set; }
+    public required string OpenRequestsWorkload { get; set; }
     public required string NumberOfRequestsLastPeriod { get; set; }
     public required string NumberOfOpenRequests { get; set; }
     public required string NumberOfRequestsStartingInLessThanThreeMonths { get; set; }
@@ -32,6 +33,7 @@ public class QueryWeeklySummaryReport
             PeriodEnd = dbWeeklySummaryReport.Period.AddDays(7),
             NumberOfPersonnel = dbWeeklySummaryReport.NumberOfPersonnel,
             CapacityInUse = dbWeeklySummaryReport.CapacityInUse,
+            OpenRequestsWorkload = dbWeeklySummaryReport.OpenRequestsWorkload,
             NumberOfRequestsLastPeriod = dbWeeklySummaryReport.NumberOfRequestsLastPeriod,
             NumberOfOpenRequests = dbWeeklySummaryReport.NumberOfOpenRequests,
             NumberOfRequestsStartingInLessThanThreeMonths =
@@ -67,6 +69,7 @@ public class QueryWeeklySummaryReport
             Period = Period,
             NumberOfPersonnel = NumberOfPersonnel,
             CapacityInUse = CapacityInUse,
+            OpenRequestsWorkload = OpenRequestsWorkload,
             NumberOfRequestsLastPeriod = NumberOfRequestsLastPeriod,
             NumberOfOpenRequests = NumberOfOpenRequests,
             NumberOfRequestsStartingInLessThanThreeMonths =

--- a/src/Fusion.Summary.Api/appsettings.json
+++ b/src/Fusion.Summary.Api/appsettings.json
@@ -22,6 +22,6 @@
     "ServiceName": "SummaryNotification"
   },
   "ConnectionStrings": {
-    "SummaryDbContext": "Server=tcp:fusion-test-sqlserver.database.windows.net,1433;Initial Catalog=sqldb-fapp-fra-summary-db-CI;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "SummaryDbContext": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=summary-db;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
   }
-} 
+}

--- a/src/Fusion.Summary.Api/appsettings.json
+++ b/src/Fusion.Summary.Api/appsettings.json
@@ -22,6 +22,6 @@
     "ServiceName": "SummaryNotification"
   },
   "ConnectionStrings": {
-    "SummaryDbContext": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=summary-db;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
+    "SummaryDbContext": "Server=tcp:fusion-test-sqlserver.database.windows.net,1433;Initial Catalog=sqldb-fapp-fra-summary-db-CI;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   }
 } 

--- a/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummarySender.cs
@@ -209,6 +209,9 @@ public class WeeklyDepartmentSummarySender
                 report.NumberOfOpenRequests,
                 "Open requests")
             .AddTextRow(
+                report.OpenRequestsWorkload,
+                "Combined open requests workload", "%")
+            .AddTextRow(
                 report.NumberOfRequestsStartingInLessThanThreeMonths,
                 "Requests with start date < 3 months")
             .AddTextRow(

--- a/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummaryWorker.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummaryWorker.cs
@@ -101,6 +101,7 @@ public class WeeklyDepartmentSummaryWorker
                 .ToArray(),
             NumberOfPersonnel = ResourceOwnerReportDataCreator.GetTotalNumberOfPersonnel(personnel).ToString(),
             CapacityInUse = ResourceOwnerReportDataCreator.GetCapacityInUse(personnel).ToString(),
+            OpenRequestsWorkload = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests, personnel).ToString(),
             NumberOfRequestsLastPeriod = ResourceOwnerReportDataCreator.GetNumberOfRequestsLastWeek(requests).ToString(),
             NumberOfOpenRequests = ResourceOwnerReportDataCreator.GetNumberOfOpenRequests(requests).ToString(),
             NumberOfRequestsStartingInLessThanThreeMonths = ResourceOwnerReportDataCreator.GetNumberOfRequestsStartingInLessThanThreeMonths(requests).ToString(),

--- a/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummaryWorker.cs
+++ b/src/Fusion.Summary.Functions/Functions/WeeklyDepartmentSummaryWorker.cs
@@ -101,7 +101,7 @@ public class WeeklyDepartmentSummaryWorker
                 .ToArray(),
             NumberOfPersonnel = ResourceOwnerReportDataCreator.GetTotalNumberOfPersonnel(personnel).ToString(),
             CapacityInUse = ResourceOwnerReportDataCreator.GetCapacityInUse(personnel).ToString(),
-            OpenRequestsWorkload = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests, personnel).ToString(),
+            OpenRequestsWorkload = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests).ToString(),
             NumberOfRequestsLastPeriod = ResourceOwnerReportDataCreator.GetNumberOfRequestsLastWeek(requests).ToString(),
             NumberOfOpenRequests = ResourceOwnerReportDataCreator.GetNumberOfOpenRequests(requests).ToString(),
             NumberOfRequestsStartingInLessThanThreeMonths = ResourceOwnerReportDataCreator.GetNumberOfRequestsStartingInLessThanThreeMonths(requests).ToString(),

--- a/src/Fusion.Summary.Functions/ReportCreator/ResourceOwnerReportDataCreator.cs
+++ b/src/Fusion.Summary.Functions/ReportCreator/ResourceOwnerReportDataCreator.cs
@@ -66,23 +66,23 @@ public abstract class ResourceOwnerReportDataCreator
             !req.State.Equals(RequestState.Completed.ToString(), StringComparison.OrdinalIgnoreCase));
 
     public static int GetCombinedOpenRequestsWorkload(IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests,
-    List<IResourcesApiClient.InternalPersonnelPerson> listOfInternalPersonnel)
+    List<IResourcesApiClient.InternalPersonnelPerson> internalPersonnel)
     {
-        if (requests == null || listOfInternalPersonnel == null || !listOfInternalPersonnel.Any())
+        if (requests == null || internalPersonnel == null || internalPersonnel.Count == 0)
             return 0;
 
         var totalOpenRequestsWorkload = requests.Where(r => r.OrgPositionInstance != null)
         .Sum(r => r.OrgPositionInstance?.Workload ?? 0);
 
-        var totalLeave = listOfInternalPersonnel
+        var totalLeave = internalPersonnel
         .SelectMany(p => p.EmploymentStatuses)
         .Where(status =>
-        (status.Type == IResourcesApiClient.ApiAbsenceType.Absence ||
-        status.Type == IResourcesApiClient.ApiAbsenceType.Vacation) &&
-        status.IsActive)
+            (status.Type == IResourcesApiClient.ApiAbsenceType.Absence ||
+            status.Type == IResourcesApiClient.ApiAbsenceType.Vacation) &&
+            status.IsActive)
         .Sum(status => status.AbsencePercentage ?? 0);
 
-        var maxPotential = listOfInternalPersonnel.Count * 100;
+        var maxPotential = internalPersonnel.Count * 100;
         var potentialAvailable = maxPotential - totalLeave;
 
         if (potentialAvailable <= 0)

--- a/src/Fusion.Summary.Functions/ReportCreator/ResourceOwnerReportDataCreator.cs
+++ b/src/Fusion.Summary.Functions/ReportCreator/ResourceOwnerReportDataCreator.cs
@@ -57,40 +57,39 @@ public abstract class ResourceOwnerReportDataCreator
                                  && req.Created > DateTime.UtcNow.AddDays(-7) && !req.IsDraft);
     }
 
+    private static IEnumerable<IResourcesApiClient.ResourceAllocationRequest> GetOpenRequests(
+        IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests
+    ) =>
+        requests.Where(req =>
+            req.OrgPositionInstance != null
+            && req.State != null
+            && req.Type != null
+            && !req.Type.Equals(
+                RequestType.ResourceOwnerChange.ToString(),
+                StringComparison.OrdinalIgnoreCase
+            )
+            && !req.HasProposedPerson
+            && !req.State.Equals(
+                RequestState.Completed.ToString(),
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
+
     public static int GetNumberOfOpenRequests(
-        IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests)
-        => requests.Count(req =>
-            req.State != null && req.Type != null && !req.Type.Equals(RequestType.ResourceOwnerChange.ToString(),
-                StringComparison.OrdinalIgnoreCase) &&
-            !req.HasProposedPerson &&
-            !req.State.Equals(RequestState.Completed.ToString(), StringComparison.OrdinalIgnoreCase));
+        IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests
+    ) => GetOpenRequests(requests).Count();
 
-    public static int GetCombinedOpenRequestsWorkload(IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests,
-    List<IResourcesApiClient.InternalPersonnelPerson> internalPersonnel)
+    public static double GetCombinedOpenRequestsWorkload(
+        IEnumerable<IResourcesApiClient.ResourceAllocationRequest> requests
+    )
     {
-        if (requests == null || internalPersonnel == null || internalPersonnel.Count == 0)
+        if (requests == null)
             return 0;
 
-        var totalOpenRequestsWorkload = requests.Where(r => r.OrgPositionInstance != null)
-        .Sum(r => r.OrgPositionInstance?.Workload ?? 0);
+        var totalOpenRequestsWorkload = GetOpenRequests(requests)
+            .Sum(r => r.OrgPositionInstance?.Workload ?? 0);
 
-        var totalLeave = internalPersonnel
-        .SelectMany(p => p.EmploymentStatuses)
-        .Where(status =>
-            (status.Type == IResourcesApiClient.ApiAbsenceType.Absence ||
-            status.Type == IResourcesApiClient.ApiAbsenceType.Vacation) &&
-            status.IsActive)
-        .Sum(status => status.AbsencePercentage ?? 0);
-
-        var maxPotential = internalPersonnel.Count * 100;
-        var potentialAvailable = maxPotential - totalLeave;
-
-        if (potentialAvailable <= 0)
-            return 0;
-
-        var percentageOfCapacity = totalOpenRequestsWorkload / potentialAvailable * 100;
-
-        return (int)Math.Round(percentageOfCapacity);
+        return totalOpenRequestsWorkload;
     }
 
     public static int GetNumberOfRequestsStartingInMoreThanThreeMonths(

--- a/src/tests/Fusion.Summary.Api.Tests/Helpers/SummaryReportHelpers.cs
+++ b/src/tests/Fusion.Summary.Api.Tests/Helpers/SummaryReportHelpers.cs
@@ -35,6 +35,7 @@ public static class SummaryReportHelpers
             Period = CreateDayOfWeek(DayOfWeek.Monday),
             NumberOfPersonnel = "1",
             CapacityInUse = "2",
+            OpenRequestsWorkload = "2",
             NumberOfRequestsLastPeriod = "3",
             NumberOfOpenRequests = "4",
             NumberOfRequestsStartingInLessThanThreeMonths = "5",

--- a/src/tests/Fusion.Summary.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
+++ b/src/tests/Fusion.Summary.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
@@ -243,4 +243,44 @@ public class ScheduledReportNotificationBuilderTests
         // Assert
         numberOfRequests.Should().Be(1);
     }
+
+    [Fact]
+    public void GetOpenRequestsWorkload_ShouldReturnCorrectCapacityRequested()
+    {
+        //Arrange
+        var requests = new List<IResourcesApiClient.ResourceAllocationRequest>
+        {
+            new()
+            {
+                OrgPositionInstance = new ApiPositionInstanceV2 {Workload =  20}
+            }
+        };
+
+        const int personnelCount = 4;
+        const int workload = 80;
+        const int otherTasks = 4;
+        const int vacationLeave = 2;
+        const int absenceLeave = 3;
+        var personnel = NotificationReportApiResponseMock.GetMockedInternalPersonnel(
+            personnelCount,
+            workload,
+            otherTasks,
+            vacationLeave,
+            absenceLeave);
+
+        // Act
+        var result = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests, personnel);
+
+        var totalOpenRequestsWorkload = 20; // Total workload from requests
+        var totalLeave = vacationLeave + absenceLeave; // Total leave percentage
+        var maxPotential = personnelCount * 100; // Max potential capacity
+        var potentialAvailable = maxPotential - totalLeave;
+
+        double expectedPercentage = potentialAvailable > 0
+           ? totalOpenRequestsWorkload / (double)potentialAvailable * 100
+           : 0;
+
+        // Assert
+        result.Should().Be((int)Math.Round(expectedPercentage));
+    }
 }

--- a/src/tests/Fusion.Summary.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
+++ b/src/tests/Fusion.Summary.Functions.Tests/Notifications/ScheduledReportNotificationBuilderTests.cs
@@ -252,35 +252,18 @@ public class ScheduledReportNotificationBuilderTests
         {
             new()
             {
-                OrgPositionInstance = new ApiPositionInstanceV2 {Workload =  20}
+                OrgPositionInstance = new ApiPositionInstanceV2 {Workload =  20},
+                Type = RequestType.Allocation.ToString(),
+                State = RequestState.Created.ToString()
             }
         };
 
-        const int personnelCount = 4;
-        const int workload = 80;
-        const int otherTasks = 4;
-        const int vacationLeave = 2;
-        const int absenceLeave = 3;
-        var personnel = NotificationReportApiResponseMock.GetMockedInternalPersonnel(
-            personnelCount,
-            workload,
-            otherTasks,
-            vacationLeave,
-            absenceLeave);
 
         // Act
-        var result = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests, personnel);
+        var totalRequestedWorkload = ResourceOwnerReportDataCreator.GetCombinedOpenRequestsWorkload(requests);
 
-        var totalOpenRequestsWorkload = 20; // Total workload from requests
-        var totalLeave = vacationLeave + absenceLeave; // Total leave percentage
-        var maxPotential = personnelCount * 100; // Max potential capacity
-        var potentialAvailable = maxPotential - totalLeave;
-
-        double expectedPercentage = potentialAvailable > 0
-           ? totalOpenRequestsWorkload / (double)potentialAvailable * 100
-           : 0;
 
         // Assert
-        result.Should().Be((int)Math.Round(expectedPercentage));
+        totalRequestedWorkload.Should().Be(20);
     }
 }


### PR DESCRIPTION
- [ ] New feature
- [ x] Bug fix
- [ ] High impact

**Description of work:**
I have filtered out open requests which dont have an orgPositionInstance i.e invalid request
Changed how the sum of combinedrequestworkload is calculated -> now it returns the sum without further calculation
Updated test


**Testing:**
- [x ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

<!--- Other comments --->
