### PR TITLE
chore(functions): update lineorg url to use fra-lineorg

### DIFF
--- a/pipelines/templates/deploy-function-pr-template.yml
+++ b/pipelines/templates/deploy-function-pr-template.yml
@@ -49,7 +49,7 @@ steps:
               serviceBus = "https://$envVaultName.vault.azure.net:443/secrets/Connectionstrings--ServiceBus"
           }
           endpoints = @{
-            lineorg = "https://lineorg.$fusionEnvironment.api.fusion-dev.net"
+            lineorg = "https://fra-lineorg.$fusionEnvironment.api.fusion-dev.net"
             org = "https://org.$fusionEnvironment.api.fusion-dev.net"
             people = "https://people.$fusionEnvironment.api.fusion-dev.net"
             resources = "https://fra-resources-$pullRequestNumber.pr.api.fusion-dev.net"

--- a/pipelines/templates/deploy-function-template.yml
+++ b/pipelines/templates/deploy-function-template.yml
@@ -38,7 +38,7 @@ steps:
       # Set correct resources URI based on environment
    
       if ($fusionEnvironment -eq "fprd") {
-        $lineorg = "https://lineorg.api.fusion.equinor.com"
+        $lineorg = "https://fra-lineorg.api.fusion.equinor.com"
         $org = "https://org.api.fusion.equinor.com"
         $people = "https://people.api.fusion.equinor.com"
         $resources = "https://fra-resources.api.fusion.equinor.com"
@@ -47,7 +47,7 @@ steps:
         $portal = "https://fusion.equinor.com"  
       }
       else {
-        $lineorg = "https://lineorg.$fusionEnvironment.api.fusion-dev.net"
+        $lineorg = "https://fra-lineorg.$fusionEnvironment.api.fusion-dev.net"
         $org = "https://org.$fusionEnvironment.api.fusion-dev.net"
         $people = "https://people.$fusionEnvironment.api.fusion-dev.net"
         $resources = "https://fra-resources.$environment.api.fusion-dev.net"

--- a/pipelines/templates/deploy-summary-function-pr-template.yml
+++ b/pipelines/templates/deploy-summary-function-pr-template.yml
@@ -50,7 +50,7 @@ steps:
                 serviceBus = "https://$envVaultName.vault.azure.net:443/secrets/Connectionstrings--ServiceBus"
             }
             endpoints = @{
-                lineorg = "https://lineorg.$fusionEnvironment.api.fusion-dev.net"
+                lineorg = "https://fra-lineorg.$fusionEnvironment.api.fusion-dev.net"
                 org = "https://org.$fusionEnvironment.api.fusion-dev.net"
                 people = "https://people.$fusionEnvironment.api.fusion-dev.net"
                 notifications = "https://notifications.$fusionEnvironment.api.fusion-dev.net"

--- a/pipelines/templates/deploy-summary-function-template.yml
+++ b/pipelines/templates/deploy-summary-function-template.yml
@@ -41,7 +41,7 @@ steps:
       if ($environment -eq "fprd") {
           $summary = "https://fra-summary.api.fusion.equinor.com"
           $portal = "https://fusion.equinor.com"
-          $lineorg = "https://lineorg.api.fusion.equinor.com"
+          $lineorg = "https://fra-lineorg.api.fusion.equinor.com"
           $org = "https://org.api.fusion.equinor.com"
           $people = "https://people.api.fusion.equinor.com"
           $resources = "https://fra-resources.api.fusion.equinor.com"
@@ -52,7 +52,7 @@ steps:
       }
       else {
          $summary = "https://fra-summary.$environment.api.fusion-dev.net"
-         $lineorg = "https://lineorg.$fusionEnvironment.api.fusion-dev.net"
+         $lineorg = "https://fra-lineorg.$fusionEnvironment.api.fusion-dev.net"
          $org = "https://org.$fusionEnvironment.api.fusion-dev.net"
          $people = "https://people.$fusionEnvironment.api.fusion-dev.net"
          $resources = "https://fra-resources.$environment.api.fusion-dev.net"

--- a/src/Fusion.Summary.Functions/Deployment/function.template.json
+++ b/src/Fusion.Summary.Functions/Deployment/function.template.json
@@ -15,7 +15,7 @@
           "serviceBus": ""
         },
         "endpoints": {
-          "lineorg": "https://lineorg.ci.api.fusion-dev.net",
+          "lineorg": "https://fra-lineorg.ci.api.fusion-dev.net",
           "org": "https://org.ci.api.fusion-dev.net",
           "people": "https://people.ci.api.fusion-dev.nett",
           "resources": "[concat('https://fra-resources.', parameters('env-name'), '.api.fusion-dev.net')]",

--- a/src/Fusion.Summary.Functions/local.settings.template.json
+++ b/src/Fusion.Summary.Functions/local.settings.template.json
@@ -12,7 +12,7 @@
     "project_summary_weekly_queue": "project-summary-weekly-queue-[REPLACE WITH DEV QUEUE]",
     "AzureWebJobsServiceBus": "[REPLACE WITH SB CONNECTION STRING]",
     "departmentFilter": "PRD",
-    "Endpoints_lineorg": "https://lineorg.ci.api.fusion-dev.net/",
+    "Endpoints_lineorg": "https://fra-lineorg.ci.api.fusion-dev.net/",
     "Endpoints_people": "https://people.ci.api.fusion-dev.net/",
     "Endpoints_org": "https://org.ci.api.fusion-dev.net/",
     "Endpoints_resources": "https://fra-resources.ci.api.fusion-dev.net/",

--- a/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
+++ b/src/backend/function/Fusion.Resources.Functions/Deployment/function.template.json
@@ -14,7 +14,7 @@
           "serviceBus": ""
         },
         "endpoints": {
-          "lineorg": "https://lineorg.ci.api.fusion-dev.net",
+          "lineorg": "https://fra-lineorg.ci.api.fusion-dev.net",
           "org": "https://org.ci.api.fusion-dev.net",
           "people": "https://people.ci.api.fusion-dev.net",
           "resources": "[concat('https://fra-resources.', parameters('env-name'), '.api.fusion-dev.net')]",

--- a/src/backend/function/Fusion.Resources.Functions/local.settings.template.json
+++ b/src/backend/function/Fusion.Resources.Functions/local.settings.template.json
@@ -10,7 +10,7 @@
     "AzureAd_TenantId": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
     "AzureAd_ClientId": "5a842df8-3238-415d-b168-9f16a6a6031b",
     "AzureAd_Secret": "[REPLACE WITH SECRET]",
-    "Endpoints_lineorg": "https://lineorg.ci.api.fusion-dev.net/",
+    "Endpoints_lineorg": "https://fra-lineorg.ci.api.fusion-dev.net/",
     "Endpoints_people": "https://people.ci.api.fusion-dev.net/",
     "Endpoints_org": "https://org.ci.api.fusion-dev.net/",
     "Endpoints_resources": "https://fra-resources.ci.api.fusion-dev.net/",


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

lineorg api is deployed with new url "fra-lineorg" instead of "lineorg"

resources and summary functions uses hardcoded url's when deploying

[AB#65013](https://statoil-proview.visualstudio.com/787035c2-8cf2-4d73-a83e-bb0e6d937eec/_workitems/edit/65013)

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

<!--- Other comments --->
