### PR TITLE
fix(functions): use resource group name directly in pipeline

### DIFF
--- a/pipelines/templates/deploy-function-template.yml
+++ b/pipelines/templates/deploy-function-template.yml
@@ -22,7 +22,7 @@ steps:
       $functionAppName = "func-fap-resources-$environment"
       $envVaultName = "kv-fap-resources-$environment"
 
-      $resourceGroup = fusion-apps-resources-$environment
+      $resourceGroup = "fusion-apps-resources-$environment"
       Write-Host "Using resource group $resourceGroup"
 
       function Get-SecretsId($secret) {

--- a/pipelines/templates/deploy-function-template.yml
+++ b/pipelines/templates/deploy-function-template.yml
@@ -21,11 +21,8 @@ steps:
       $fusionEnvironment = "${{ parameters.fusionEnvironment }}"
       $functionAppName = "func-fap-resources-$environment"
       $envVaultName = "kv-fap-resources-$environment"
-      $envResourceGroup = Get-AzResourceGroup -Tag @{ "fusion-app-component" = "resources-rg-$environment" }
 
-      if ($envResourceGroup -eq $null) { throw "Cannot locate resource group for environment '$environment'" }
-
-      $resourceGroup = $envResourceGroup.ResourceGroupName
+      $resourceGroup = fusion-apps-resources-$environment
       Write-Host "Using resource group $resourceGroup"
 
       function Get-SecretsId($secret) {


### PR DESCRIPTION
- [ ] New feature
- [x] Bug fix
- [ ] High impact

**Description of work:**
<!--- Please give a description of the work --->

The tag that was used previously does not exists in azure anymore, probably deleted. this caused the pipeline to fail as it did not find the resource group

**Testing:**
- [ ] Can be tested
- [ ] Automatic tests created / updated
- [ ] Local tests are passing

<!--- Please give a description of how this can be tested --->


**Checklist:**
- [ ] Considered automated tests
- [ ] Considered updating specification / documentation
- [ ] Considered work items 
- [ ] Considered security
- [ ] Performed developer testing
- [ ] Checklist finalized / ready for review

<!--- Other comments --->
